### PR TITLE
Add default empty state.

### DIFF
--- a/src/Components/EmptyState.js
+++ b/src/Components/EmptyState.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    Button,
     Title,
     EmptyState,
     EmptyStateVariant,
@@ -31,6 +32,14 @@ const DefaultEmptyState = ({ error }) => (
                 <EmptyStateBody>
                     You do not have the correct permissions to view this page.
                 </EmptyStateBody>
+            </>
+        ) }
+        { !error.status && (
+            <>
+                <Title headingLevel="h5" size="lg">
+                    Something went wrong. Please try reloading the page.
+                </Title>
+                <Button variant="primary" onClick={ () => window.location.reload() }>Reload</Button>
             </>
         ) }
     </EmptyState>


### PR DESCRIPTION
For non-`401/404` errors we should show a default message to the user.
![Screen Shot 2019-09-20 at 11 35 24 AM](https://user-images.githubusercontent.com/2293210/65340202-c1d6bb80-db9b-11e9-9845-57c50ca77508.png)
