### PR TITLE
Revert CSS changes until afer fest.

### DIFF
--- a/src/SmartComponents/SamplePage/SamplePage.js
+++ b/src/SmartComponents/SamplePage/SamplePage.js
@@ -288,9 +288,8 @@ class SamplePage extends Component {
                   id="refTab1Section"
                   ref={ this.contentRef1 }
                   aria-label="Tab item 1"
-                  style={ { height: '100vh' } }
               >
-                  <Main style={ { height: '100%' } }>
+                  <Main>
                       <Card>
                           <CardHeader
                               style={ {
@@ -386,9 +385,8 @@ class SamplePage extends Component {
                   ref={ this.contentRef2 }
                   aria-label="Tab item 2"
                   hidden
-                  style={ { height: '100vh' } }
               >
-                  <Main style={ { height: '100%' } }>
+                  <Main>
                       <TopCard>
                           <CardHeader
                               style={ {


### PR DESCRIPTION
Turns out `100vh` is not the height we want. It can cause background bugs like this if your browser height isn't maximized:
![Screen Shot 2019-09-20 at 12 15 35 PM](https://user-images.githubusercontent.com/2293210/65342265-665afc80-dba0-11e9-83a2-1dda70bfd75d.png)
This PR reverts the CSS changes that caused this new visual regression.