### PR TITLE
Manually bump tooltip width.

### DIFF
--- a/src/Utilities/Tooltip.js
+++ b/src/Utilities/Tooltip.js
@@ -29,7 +29,7 @@ class Tooltip {
         .attr('y', -41)
         .attr('rx', 2)
         .attr('height', 82)
-        .attr('width', 135)
+        .attr('width', 155)
         .attr('fill', '#393f44');
         this.circleGreen = this.toolTipBase
         .append('circle')


### PR DESCRIPTION
Band-aid fix for narrow tooltip width.
related: https://github.com/RedHatInsights/tower-analytics-backend/issues/30

A more permanent fix to come later.