### PR TITLE
Some small styling tweaks.

### DIFF
--- a/src/SmartComponents/SamplePage/sample-page.scss
+++ b/src/SmartComponents/SamplePage/sample-page.scss
@@ -67,3 +67,7 @@ h2 {
   color: white;
   font-size: 14px;
 }
+
+section#refTab1Section, section#refTab2Section {
+  outline: none;
+}

--- a/src/Utilities/Tooltip.js
+++ b/src/Utilities/Tooltip.js
@@ -150,16 +150,16 @@ class Tooltip {
         this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
         if (flipped) {
             this.toolTipPoint.attr('transform', 'translate(-20, -10) rotate(45)');
-            this.boundingBOx.attr('x', -155);
-            this.circleGreen.attr('cx', -140);
-            this.circleRed.attr('cx', -140);
-            this.icon.attr('x', -142);
-            this.successText.attr('x', -120);
-            this.failText.attr('x', -120);
-            this.successful.attr('x', -50);
-            this.failed.attr('x', -50);
-            this.date.attr('x', -145);
-            this.jobs.attr('x', -35);
+            this.boundingBOx.attr('x', -175);
+            this.circleGreen.attr('cx', -155);
+            this.circleRed.attr('cx', -155);
+            this.icon.attr('x', -157);
+            this.successText.attr('x', -138);
+            this.failText.attr('x', -138);
+            this.successful.attr('x', -55);
+            this.failed.attr('x', -55);
+            this.date.attr('x', -160);
+            this.jobs.attr('x', -40);
         } else {
             this.toolTipPoint.attr('transform', 'translate(10, -10) rotate(45)');
             this.boundingBOx.attr('x', 10);


### PR DESCRIPTION
- Adjust spacing of visual elements to accommodate for toolbar width increase.
- Remove blue border when app panel is clicked on.

This PR addresses a visual regression in which a flipped toolbar would hide the tooltip pointer:
![Screen Shot 2019-09-23 at 12 34 24 PM](https://user-images.githubusercontent.com/2293210/65458915-b6de8e00-de1c-11e9-9ecf-40b73afd053b.png)

It also removes the blue border when a card panel is clicked on within the UI:
![Screen Shot 2019-09-23 at 12 40 50 PM](https://user-images.githubusercontent.com/2293210/65459017-e7262c80-de1c-11e9-904e-18bb7ed30eff.png)
