### PR TITLE
Reusable queryparams hook

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,7 +2,8 @@ parser: babel-eslint
 env:
   browser: true
   node: true
-  es6: true
+  es6: true,
+  jest: true,
 settings:
   react:
     version: '16.0'

--- a/src/Api.js
+++ b/src/Api.js
@@ -1,5 +1,4 @@
 /*eslint max-len: ["error", { "ignoreStrings": true }]*/
-import moment from 'moment';
 
 const barChartEndpoint = '/api/tower-analytics/chart30/';
 const clustersEndpoint = '/api/tower-analytics/clusters/';
@@ -54,18 +53,12 @@ export const readClusters = () => {
     return fetch(clustersEndpoint).then(handleResponse);
 };
 
-export const readChart30 = () => {
-    return fetch(barChartEndpoint).then(handleResponse);
-};
-
-export const readChart30ById = ({ id = {}}) => {
-    const { id: clusterId } = id;
+export const readChart30 = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(barChartEndpoint, formattedUrl);
-    if (clusterId) {
-        url.searchParams.append('id', clusterId);
-    }
-
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
     return fetch(url).then(handleResponse);
 };
 
@@ -73,16 +66,31 @@ export const readJobsByDateAndOrg = () => {
     return fetch(groupedBarChartEndpoint).then(handleResponse);
 };
 
-export const readModules = () => {
-    return fetch(modulesEndpoint).then(handleResponse);
+export const readModules = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(modulesEndpoint, formattedUrl);
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
+    return fetch(url).then(handleResponse);
 };
 
-export const readTemplates = () => {
-    return fetch(templatesEndPoint).then(handleResponse);
+export const readTemplates = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(templatesEndPoint, formattedUrl);
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
+    return fetch(url).then(handleResponse);
 };
 
-export const readNotifications = () => {
-    return fetch(notificationsEndPoint).then(handleResponse);
+export const readNotifications = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(notificationsEndPoint, formattedUrl);
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
+    return fetch(url).then(handleResponse);
 };
 
 export const readJobRunsByOrg = ({ params = {}}) => {
@@ -101,22 +109,4 @@ export const readJobEventsByOrg = ({ params = {}}) => {
         url.searchParams.append(key, params[key])
     );
     return fetch(url).then(handleResponse);
-};
-
-export const getAllEndpoints = () => {
-    const today = moment.utc().format('YYYY-MM-DD');
-    const previousDay = moment.utc()
-    .subtract(7, 'days')
-    .format('YYYY-MM-DD');
-    const defaultPrams = { params: { startDate: previousDay, endDate: today }};
-    return Promise.all([
-        readChart30(),
-        readJobsByDateAndOrg(),
-        readModules(),
-        readTemplates(),
-        readNotifications(),
-        readClusters(),
-        readJobRunsByOrg(defaultPrams),
-        readJobEventsByOrg(defaultPrams)
-    ].map(p => p.catch(() => [])));
 };

--- a/src/Api.js
+++ b/src/Api.js
@@ -62,8 +62,13 @@ export const readChart30 = ({ params = {}}) => {
     return fetch(url).then(handleResponse);
 };
 
-export const readJobsByDateAndOrg = () => {
-    return fetch(groupedBarChartEndpoint).then(handleResponse);
+export const readJobsByDateAndOrg = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(groupedBarChartEndpoint, formattedUrl);
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
+    return fetch(url).then(handleResponse);
 };
 
 export const readModules = ({ params = {}}) => {

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -57,9 +57,7 @@ class LineChart extends Component {
             return value;
         }
     }
-    async updateCluster() {
-        const { cluster, onClusterToggle } = this.props;
-        await onClusterToggle({ id: cluster });
+    updateCluster() {
         this.init();
     }
     async init() {
@@ -318,9 +316,6 @@ class LineChart extends Component {
             this.updateCluster();
         }
 
-        if (prevProps.cluster !== this.props.cluster) {
-            this.updateCluster();
-        }
     }
 
     componentWillUnmount() {
@@ -343,10 +338,6 @@ LineChart.propTypes = {
     id: PropTypes.string,
     data: PropTypes.array,
     value: PropTypes.number,
-    cluster: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number
-    ]),
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import * as d3 from 'd3';
-import moment from 'moment';
 import initializeChart from './BaseChart';
 import { getTotal } from '../Utilities/helpers';
 import Legend from '../Utilities/Legend';
@@ -138,7 +137,6 @@ class PieChart extends Component {
         this.draw = this.draw.bind(this);
         this.init = this.init.bind(this);
         this.resize = this.resize.bind(this);
-        this.updateTimeFrame = this.updateTimeFrame.bind(this);
     }
     // Methods
     resize() {
@@ -153,12 +151,6 @@ class PieChart extends Component {
         data.sort((a, b) =>
             d3.descending(parseFloat(a.count), parseFloat(b.count))
         );
-    }
-    updateTimeFrame() {
-        const { onDateToggle, tag, timeFrame } = this.props;
-        const today = moment.utc().format('YYYY-MM-DD');
-        const previousDay = moment.utc().subtract(timeFrame, 'days').format('YYYY-MM-DD');
-        onDateToggle({ startDate: previousDay, endDate: today }, tag);
     }
     init() {
         const { data } = this.props;
@@ -259,10 +251,6 @@ class PieChart extends Component {
         if (prevProps.data !== this.props.data) {
             this.init();
         }
-
-        if (prevProps.timeFrame !== this.props.timeFrame) {
-            this.updateTimeFrame();
-        }
     }
 
     render() {
@@ -291,9 +279,7 @@ PieChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
-    onDateToggle: PropTypes.func,
-    timeFrame: PropTypes.number,
-    tag: PropTypes.number
+    timeFrame: PropTypes.number
 };
 
 export default initializeChart(PieChart);

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useReducer } from 'react';
 import styled from 'styled-components';
+import moment from 'moment';
 import LoadingState from '../../Components/LoadingState';
 import EmptyState from '../../Components/EmptyState';
 import {
     preflightRequest,
     readChart30,
-    readChart30ById,
     readClusters,
     readModules,
     readTemplates,
@@ -25,6 +25,8 @@ import {
     FormSelect,
     FormSelectOption
 } from '@patternfly/react-core';
+
+import { FilterIcon } from '@patternfly/react-icons';
 
 import BarChart from '../../Charts/BarChart';
 import LineChart from '../../Charts/LineChart';
@@ -86,6 +88,26 @@ function formatClusterName(data) {
     );
 }
 
+const initialQueryParams = {
+    startDate: moment.utc()
+    .subtract(7, 'days')
+    .format('YYYY-MM-DD'),
+    endDate: moment.utc().format('YYYY-MM-DD')
+};
+
+function paramsReducer(state, action) {
+    switch (action.type) {
+        case 'STARTDATE':
+            return { ...state, startDate: action.startDate };
+        case 'ENDDATE':
+            return { ...state, endDate: action.endDate };
+        case 'ID':
+            return { ...state, id: action.id };
+        default:
+            throw new Error();
+    }
+}
+
 const Clusters = () => {
     const [ preflightError, setPreFlightError ] = useState(null);
     const [ barChartData, setBarChartData ] = useState([]);
@@ -97,26 +119,69 @@ const Clusters = () => {
     const [ clusterTimeFrame, setClusterTimeFrame ] = useState(7);
     const [ selectedCluster, setSelectedCluster ] = useState('all');
     const [ selectedNotification, setSelectedNotification ] = useState('all');
+    const [ firstRender, setFirstRender ] = useState(true);
+    const [ queryParams, dispatch ] = useReducer(
+        paramsReducer,
+        initialQueryParams
+    );
 
-    const handleClusterToggle =  async (id) => {
-        if (!id) {
+    const updateEndDate = () => {
+        const endDate = moment.utc().format('YYYY-MM-DD');
+        dispatch({ type: 'ENDDATE', endDate });
+    };
+
+    const updateStartDate = (days) => {
+        const startDate = moment.utc()
+        .subtract(days, 'days')
+        .format('YYYY-MM-DD');
+        dispatch({ type: 'STARTDATE', startDate });
+    };
+
+    const updateId = (id) => {
+        dispatch({ type: 'ID', id });
+    };
+
+    useEffect(() => {
+        if (firstRender) {
             return;
         }
 
-        setLineChartData([]);
-        const { data: lineChartData } = await readChart30ById({ id });
-        setLineChartData(lineChartData);
-    };
+        const fetchEndpoints = () => {
+            return Promise.all([
+                readChart30({ params: queryParams }),
+                readModules({ params: queryParams }),
+                readTemplates({ params: queryParams }),
+                readNotifications({ params: queryParams })
+            ].map(p => p.catch(() => [])));
+        };
+
+        const update = () => {
+            setLineChartData([]); // Clear out line chart values
+            fetchEndpoints().then(([
+                { data: lineChartData = []},
+                { modules: modulesData = []},
+                { templates: templatesData = []},
+                { notifications: notificationsData = []}
+            ]) => {
+                setLineChartData(lineChartData);
+                setModulesData(modulesData);
+                setTemplatesData(templatesData);
+                setNotificationsData(notificationsData);
+            });
+        };
+
+        update();
+    }, [ queryParams ]);
 
     useEffect(() => {
         let ignore = false;
         const getData = () => {
             return Promise.all([
-                readChart30(),
+                readChart30({ params: queryParams }),
                 readClusters(),
-                readModules(),
-                readTemplates(),
-                readNotifications()
+                readModules({ params: queryParams }),
+                readTemplates({ params: queryParams }),
+                readNotifications({ params: queryParams })
             ].map(p => p.catch(() => [])));
         };
 
@@ -140,6 +205,7 @@ const Clusters = () => {
                     setModulesData(modulesData);
                     setTemplatesData(templatesData);
                     setNotificationsData(notificationsData);
+                    setFirstRender(false);
                 }
             });
         }
@@ -163,31 +229,19 @@ const Clusters = () => {
                 </Main>
             ) }
             { !preflightError && (
-                <Main>
+                <>
+                <Main style={ { paddingBottom: '0' } }>
                     <Card>
-                        <CardHeader>
-                            <h2>Job Status</h2>
+                        <CardHeader style={ { paddingBottom: '0', paddingTop: '0' } }>
+                            <h2><FilterIcon style={ { marginRight: '10px' } }/>Filter</h2>
                             <div style={ { display: 'flex', justifyContent: 'flex-end' } }>
-                                <FormSelect
-                                    name="clusterTimeFrame"
-                                    value={ clusterTimeFrame }
-                                    onChange={ (value) => setClusterTimeFrame(+value) }
-                                    aria-label="Select Date Range"
-                                    style={ { margin: '2px 10px' } }
-                                >
-                                    { timeFrameOptions.map((option, index) => (
-                                        <FormSelectOption
-                                            isDisabled={ option.disabled }
-                                            key={ index }
-                                            value={ option.value }
-                                            label={ option.label }
-                                        />
-                                    )) }
-                                </FormSelect>
                                 <FormSelect
                                     name="selectedCluster"
                                     value={ selectedCluster }
-                                    onChange={ (value) => setSelectedCluster(value) }
+                                    onChange={ (value) => {
+                                        setSelectedCluster(value);
+                                        updateId(value);
+                                    } }
                                     aria-label="Select Cluster"
                                     style={ { margin: '2px 10px' } }
                                 >
@@ -200,7 +254,34 @@ const Clusters = () => {
                                         />
                                     )) }
                                 </FormSelect>
+                                <FormSelect
+                                    name="clusterTimeFrame"
+                                    value={ clusterTimeFrame }
+                                    onChange={ (value) => {
+                                        setClusterTimeFrame(+value);
+                                        updateEndDate();
+                                        updateStartDate(+value);
+                                    } }
+                                    aria-label="Select Date Range"
+                                    style={ { margin: '2px 10px' } }
+                                >
+                                    { timeFrameOptions.map((option, index) => (
+                                        <FormSelectOption
+                                            isDisabled={ option.disabled }
+                                            key={ index }
+                                            value={ option.value }
+                                            label={ option.label }
+                                        />
+                                    )) }
+                                </FormSelect>
                             </div>
+                        </CardHeader>
+                    </Card>
+                </Main>
+                <Main>
+                    <Card>
+                        <CardHeader>
+                            <h2>Job Status</h2>
                         </CardHeader>
                         <CardBody>
                             { barChartData.length <= 0 && !preflightError && <LoadingState /> }
@@ -213,14 +294,13 @@ const Clusters = () => {
                                     value={ clusterTimeFrame }
                                 />
                             ) }
-                            { selectedCluster !== 'all' && (
+                            { lineChartData.length <= 0 && selectedCluster !== 'all' && <LoadingState /> }
+                            { selectedCluster !== 'all' && lineChartData.length > 0 && (
                                 <LineChart
                                     margin={ { top: 20, right: 20, bottom: 50, left: 70 } }
                                     id="d3-bar-chart-root"
                                     data={ lineChartData }
                                     value={ clusterTimeFrame }
-                                    cluster={ selectedCluster }
-                                    onClusterToggle={ handleClusterToggle }
                                 />
                             ) }
                         </CardBody>
@@ -239,6 +319,7 @@ const Clusters = () => {
                         />
                     </div>
                 </Main>
+                </>
             ) }
         </React.Fragment>
     );

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -97,11 +97,11 @@ const initialQueryParams = {
 
 function paramsReducer(state, action) {
     switch (action.type) {
-        case 'STARTDATE':
+        case 'SET_STARTDATE':
             return { ...state, startDate: action.startDate };
-        case 'ENDDATE':
+        case 'SET_ENDDATE':
             return { ...state, endDate: action.endDate };
-        case 'ID':
+        case 'SET_ID':
             return { ...state, id: action.id };
         default:
             throw new Error();
@@ -127,18 +127,18 @@ const Clusters = () => {
 
     const updateEndDate = () => {
         const endDate = moment.utc().format('YYYY-MM-DD');
-        dispatch({ type: 'ENDDATE', endDate });
+        dispatch({ type: 'SET_ENDDATE', endDate });
     };
 
     const updateStartDate = (days) => {
         const startDate = moment.utc()
         .subtract(days, 'days')
         .format('YYYY-MM-DD');
-        dispatch({ type: 'STARTDATE', startDate });
+        dispatch({ type: 'SET_STARTDATE', startDate });
     };
 
     const updateId = (id) => {
-        dispatch({ type: 'ID', id });
+        dispatch({ type: 'SET_ID', id });
     };
 
     useEffect(() => {

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -1,6 +1,9 @@
-import React, { useState, useEffect, useReducer } from 'react';
-import styled from 'styled-components';
+import React, { useState, useEffect } from 'react';
 import moment from 'moment';
+
+import { useQueryParams } from '../../Utilities/useQueryParams';
+
+import styled from 'styled-components';
 import LoadingState from '../../Components/LoadingState';
 import EmptyState from '../../Components/EmptyState';
 import {
@@ -95,19 +98,6 @@ const initialQueryParams = {
     endDate: moment.utc().format('YYYY-MM-DD')
 };
 
-function paramsReducer(state, action) {
-    switch (action.type) {
-        case 'SET_STARTDATE':
-            return { ...state, startDate: action.startDate };
-        case 'SET_ENDDATE':
-            return { ...state, endDate: action.endDate };
-        case 'SET_ID':
-            return { ...state, id: action.id };
-        default:
-            throw new Error();
-    }
-}
-
 const Clusters = () => {
     const [ preflightError, setPreFlightError ] = useState(null);
     const [ barChartData, setBarChartData ] = useState([]);
@@ -120,26 +110,7 @@ const Clusters = () => {
     const [ selectedCluster, setSelectedCluster ] = useState('all');
     const [ selectedNotification, setSelectedNotification ] = useState('all');
     const [ firstRender, setFirstRender ] = useState(true);
-    const [ queryParams, dispatch ] = useReducer(
-        paramsReducer,
-        initialQueryParams
-    );
-
-    const updateEndDate = () => {
-        const endDate = moment.utc().format('YYYY-MM-DD');
-        dispatch({ type: 'SET_ENDDATE', endDate });
-    };
-
-    const updateStartDate = (days) => {
-        const startDate = moment.utc()
-        .subtract(days, 'days')
-        .format('YYYY-MM-DD');
-        dispatch({ type: 'SET_STARTDATE', startDate });
-    };
-
-    const updateId = (id) => {
-        dispatch({ type: 'SET_ID', id });
-    };
+    const { queryParams, setEndDate, setStartDate, setId } = useQueryParams(initialQueryParams);
 
     useEffect(() => {
         if (firstRender) {
@@ -240,7 +211,7 @@ const Clusters = () => {
                                     value={ selectedCluster }
                                     onChange={ (value) => {
                                         setSelectedCluster(value);
-                                        updateId(value);
+                                        setId(value);
                                     } }
                                     aria-label="Select Cluster"
                                     style={ { margin: '2px 10px' } }
@@ -259,8 +230,8 @@ const Clusters = () => {
                                     value={ clusterTimeFrame }
                                     onChange={ (value) => {
                                         setClusterTimeFrame(+value);
-                                        updateEndDate();
-                                        updateStartDate(+value);
+                                        setEndDate();
+                                        setStartDate(+value);
                                     } }
                                     aria-label="Select Date Range"
                                     style={ { margin: '2px 10px' } }

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -10,6 +10,8 @@ export const useQueryParams = initial => {
                 return { ...state, endDate: action.endDate };
             case 'SET_ID':
                 return { ...state, id: action.id };
+            case 'SET_ORDERBY':
+                return { ...state, orderBy: action.order };
             default:
                 throw new Error();
         }
@@ -36,6 +38,8 @@ export const useQueryParams = initial => {
                 .subtract(days, 'days')
                 .format('YYYY-MM-DD');
                 dispatch({ type: 'SET_STARTDATE', startDate });
-            }
+            },
+        setOrderBy:
+            order => dispatch({ type: 'SET_ORDERBY', order })
     };
 };

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,0 +1,41 @@
+import { useReducer } from 'react';
+import moment from 'moment';
+
+export const useQueryParams = initial => {
+    const paramsReducer = (state, action) => {
+        switch (action.type) {
+            case 'SET_STARTDATE':
+                return { ...state, startDate: action.startDate };
+            case 'SET_ENDDATE':
+                return { ...state, endDate: action.endDate };
+            case 'SET_ID':
+                return { ...state, id: action.id };
+            default:
+                throw new Error();
+        }
+    };
+
+    const [ queryParams, dispatch ] = useReducer(
+        paramsReducer,
+        { ...initial }
+    );
+
+    return {
+        queryParams,
+        dispatch,
+        setEndDate:
+            () => {
+                const endDate = moment.utc().format('YYYY-MM-DD');
+                dispatch({ type: 'SET_ENDDATE', endDate });
+            },
+        setId:
+            id => dispatch({ type: 'SET_ID', id }),
+        setStartDate:
+            days => {
+                const startDate = moment.utc()
+                .subtract(days, 'days')
+                .format('YYYY-MM-DD');
+                dispatch({ type: 'SET_STARTDATE', startDate });
+            }
+    };
+};

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -1,0 +1,87 @@
+import { mount } from 'enzyme';
+import { useQueryParams } from './useQueryParams/';
+import { act } from 'react-dom/test-utils';
+
+/* See https://github.com/testing-library/react-testing-library/pull/274
+for more details regarding the need to create a test component to call
+custom hooks from within a testing environment. */
+
+const TestHook = ({ callback }) => {
+    callback();
+    return null;
+};
+
+const testHook = (callback) => {
+    mount(<TestHook callback={callback} />);
+};
+
+const initialValues = { foo: '1', bar: 2, orderBy: 'baz' };
+
+let page;
+
+beforeEach(() => {
+    testHook(() => {
+        page = useQueryParams(initialValues);
+    });
+});
+
+describe('Utilities/useQueryParams', () => {
+    it('returns expected initial values as queryParams ', () => {
+        expect(page.queryParams).toEqual(initialValues);
+    });
+
+    it('returns setId, setStartDate, setEndDate, and setOrderBy as methods', () => {
+        expect(page.setId).toBeInstanceOf(Function);
+        expect(page.setStartDate).toBeInstanceOf(Function);
+        expect(page.setEndDate).toBeInstanceOf(Function);
+        expect(page.setOrderBy).toBeInstanceOf(Function);
+    });
+
+    it('invoked methods returns new queryParams object', () => {
+        act(() => {
+            page.setId('baz');
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, id: 'baz' });
+    });
+
+    it('methods correctly update existing values in queryParams object', () => {
+        act(() => {
+            page.setOrderBy('fizz');
+        });
+        expect(page.queryParams).toEqual({ foo: '1', bar: 2, orderBy: 'fizz' });
+    });
+
+    it('correctly handles null and NaN values', () => {
+        act(() => {
+            page.setId(null);
+            page.setOrderBy(NaN);
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, id: null, orderBy: NaN });
+    });
+
+    it('setEndDate returns current day in `YYYY-MM-DD` string format', () => {
+        const currentDate = new Date().toJSON().slice(0, 10).replace(/-/g, '-');
+        act(() => {
+            page.setEndDate();
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, endDate: currentDate });
+    });
+
+    it('setStartDate returns current day if passed a null value', () => {
+        const currentDate = new Date().toJSON().slice(0, 10).replace(/-/g, '-');
+        act(() => {
+            page.setStartDate(null);
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, startDate: currentDate });
+    });
+
+    it('setStartDate returns expected day when invoked', () => {
+        const days = 8
+        const date = new Date(new Date().setDate(new Date().getDate() - days));
+        const expected = date.toJSON().slice(0, 10).replace(/-/g, '-');
+        act(() => {
+            page.setStartDate(days);
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, startDate: expected });
+    });
+});

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -12,7 +12,7 @@ const TestHook = ({ callback }) => {
 };
 
 const testHook = (callback) => {
-    mount(<TestHook callback={callback} />);
+    mount(<TestHook callback={ callback } />);
 };
 
 const initialValues = { foo: '1', bar: 2, orderBy: 'baz' };
@@ -76,7 +76,7 @@ describe('Utilities/useQueryParams', () => {
     });
 
     it('setStartDate returns expected day when invoked', () => {
-        const days = 8
+        const days = 8;
         const date = new Date(new Date().setDate(new Date().getDate() - days));
         const expected = date.toJSON().slice(0, 10).replace(/-/g, '-');
         act(() => {


### PR DESCRIPTION
As a continuation of PR #51, this PR abstracts the `useReducer` hook created in the Clusters view into a generalized, reusable hook that handle how page parameters should be packaged in order to be digested by the API.

Note #51 should be merged before merging this one.