### PR TITLE
Update UI usage of API fields for upcoming Clusters API change

### DIFF
--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -162,7 +162,7 @@ const TemplatesList = ({ templates }) => {
                           { job.job_name }
                       </PFDataListCell>
                       <PFDataListCell key="job cluster">
-                          { job.system_label || job.system_uuid }
+                          { job.system_label || job.install_uuid }
                       </PFDataListCell>
                       <PFDataListCell key="start time">
                           { formatDateTime(job.start_time) }

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -77,7 +77,7 @@ function formatClusterName(data) {
         { value: 'all', label: 'All Clusters', disabled: false }
     ];
     return data.reduce(
-        (formatted, { label, system_id: id, system_uuid: uuid }) => {
+        (formatted, { label, cluster_id: id, install_uuid: uuid }) => {
             if (label.length === 0) {
                 formatted.push({ value: id, label: uuid, disabled: false });
             } else {


### PR DESCRIPTION
This PR replaces all instances of `system_id` and `system_uuid` in the UI and replaces them with `cluster_id` and `install_uuid` respectively.