### PR TITLE
Some updates to useQueryParams reducer:

### DIFF
--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -55,6 +55,10 @@ export const useQueryParams = initial => {
                     startDate = moment.utc().subtract(1, 'month')
                     .format('YYYY-MM-DD');
                 }
+                else {
+                    startDate = moment.utc().subtract(days, 'days')
+                    .format('YYYY-MM-DD');
+                }
 
                 dispatch({ type: 'SET_STARTDATE', startDate });
             },

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -9,6 +9,12 @@ export const useQueryParams = initial => {
             case 'SET_ENDDATE':
                 return { ...state, endDate: action.endDate };
             case 'SET_ID':
+                if (!parseInt(action.id)) {
+                    /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
+                    const { id: ignored, ...rest } = state;
+                    return rest;
+                }
+
                 return { ...state, id: action.id };
             case 'SET_ORDERBY':
                 return { ...state, orderBy: action.order };
@@ -34,9 +40,22 @@ export const useQueryParams = initial => {
             id => dispatch({ type: 'SET_ID', id }),
         setStartDate:
             days => {
-                const startDate = moment.utc()
-                .subtract(days, 'days')
-                .format('YYYY-MM-DD');
+                let startDate;
+                if (days === 7) {
+                    startDate = moment.utc().subtract(1, 'week')
+                    .format('YYYY-MM-DD');
+                }
+
+                if (days === 14) {
+                    startDate = moment.utc().subtract(2, 'weeks')
+                    .format('YYYY-MM-DD');
+                }
+
+                if (days === 31) {
+                    startDate = moment.utc().subtract(1, 'month')
+                    .format('YYYY-MM-DD');
+                }
+
                 dispatch({ type: 'SET_STARTDATE', startDate });
             },
         setOrderBy:

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -39,9 +39,9 @@ describe('Utilities/useQueryParams', () => {
 
     it('invoked methods returns new queryParams object', () => {
         act(() => {
-            page.setId('baz');
+            page.setId(1);
         });
-        expect(page.queryParams).toEqual({ ...initialValues, id: 'baz' });
+        expect(page.queryParams).toEqual({ ...initialValues, id: 1 });
     });
 
     it('methods correctly update existing values in queryParams object', () => {
@@ -56,7 +56,7 @@ describe('Utilities/useQueryParams', () => {
             page.setId(null);
             page.setOrderBy(NaN);
         });
-        expect(page.queryParams).toEqual({ ...initialValues, id: null, orderBy: NaN });
+        expect(page.queryParams).toEqual({ ...initialValues, orderBy: NaN });
     });
 
     it('setEndDate returns current day in `YYYY-MM-DD` string format', () => {


### PR DESCRIPTION
- Refactor how dates are calculated using built-in timespans rather than calculating that manually
- Remove id from queryParams object if passed in value is a string