### PR TITLE
Change orderby to ipp standards

### DIFF
--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -90,7 +90,8 @@ const initialQueryParams = {
     .subtract(7, 'days')
     .format('YYYY-MM-DD'),
     endDate: moment.utc().format('YYYY-MM-DD'),
-    sort_by: 'count:desc'
+    sort_by: 'count:desc',
+    limit: 5
 };
 
 const OrganizationStatistics = () => {
@@ -101,7 +102,19 @@ const OrganizationStatistics = () => {
     const [ timeframe, setTimeframe ] = useState(7);
     const [ sortOrder, setSortOrder ] = useState('count:desc');
     const [ firstRender, setFirstRender ] = useState(true);
-    const { queryParams, setEndDate, setStartDate, setSortBy } = useQueryParams(initialQueryParams);
+    const { queryParams, setEndDate, setStartDate, setSortBy, setLimit } = useQueryParams(initialQueryParams);
+
+    const setLimitValue = val => {
+        let limit;
+        if (val === 'count:asc' || val === 'count:desc') {
+            limit = 5;
+        }
+        else {
+            limit = 200;
+        }
+
+        return setLimit(limit);
+    };
 
     useEffect(() => {
         let ignore = false;
@@ -179,6 +192,7 @@ const OrganizationStatistics = () => {
                                         onChange={ (value) => {
                                             setSortOrder(value);
                                             setSortBy(value);
+                                            setLimitValue(value);
                                         } }
                                         aria-label="Select Cluster"
                                         style={ { margin: '2px 10px' } }

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: ["error", {properties: "never"}]*/
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -89,7 +90,7 @@ const initialQueryParams = {
     .subtract(7, 'days')
     .format('YYYY-MM-DD'),
     endDate: moment.utc().format('YYYY-MM-DD'),
-    orderBy: 'count:desc'
+    sort_by: 'count:desc'
 };
 
 const OrganizationStatistics = () => {
@@ -100,7 +101,7 @@ const OrganizationStatistics = () => {
     const [ timeframe, setTimeframe ] = useState(7);
     const [ sortOrder, setSortOrder ] = useState('count:desc');
     const [ firstRender, setFirstRender ] = useState(true);
-    const { queryParams, setEndDate, setStartDate, setOrderBy } = useQueryParams(initialQueryParams);
+    const { queryParams, setEndDate, setStartDate, setSortBy } = useQueryParams(initialQueryParams);
 
     useEffect(() => {
         let ignore = false;
@@ -177,7 +178,7 @@ const OrganizationStatistics = () => {
                                         value={ sortOrder }
                                         onChange={ (value) => {
                                             setSortOrder(value);
-                                            setOrderBy(value);
+                                            setSortBy(value);
                                         } }
                                         aria-label="Select Cluster"
                                         style={ { margin: '2px 10px' } }

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -79,8 +79,8 @@ const timeFrameOptions = [
 
 const sortOptions = [
     { value: 'please choose', label: 'Order By', disabled: true },
-    { value: 'top_5', label: 'Top 5 Orgs', disabled: false },
-    { value: 'bottom_5', label: 'Bottom 5 Orgs', disabled: false },
+    { value: 'count:desc', label: 'Top 5 Orgs', disabled: false },
+    { value: 'count:asc', label: 'Bottom 5 Orgs', disabled: false },
     { value: 'all', label: 'All Orgs', disabled: false }
 ];
 
@@ -89,7 +89,7 @@ const initialQueryParams = {
     .subtract(7, 'days')
     .format('YYYY-MM-DD'),
     endDate: moment.utc().format('YYYY-MM-DD'),
-    orderBy: 'top_5'
+    orderBy: 'count:desc'
 };
 
 const OrganizationStatistics = () => {
@@ -98,7 +98,7 @@ const OrganizationStatistics = () => {
     const [ pieChart2Data, setPieChart2Data ] = useState([]);
     const [ groupedBarChartData, setGroupedBarChartData ] = useState([]);
     const [ timeframe, setTimeframe ] = useState(7);
-    const [ sortOrder, setSortOrder ] = useState('top_5');
+    const [ sortOrder, setSortOrder ] = useState('count:desc');
     const [ firstRender, setFirstRender ] = useState(true);
     const { queryParams, setEndDate, setStartDate, setOrderBy } = useQueryParams(initialQueryParams);
 

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,5 +1,6 @@
 /*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
+
 import { useReducer } from 'react';
 import moment from 'moment';
 
@@ -16,7 +17,7 @@ export const useQueryParams = initial => {
                     return rest;
                 }
 
-                return { ...state, id: action.id };
+                return { ...state, id: parseInt(action.id) };
             case 'SET_SORT_BY':
                 if (action.sort === 'count:asc' || action.sort === 'count:desc') {
                     return { ...state, sort_by: action.sort };
@@ -25,51 +26,59 @@ export const useQueryParams = initial => {
                     return rest;
                 }
 
+            case 'SET_LIMIT':
+                if (!parseInt(action.limit)) {
+                    const { limit: ignored, ...rest } = state;
+                    return rest;
+                }
+
+                return { ...state, limit: parseInt(action.limit) };
             default:
                 throw new Error();
         }
     };
 
-    const [ queryParams, dispatch ] = useReducer(
-        paramsReducer,
-        { ...initial }
-    );
+    const [ queryParams, dispatch ] = useReducer(paramsReducer, { ...initial });
 
     return {
         queryParams,
         dispatch,
-        setEndDate:
-            () => {
-                const endDate = moment.utc().format('YYYY-MM-DD');
-                dispatch({ type: 'SET_ENDDATE', endDate });
-            },
-        setId:
-            id => dispatch({ type: 'SET_ID', id }),
-        setStartDate:
-            days => {
-                let startDate;
-                if (days === 7) {
-                    startDate = moment.utc().subtract(1, 'week')
-                    .format('YYYY-MM-DD');
-                }
+        setEndDate: () => {
+            const endDate = moment.utc().format('YYYY-MM-DD');
+            dispatch({ type: 'SET_ENDDATE', endDate });
+        },
+        setId: id => dispatch({ type: 'SET_ID', id }),
+        setStartDate: days => {
+            let startDate;
+            if (days === 7) {
+                startDate = moment
+                .utc()
+                .subtract(1, 'week')
+                .format('YYYY-MM-DD');
+            }
 
-                if (days === 14) {
-                    startDate = moment.utc().subtract(2, 'weeks')
-                    .format('YYYY-MM-DD');
-                }
+            if (days === 14) {
+                startDate = moment
+                .utc()
+                .subtract(2, 'weeks')
+                .format('YYYY-MM-DD');
+            }
 
-                if (days === 31) {
-                    startDate = moment.utc().subtract(1, 'month')
-                    .format('YYYY-MM-DD');
-                }
-                else {
-                    startDate = moment.utc().subtract(days, 'days')
-                    .format('YYYY-MM-DD');
-                }
+            if (days === 31) {
+                startDate = moment
+                .utc()
+                .subtract(1, 'month')
+                .format('YYYY-MM-DD');
+            } else {
+                startDate = moment
+                .utc()
+                .subtract(days, 'days')
+                .format('YYYY-MM-DD');
+            }
 
-                dispatch({ type: 'SET_STARTDATE', startDate });
-            },
-        setSortBy:
-            sort => dispatch({ type: 'SET_SORT_BY', sort })
+            dispatch({ type: 'SET_STARTDATE', startDate });
+        },
+        setSortBy: sort => dispatch({ type: 'SET_SORT_BY', sort }),
+        setLimit: limit => dispatch({ type: 'SET_LIMIT', limit })
     };
 };

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 import { useReducer } from 'react';
 import moment from 'moment';
 
@@ -10,14 +11,19 @@ export const useQueryParams = initial => {
                 return { ...state, endDate: action.endDate };
             case 'SET_ID':
                 if (!parseInt(action.id)) {
-                    /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
                     const { id: ignored, ...rest } = state;
                     return rest;
                 }
 
                 return { ...state, id: action.id };
             case 'SET_ORDERBY':
-                return { ...state, orderBy: action.order };
+                if (action.order === 'count:asc' || action.order === 'count:desc') {
+                    return { ...state, orderBy: action.order };
+                } else {
+                    const { orderBy: ignored, ...rest } = state;
+                    return rest;
+                }
+
             default:
                 throw new Error();
         }

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 import { useReducer } from 'react';
 import moment from 'moment';
@@ -16,11 +17,11 @@ export const useQueryParams = initial => {
                 }
 
                 return { ...state, id: action.id };
-            case 'SET_ORDERBY':
-                if (action.order === 'count:asc' || action.order === 'count:desc') {
-                    return { ...state, orderBy: action.order };
+            case 'SET_SORT_BY':
+                if (action.sort === 'count:asc' || action.sort === 'count:desc') {
+                    return { ...state, sort_by: action.sort };
                 } else {
-                    const { orderBy: ignored, ...rest } = state;
+                    const { sort_by: ignored, ...rest } = state;
                     return rest;
                 }
 
@@ -68,7 +69,7 @@ export const useQueryParams = initial => {
 
                 dispatch({ type: 'SET_STARTDATE', startDate });
             },
-        setOrderBy:
-            order => dispatch({ type: 'SET_ORDERBY', order })
+        setSortBy:
+            sort => dispatch({ type: 'SET_SORT_BY', sort })
     };
 };

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -15,7 +15,7 @@ const testHook = (callback) => {
     mount(<TestHook callback={ callback } />);
 };
 
-const initialValues = { foo: '1', bar: 2, orderBy: 'asc' };
+const initialValues = { foo: '1', bar: 2, sort_by: 'count:asc' };
 
 let page;
 
@@ -30,11 +30,11 @@ describe('Utilities/useQueryParams', () => {
         expect(page.queryParams).toEqual(initialValues);
     });
 
-    it('returns setId, setStartDate, setEndDate, and setOrderBy as methods', () => {
+    it('returns setId, setStartDate, setEndDate, and setSortBy as methods', () => {
         expect(page.setId).toBeInstanceOf(Function);
         expect(page.setStartDate).toBeInstanceOf(Function);
         expect(page.setEndDate).toBeInstanceOf(Function);
-        expect(page.setOrderBy).toBeInstanceOf(Function);
+        expect(page.setSortBy).toBeInstanceOf(Function);
     });
 
     it('invoked methods returns new queryParams object', () => {
@@ -46,15 +46,15 @@ describe('Utilities/useQueryParams', () => {
 
     it('methods correctly update existing values in queryParams object', () => {
         act(() => {
-            page.setOrderBy('desc');
+            page.setSortBy('count:desc');
         });
-        expect(page.queryParams).toEqual({ foo: '1', bar: 2, orderBy: 'desc' });
+        expect(page.queryParams).toEqual({ foo: '1', bar: 2, sort_by: 'count:desc' });
     });
 
     it('correctly handles null and NaN values', () => {
         act(() => {
             page.setId(null);
-            page.setOrderBy(NaN);
+            page.setSortBy(NaN);
         });
         expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
     });
@@ -84,9 +84,9 @@ describe('Utilities/useQueryParams', () => {
         });
         expect(page.queryParams).toEqual({ ...initialValues, startDate: expected });
     });
-    it('setOrderBy returns nothing when specifying a non-column type', () => {
+    it('setSortBy returns nothing when specifying a non-column type', () => {
         act(() => {
-            page.setOrderBy('foo');
+            page.setSortBy('foo');
         });
         expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
     });

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -1,3 +1,4 @@
+/*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
 import { mount } from 'enzyme';
 import { useQueryParams } from './useQueryParams/';
 import { act } from 'react-dom/test-utils';
@@ -30,30 +31,33 @@ describe('Utilities/useQueryParams', () => {
         expect(page.queryParams).toEqual(initialValues);
     });
 
-    it('returns setId, setStartDate, setEndDate, and setSortBy as methods', () => {
+    it('returns setId, setStartDate, setEndDate, setSortBy, and setLimit as methods', () => {
         expect(page.setId).toBeInstanceOf(Function);
         expect(page.setStartDate).toBeInstanceOf(Function);
         expect(page.setEndDate).toBeInstanceOf(Function);
         expect(page.setSortBy).toBeInstanceOf(Function);
+        expect(page.setLimit).toBeInstanceOf(Function);
     });
 
     it('invoked methods returns new queryParams object', () => {
         act(() => {
             page.setId(1);
+            page.setLimit(2);
         });
-        expect(page.queryParams).toEqual({ ...initialValues, id: 1 });
+        expect(page.queryParams).toEqual({ ...initialValues, id: 1, limit: 2 });
     });
 
-    it('methods correctly update existing values in queryParams object', () => {
+    it('invoked methods correctly update existing values in queryParams object', () => {
         act(() => {
             page.setSortBy('count:desc');
         });
         expect(page.queryParams).toEqual({ foo: '1', bar: 2, sort_by: 'count:desc' });
     });
 
-    it('correctly handles null and NaN values', () => {
+    it('setId, setLimit, setSortBy correctly handles null, undefined and NaN values', () => {
         act(() => {
             page.setId(null);
+            page.setLimit(undefined);
             page.setSortBy(NaN);
         });
         expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
@@ -89,5 +93,24 @@ describe('Utilities/useQueryParams', () => {
             page.setSortBy('foo');
         });
         expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
+    });
+    it('setLimit returns expected value', () => {
+        act(() => {
+            page.setLimit(10);
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, limit: 10 });
+    });
+    it('setLimit returns nothing when passed a non-integer value', () => {
+        act(() => {
+            page.setLimit('bar');
+        });
+        expect(page.queryParams).toEqual({ ...initialValues });
+    });
+    it('setLimit and setId cast strings into integers when passed string values', () => {
+        act(() => {
+            page.setLimit('10');
+            page.setId('100');
+        });
+        expect(page.queryParams).toEqual({ ...initialValues, id: 100, limit: 10 });
     });
 });

--- a/src/Utilities/useQueryParams.test.js
+++ b/src/Utilities/useQueryParams.test.js
@@ -15,7 +15,7 @@ const testHook = (callback) => {
     mount(<TestHook callback={ callback } />);
 };
 
-const initialValues = { foo: '1', bar: 2, orderBy: 'baz' };
+const initialValues = { foo: '1', bar: 2, orderBy: 'asc' };
 
 let page;
 
@@ -46,9 +46,9 @@ describe('Utilities/useQueryParams', () => {
 
     it('methods correctly update existing values in queryParams object', () => {
         act(() => {
-            page.setOrderBy('fizz');
+            page.setOrderBy('desc');
         });
-        expect(page.queryParams).toEqual({ foo: '1', bar: 2, orderBy: 'fizz' });
+        expect(page.queryParams).toEqual({ foo: '1', bar: 2, orderBy: 'desc' });
     });
 
     it('correctly handles null and NaN values', () => {
@@ -56,7 +56,7 @@ describe('Utilities/useQueryParams', () => {
             page.setId(null);
             page.setOrderBy(NaN);
         });
-        expect(page.queryParams).toEqual({ ...initialValues, orderBy: NaN });
+        expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
     });
 
     it('setEndDate returns current day in `YYYY-MM-DD` string format', () => {
@@ -83,5 +83,11 @@ describe('Utilities/useQueryParams', () => {
             page.setStartDate(days);
         });
         expect(page.queryParams).toEqual({ ...initialValues, startDate: expected });
+    });
+    it('setOrderBy returns nothing when specifying a non-column type', () => {
+        act(() => {
+            page.setOrderBy('foo');
+        });
+        expect(page.queryParams).toEqual({ foo: '1', bar: 2 });
     });
 });


### PR DESCRIPTION
Related: https://github.com/RedHatInsights/tower-analytics-backend/pull/197
This PR changes `orderBy` params:
- use `sort_by`
- specify column ordering
- add `limit`; defaults to 200 results

examples:
`sort_by=count:asc`
`sort_by=count:desc&limit=5`

If a user toggles View All (Orgs), then the UI will not specify an `sort_by` param and uses the default limit. 