### PR TITLE
Add emptystate and loading state for Clusters and Org Stats views

### DIFF
--- a/src/Components/ModulesList.js
+++ b/src/Components/ModulesList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { trimStr } from '../Utilities/helpers';
 import styled from 'styled-components';
 import LoadingState from '../Components/LoadingState';
+import NoData from '../Components/NoData';
 
 import {
     Badge,
@@ -28,7 +29,7 @@ const DataCellEnd = styled(DataListCell)`
   align-items: center;
 `;
 
-const ModulesList = ({ modules }) => (
+const ModulesList = ({ modules, isLoading }) => (
     <DataList aria-label="Top Modules" style={ {
         maxHeight: '400px',
         overflow: 'auto'
@@ -43,8 +44,26 @@ const ModulesList = ({ modules }) => (
                 </h3>
             </DataCellEnd>
         </DataListItem>
-        { modules.length <= 0 && (
-            <LoadingState />
+        { isLoading && (
+            <PFDataListItem
+                aria-labelledby="modules-loading"
+                key={ isLoading }
+            >
+                <PFDataListCell>
+                    <LoadingState />
+                </PFDataListCell>
+            </PFDataListItem>
+        ) }
+        { !isLoading && modules.length <= 0 && (
+            <PFDataListItem
+                aria-labelledby="modules-no-data"
+                key={ isLoading }
+            >
+                <PFDataListCell>
+                    <NoData />
+
+                </PFDataListCell>
+            </PFDataListItem>
         ) }
         { modules.filter(module => module.module !== null).map(({ module, count }) => (
             <DataListItem aria-labelledby="top-modules-detail" key={ module }>
@@ -60,7 +79,8 @@ const ModulesList = ({ modules }) => (
 );
 
 ModulesList.propTypes = {
-    modules: PropTypes.array
+    modules: PropTypes.array,
+    isLoading: PropTypes.bool
 };
 
 export default ModulesList;

--- a/src/Components/ModulesList.js
+++ b/src/Components/ModulesList.js
@@ -65,8 +65,8 @@ const ModulesList = ({ modules, isLoading }) => (
                 </PFDataListCell>
             </PFDataListItem>
         ) }
-        { !isLoading && modules.filter(module => module.module !== null).map(({ module, count }) => (
-            <DataListItem aria-labelledby="top-modules-detail" key={ module }>
+        { !isLoading && modules.filter(module => module.module !== null).map(({ module, count }, index) => (
+            <DataListItem aria-labelledby="top-modules-detail" key={ index }>
                 <DataListCell>
                     <span>{ trimStr(module) }</span>
                 </DataListCell>

--- a/src/Components/ModulesList.js
+++ b/src/Components/ModulesList.js
@@ -65,7 +65,7 @@ const ModulesList = ({ modules, isLoading }) => (
                 </PFDataListCell>
             </PFDataListItem>
         ) }
-        { modules.filter(module => module.module !== null).map(({ module, count }) => (
+        { !isLoading && modules.filter(module => module.module !== null).map(({ module, count }) => (
             <DataListItem aria-labelledby="top-modules-detail" key={ module }>
                 <DataListCell>
                     <span>{ trimStr(module) }</span>

--- a/src/Components/NoData.js
+++ b/src/Components/NoData.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+    Title,
+    EmptyState,
+    EmptyStateVariant,
+    EmptyStateIcon
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+
+const NoData = () => (
+    <EmptyState variant={ EmptyStateVariant.full }>
+        <EmptyStateIcon icon={ CubesIcon } />
+        <Title headingLevel="h5" size="lg">
+            No Data
+        </Title>
+    </EmptyState>
+);
+
+export default NoData;

--- a/src/Components/NotificationsList.js
+++ b/src/Components/NotificationsList.js
@@ -145,10 +145,10 @@ const NotificationsList = ({
                 </PFDataListCell>
             </PFDataListItem>
         ) }
-        { filterBy === 'all' && (
+        { !isLoading && filterBy === 'all' && (
             <NotificationTemplate notifications={ notifications } />
         ) }
-        { filterBy === 'error' && (
+        { !isLoading && filterBy === 'error' && (
             <ErrorNotificationTemplate notifications={ notifications } />
         ) }
     </DataList>

--- a/src/Components/NotificationsList.js
+++ b/src/Components/NotificationsList.js
@@ -11,6 +11,7 @@ import {
 
 import { WarningTriangleIcon, ArrowIcon as PFArrowIcon } from '@patternfly/react-icons';
 import LoadingState from '../Components/LoadingState';
+import NoData from '../Components/NoData';
 
 const ArrowIcon = styled(PFArrowIcon)`
     margin-left: 7px;
@@ -93,7 +94,8 @@ const NotificationsList = ({
     filterBy,
     onNotificationChange,
     options,
-    notifications
+    notifications,
+    isLoading
 }) => (
     <DataList style={ {
         flex: '1',
@@ -123,8 +125,26 @@ const NotificationsList = ({
                 </FormSelect>
             </DataCellEnd>
         </DataListItem>
-        { notifications.length <= 0 && (
-            <LoadingState />
+        { isLoading && (
+            <PFDataListItem
+                aria-labelledby="notifications-loading"
+                key={ isLoading }
+            >
+                <PFDataListCell>
+                    <LoadingState />
+                </PFDataListCell>
+            </PFDataListItem>
+        ) }
+        { !isLoading && notifications.length <= 0 && (
+            <PFDataListItem
+                aria-labelledby="notifications-no-data"
+                key={ isLoading }
+            >
+                <PFDataListCell>
+                    <NoData />
+
+                </PFDataListCell>
+            </PFDataListItem>
         ) }
         { filterBy === 'all' && (
             <NotificationTemplate notifications={ notifications } />
@@ -143,7 +163,8 @@ NotificationsList.propTypes = {
     notifications: PropTypes.array,
     options: PropTypes.array,
     filterBy: PropTypes.string,
-    onNotificationChange: PropTypes.func
+    onNotificationChange: PropTypes.func,
+    isLoading: PropTypes.bool
 };
 
 export default NotificationsList;

--- a/src/Components/NotificationsList.js
+++ b/src/Components/NotificationsList.js
@@ -142,7 +142,6 @@ const NotificationsList = ({
             >
                 <PFDataListCell>
                     <NoData />
-
                 </PFDataListCell>
             </PFDataListItem>
         ) }

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -144,7 +144,7 @@ const TemplatesList = ({ templates, isLoading }) => {
                   </PFDataListCell>
               </PFDataListItem>
           ) }
-          { templates.map(({ name, count, id }) => (
+          { !isLoading && templates.map(({ name, count, id }) => (
               <DataListItem aria-labelledby="top-templates-detail" key={ name }>
                   <DataListCell>
                       <a

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -144,8 +144,8 @@ const TemplatesList = ({ templates, isLoading }) => {
                   </PFDataListCell>
               </PFDataListItem>
           ) }
-          { !isLoading && templates.map(({ name, count, id }) => (
-              <DataListItem aria-labelledby="top-templates-detail" key={ name }>
+          { !isLoading && templates.map(({ name, count, id }, index) => (
+              <DataListItem aria-labelledby="top-templates-detail" key={ index }>
                   <DataListCell>
                       <a
                           onClick={ () => {

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { formatDateTime, formatSeconds, formatPercentage } from '../Utilities/helpers';
 import styled from 'styled-components';
 import LoadingState from '../Components/LoadingState';
+import NoData from '../Components/NoData';
 
 import {
     Badge,
@@ -92,7 +93,7 @@ const renderTemplateTitle = ({ name, type }) => {
     );
 };
 
-const TemplatesList = ({ templates }) => {
+const TemplatesList = ({ templates, isLoading }) => {
     const [ isModalOpen, setIsModalOpen ] = useState(false);
     const [ selectedId, setSelectedId ] = useState(null);
     const [ selectedTemplate, setSelectedTemplate ] = useState([]);
@@ -123,7 +124,26 @@ const TemplatesList = ({ templates }) => {
                   </h3>
               </DataCellEnd>
           </DataListItem>
-          { templates.length <= 0 && <LoadingState /> }
+          { isLoading && (
+              <PFDataListItem
+                  aria-labelledby="templates-loading"
+                  key={ isLoading }
+              >
+                  <PFDataListCell>
+                      <LoadingState />
+                  </PFDataListCell>
+              </PFDataListItem>
+          ) }
+          { !isLoading && templates.length <= 0 && (
+              <PFDataListItem
+                  aria-labelledby="templates-no-data"
+                  key={ isLoading }
+              >
+                  <PFDataListCell>
+                      <NoData />
+                  </PFDataListCell>
+              </PFDataListItem>
+          ) }
           { templates.map(({ name, count, id }) => (
               <DataListItem aria-labelledby="top-templates-detail" key={ name }>
                   <DataListCell>
@@ -241,7 +261,8 @@ const TemplatesList = ({ templates }) => {
 };
 
 TemplatesList.propTypes = {
-    templates: PropTypes.array
+    templates: PropTypes.array,
+    isLoading: PropTypes.bool
 };
 
 export default TemplatesList;

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -109,6 +109,7 @@ const Clusters = () => {
     const [ selectedCluster, setSelectedCluster ] = useState('all');
     const [ selectedNotification, setSelectedNotification ] = useState('all');
     const [ firstRender, setFirstRender ] = useState(true);
+    const [ isLoading, setIsLoading ] = useState(true);
     const { queryParams, setEndDate, setStartDate, setId } = useQueryParams(initialQueryParams);
 
     useEffect(() => {
@@ -126,6 +127,7 @@ const Clusters = () => {
         };
 
         const update = () => {
+            setIsLoading(true);
             setLineChartData([]); // Clear out line chart values
             fetchEndpoints().then(([
                 { data: lineChartData = []},
@@ -137,6 +139,7 @@ const Clusters = () => {
                 setModulesData(modulesData);
                 setTemplatesData(templatesData);
                 setNotificationsData(notificationsData);
+                setIsLoading(false);
             });
         };
 
@@ -156,6 +159,7 @@ const Clusters = () => {
         };
 
         async function initializeWithPreflight() {
+            setIsLoading(true);
             await window.insights.chrome.auth.getUser();
             await preflightRequest().catch(error => {
                 setPreFlightError({ preflightError: error });
@@ -176,6 +180,7 @@ const Clusters = () => {
                     setTemplatesData(templatesData);
                     setNotificationsData(notificationsData);
                     setFirstRender(false);
+                    setIsLoading(false);
                 }
             });
         }
@@ -279,13 +284,14 @@ const Clusters = () => {
                         className="dataCard"
                         style={ { display: 'flex', marginTop: '20px' } }
                     >
-                        <TemplatesList templates={ templatesData.slice(0, 10) } />
-                        <ModulesList modules={ modulesData.slice(0, 10) } />
+                        <TemplatesList templates={ templatesData.slice(0, 10) } isLoading={ isLoading } />
+                        <ModulesList modules={ modulesData.slice(0, 10) } isLoading={ isLoading }/>
                         <NotificationsList
                             onNotificationChange={ (value) => setSelectedNotification(value) }
                             filterBy={ selectedNotification }
                             options={ notificationOptions }
                             notifications={ notificationsData }
+                            isLoading={ isLoading }
                         />
                     </div>
                 </Main>

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { useQueryParams } from '../../Utilities/useQueryParams';
 
 import LoadingState from '../../Components/LoadingState';
+import NoData from '../../Components/NoData';
 import EmptyState from '../../Components/EmptyState';
 import {
     preflightRequest,
@@ -102,6 +103,7 @@ const OrganizationStatistics = () => {
     const [ timeframe, setTimeframe ] = useState(7);
     const [ sortOrder, setSortOrder ] = useState('count:desc');
     const [ firstRender, setFirstRender ] = useState(true);
+    const [ isLoading, setIsLoading ] = useState(true);
     const { queryParams, setEndDate, setStartDate, setSortBy, setLimit } = useQueryParams(initialQueryParams);
 
     const setLimitValue = val => {
@@ -127,6 +129,7 @@ const OrganizationStatistics = () => {
         };
 
         const update = () => {
+            setIsLoading(true);
             fetchEndpoints().then(([
                 { dates: groupedBarChartData = []},
                 { usages: pieChart1Data = []},
@@ -135,10 +138,12 @@ const OrganizationStatistics = () => {
                 setGroupedBarChartData(groupedBarChartData);
                 setPieChart1Data(pieChart1Data);
                 setPieChart2Data(pieChart2Data);
+                setIsLoading(false);
             });
         };
 
         async function initializeWithPreflight() {
+            setIsLoading(true);
             await window.insights.chrome.auth.getUser();
             await preflightRequest().catch(error => {
                 setPreFlightError({ preflightError: error });
@@ -153,6 +158,7 @@ const OrganizationStatistics = () => {
                     setPieChart1Data(pieChart1Data);
                     setPieChart2Data(pieChart2Data);
                     setFirstRender(false);
+                    setIsLoading(false);
                 }
             });
         }
@@ -236,8 +242,11 @@ const OrganizationStatistics = () => {
                             <h2>Organization Status</h2>
                         </CardHeader>
                         <CardBody>
-                            { groupedBarChartData.length <= 0 && <LoadingState /> }
-                            { groupedBarChartData.length > 0 && (
+                            { isLoading && <LoadingState /> }
+                            { !isLoading && groupedBarChartData.length <= 0 && (
+                                <NoData />
+                            ) }
+                            { !isLoading && groupedBarChartData.length > 0 && (
                                 <GroupedBarChart
                                     margin={ { top: 20, right: 20, bottom: 50, left: 50 } }
                                     id="d3-grouped-bar-chart-root"
@@ -257,8 +266,11 @@ const OrganizationStatistics = () => {
                                 Job Runs by Organization
                                     </h2>
                                 </CardHeader>
-                                { pieChart1Data.length <= 0 && <LoadingState /> }
-                                { pieChart1Data.length > 0 && (
+                                { isLoading && <LoadingState /> }
+                                { !isLoading && pieChart1Data.length <= 0 && (
+                                    <NoData />
+                                ) }
+                                { !isLoading && pieChart1Data.length > 0 && (
                                     <PieChart
                                         margin={ { top: 20, right: 20, bottom: 0, left: 20 } }
                                         id="d3-donut-1-chart-root"
@@ -275,8 +287,11 @@ const OrganizationStatistics = () => {
                                 >
                                     <h2 style={ { marginLeft: '20px' } }>Usage by Organization (Tasks)</h2>
                                 </CardHeader>
-                                { pieChart2Data.length <= 0 && <LoadingState /> }
-                                { pieChart2Data.length > 0 && (
+                                { isLoading && <LoadingState /> }
+                                { !isLoading && pieChart2Data.length <= 0 && (
+                                    <NoData />
+                                ) }
+                                { !isLoading && pieChart2Data.length > 0 && (
                                     <PieChart
                                         margin={ { top: 20, right: 20, bottom: 0, left: 20 } }
                                         id="d3-donut-2-chart-root"


### PR DESCRIPTION
Related: https://github.com/RedHatInsights/tower-analytics-frontend/issues/49
Currently our app shows the same loading state if the API returns empty results. This PR fixes that by creating a NoData component to render:

Before:
![only loading](https://user-images.githubusercontent.com/2293210/73985177-83eaf180-4908-11ea-8e95-8739d45935eb.gif)



After:
![loading and empty](https://user-images.githubusercontent.com/2293210/73984990-0de68a80-4908-11ea-8bd5-d02d434705b6.gif)

