### PR TITLE
Standardize decimal up to second decimal place using toFixed().

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -544,15 +544,15 @@ const AutomationCalculator = () => {
                                                       <TooltipWrapper>
                                                           <p>
                                                               <b>Total elapsed sum</b>:{ ' ' }
-                                                              { data.elapsed_sum }s
+                                                              { data.elapsed_sum.toFixed(2) }s
                                                           </p>
                                                           <p>
                                                               <b>Success elapsed sum</b>:{ ' ' }
-                                                              { data.successful_elapsed_sum }s
+                                                              { data.successful_elapsed_sum.toFixed(2) }s
                                                           </p>
                                                           <p>
                                                               <b>Failed elapsed sum</b>:{ ' ' }
-                                                              { data.failed_elapsed_sum }s
+                                                              { data.failed_elapsed_sum.toFixed(2) }s
                                                           </p>
                                                           <p>
                                                               <b>Automation Percentage</b>:{ ' ' }


### PR DESCRIPTION
Linked issue: https://github.com/RedHatInsights/tower-analytics-backend/issues/346

This PR handles standardizing float values (`elapsed_sum, successful_elapsed_sum, failed_elapsed_sum) rendered in the tooltip on the top templates card  to the second decimal place.