### PR TITLE
Adjust y axis labels to accomodate large numbers.

### DIFF
--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -215,12 +215,13 @@ class TopTemplatesSavings extends Component {
         // format our X Axis ticks
         let ticks;
         ticks = data.map(d => d.name);
-
+        const formatYAxisValue = d3.format('.2s');
         const xAxis = d3.axisBottom(x).tickValues(ticks);
 
         const yAxis = d3
         .axisLeft(y)
         .ticks(8)
+        .tickFormat(d => formatYAxisValue(d).replace('G', 'B'))
         .tickSize(-width, 0, 0);
 
         const svg = d3


### PR DESCRIPTION
Related #120 
This PR adjusts the y axis on the automation calculator chart to accommodate large numbers.
![y-axis-format](https://user-images.githubusercontent.com/2293210/79591611-c5391380-80a6-11ea-902f-6d5f3a9b08f7.gif)
