### PR TITLE
Update the dropdown menu prompt for clusters 

### DIFF
--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -100,7 +100,7 @@ const perPageOptions = [
 
 function formatClusterName(data) {
     const defaultClusterOptions = [
-        { value: 'please choose', label: 'Select Notification Type', disabled: true },
+        { value: 'please choose', label: 'Select cluster', disabled: true },
         { value: '', label: 'All Clusters', disabled: false },
         { value: -1, label: 'Unassociated', disabled: false }
     ];


### PR DESCRIPTION
Linked issue: https://slack-redir.net/link?url=https%3A%2F%2Fgithub.com%2FRedHatInsights%2Ftower-analytics-frontend%2Fissues%2F113

This PR handles updating the section prompt for clusters on the notifications page.