### PR TITLE
Replace eye icon with toggle on/off icons

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -30,8 +30,8 @@ import {
 import {
     DollarSignIcon,
     InfoCircleIcon,
-    OutlinedEyeIcon,
-    OutlinedEyeSlashIcon
+    ToggleOnIcon,
+    ToggleOffIcon
 } from '@patternfly/react-icons';
 
 import TopTemplatesSavings from '../../Charts/ROITopTemplates';
@@ -546,7 +546,7 @@ const AutomationCalculator = () => {
                                                   <InfoCircleIcon />
                                               </Tooltip>
                                               { data.isActive === true && (
-                                                  <OutlinedEyeIcon
+                                                  <ToggleOnIcon
                                                       onClick={ () => {
                                                           const selected = handleToggle(
                                                               data.id,
@@ -557,7 +557,7 @@ const AutomationCalculator = () => {
                                                   />
                                               ) }
                                               { data.isActive === false && (
-                                                  <OutlinedEyeSlashIcon
+                                                  <ToggleOffIcon
                                                       onClick={ () => {
                                                           const selected = handleToggle(
                                                               data.id,


### PR DESCRIPTION
Linked issue: https://slack-redir.net/link?url=https%3A%2F%2Fgithub.com%2FRedHatInsights%2Ftower-analytics-frontend%2Fissues%2F112

This PR handles swapping the eye icon with the toggle on/off icon on the top templates card for clearer intended use.  