### PR TITLE
Fix chart not being able to find correct container

### DIFF
--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -200,7 +200,7 @@ class TopTemplatesSavings extends Component {
         let width;
         // adjust chart width to support larger datasets
         if (data.length >= 15) {
-            const containerWidth = d3.select('.pf-l-grid').node();
+            const containerWidth = d3.select('.automation-wrapper').node();
             width = containerWidth.getBoundingClientRect().width - this.props.margin.left - this.props.margin.right;
         } else {
             width = this.props.getWidth();

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -109,6 +109,7 @@ const WrapperLeft = styled.div`
     flex: 5;
     display: flex;
     flex-direction: column;
+    overflow: auto;
 `;
 
 const WrapperRight = styled.div`
@@ -366,7 +367,7 @@ const AutomationCalculator = () => {
       )}
       {!preflightError && (
           <>
-          <Wrapper>
+          <Wrapper className="automation-wrapper">
               <WrapperLeft>
                   <Main style={ { paddingBottom: '0' } }>
                       <Card>


### PR DESCRIPTION
This PR adjusts both logic and styling in `AutomationCalculator.js` and `ROITopTemplates.js` so that the correct component is selected to render the chart (if more than 15 templates are returned) and to adjust its overflow style accordingly.