### PR TITLE
Prevent users from manually entering negative values 

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -442,7 +442,7 @@ const AutomationCalculator = () => {
                                           step="any"
                                           min="0"
                                           aria-label="manual-cost"
-                                          value={ costManual }
+                                          value={ parseInt(costManual) }
                                           onChange={ e => setCostManual(e) }
                                       />
                                       <InputGroupText>/hr</InputGroupText>
@@ -460,7 +460,7 @@ const AutomationCalculator = () => {
                                           step="any"
                                           min="0"
                                           aria-label="automation-cost"
-                                          value={ costAutomation }
+                                          value={ parseInt(costAutomation) }
                                           onChange={ e => setCostAutomation(e) }
                                       />
                                       <InputGroupText>/hr</InputGroupText>

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -442,7 +442,7 @@ const AutomationCalculator = () => {
                                           step="any"
                                           min="0"
                                           aria-label="manual-cost"
-                                          value={ parseInt(costManual) }
+                                          value={ parseFloat(costManual) }
                                           onChange={ e => setCostManual(e) }
                                       />
                                       <InputGroupText>/hr</InputGroupText>
@@ -460,7 +460,7 @@ const AutomationCalculator = () => {
                                           step="any"
                                           min="0"
                                           aria-label="automation-cost"
-                                          value={ parseInt(costAutomation) }
+                                          value={ parseFloat(costAutomation) }
                                           onChange={ e => setCostAutomation(e) }
                                       />
                                       <InputGroupText>/hr</InputGroupText>


### PR DESCRIPTION
linked issue: https://github.com/RedHatInsights/tower-analytics-frontend/issues/131

This PR handles preventing users from manually entering negative values into the automation cost inputs on the ROI calculator. 