### PR TITLE
[Depends] Orgs in charts share color

### DIFF
--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -1,37 +1,18 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
 import Tooltip from '../Utilities/Tooltip';
 
-class BarChart extends Component {
-    constructor(props) {
-        super(props);
-        this.draw = this.draw.bind(this);
-        this.init = this.init.bind(this);
-        this.resize = this.resize.bind(this);
-        this.state = {
-            formattedData: [],
-            timeout: null
-        };
-    }
-    resize() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        this.setState({
-            timeout: setTimeout(() => { this.init(); }, 500)
-        });
-    }
+const BarChart = (props) => {
+    const [ time, setTime ] = useState(null);
 
-    init() {
-        this.draw();
-    }
     // Methods
-    draw() {
+    const draw = () => {
         // Clear our chart container element first
-        d3.selectAll('#' + this.props.id + ' > *').remove();
+        d3.selectAll('#' + props.id + ' > *').remove();
         const parseTime = d3.timeParse('%Y-%m-%d');
-        let { data: unformattedData, value } = this.props;
+        let { data: unformattedData, value } = props;
         const data = unformattedData.reduce((formatted, { created, successful, failed }) => {
             let DATE = parseTime(created) || new Date();
             let RAN = +successful || 0;
@@ -39,8 +20,8 @@ class BarChart extends Component {
             let TOTAL = +successful + failed || 0;
             return formatted.concat({ DATE, RAN, FAIL, TOTAL });
         }, []);
-        const width = this.props.getWidth();
-        const height = this.props.getHeight();
+        const width = props.getWidth();
+        const height = props.getHeight();
         const x = d3
         .scaleBand()
         .rangeRound([ 0, width ])
@@ -48,24 +29,24 @@ class BarChart extends Component {
         const y = d3.scaleLinear().range([ height, 0 ]);
 
         const svg = d3
-        .select('#' + this.props.id)
+        .select('#' + props.id)
         .append('svg')
-        .attr('width', width + this.props.margin.left + this.props.margin.right)
-        .attr('height', height + this.props.margin.top + this.props.margin.bottom)
+        .attr('width', width + props.margin.left + props.margin.right)
+        .attr('height', height + props.margin.top + props.margin.bottom)
         .append('g')
         .attr(
             'transform',
             'translate(' +
-                this.props.margin.left +
+                props.margin.left +
                 ',' +
-                this.props.margin.top +
+                props.margin.top +
                 ')'
         );
         //[fail, success]
         let colors = d3.scaleOrdinal([ '#6EC664', '#A30000' ]);
 
         const barTooltip = new Tooltip({
-            svg: '#' + this.props.id,
+            svg: '#' + props.id,
             colors
         });
         const status = [ 'FAIL', 'RAN' ];
@@ -97,7 +78,7 @@ class BarChart extends Component {
         svg
         .append('text')
         .attr('transform', 'rotate(-90)')
-        .attr('y', 0 - this.props.margin.left)
+        .attr('y', 0 - props.margin.left)
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
@@ -134,7 +115,7 @@ class BarChart extends Component {
             'translate(' +
                 width / 2 +
                 ' ,' +
-                (height + this.props.margin.top + 20) +
+                (height + props.margin.top + 20) +
                 ')'
         )
         .style('text-anchor', 'middle')
@@ -166,30 +147,31 @@ class BarChart extends Component {
         .on('mouseover', barTooltip.handleMouseOver)
         .on('mousemove', barTooltip.handleMouseOver)
         .on('mouseout', barTooltip.handleMouseOut);
-    }
+    };
 
-    componentDidMount() {
-        this.init();
+    const resize = () => {
+        clearTimeout(time);
+        setTime(setTimeout(() => { draw(); }, 500));
+    };
+
+    useEffect(() => {
+        draw();
         // Call the resize function whenever a resize event occurs
-        window.addEventListener('resize', this.resize);
-    }
+        window.addEventListener('resize', resize);
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.value !== this.props.value) {
-            this.init();
-        }
-    }
+        return () => {
+            clearTimeout(time);
+            window.removeEventListener('resize', resize);
+        };
+    }, []);
 
-    componentWillUnmount() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        window.removeEventListener('resize', this.resize);
-    }
+    // FIXME: Verify if it is needed.
+    useEffect(() => draw(), [ props ]);
 
-    render() {
-        return <div id={ this.props.id } />;
-    }
-}
+    return (
+        <div id={ props.id } />
+    );
+};
 
 BarChart.propTypes = {
     id: PropTypes.string,

--- a/src/Charts/BaseChart.js
+++ b/src/Charts/BaseChart.js
@@ -1,51 +1,43 @@
-/* eslint react/prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
-function initializeChart(Chart) {
-    return class BaseChart extends React.Component {
-        constructor(props) {
-            super(props);
-            this.getWidth = this.getWidth.bind(this);
-            this.getHeight = this.getHeight.bind(this);
-        }
+const initializeChart = Chart => {
+    const BaseChart = (props) => {
+        const { id, margin } = props;
 
-        propTypes = {
-            id: PropTypes.string,
-            margin: PropTypes.object
-        }
-
-        // Methods
-        getWidth() {
+        const getWidth = () => {
             let width;
             width =
-            parseInt(d3.select('#' + this.props.id).style('width')) -
-            this.props.margin.left -
-            this.props.margin.right || 700;
+            parseInt(d3.select('#' + id).style('width')) -
+                margin.left - margin.right || 700;
             return width;
-        }
+        };
 
-        getHeight() {
+        const getHeight = () => {
             let height;
             height =
-            parseInt(d3.select('#' + this.props.id).style('height')) -
-            this.props.margin.top -
-            this.props.margin.bottom || 450;
+            parseInt(d3.select('#' + id).style('height')) -
+                margin.top - margin.bottom || 450;
             return height;
-        }
+        };
 
-        render() {
-            return (
-                <Chart
-                    { ...this.props }
-                    getWidth={ this.getWidth }
-                    getHeight={ this.getHeight }
-                />
-            );
-        }
+        return (
+            <Chart
+                { ...props }
+                getWidth={ getWidth }
+                getHeight={ getHeight }
+            />
+        );
     };
-}
+
+    BaseChart.propTypes = {
+        id: PropTypes.string,
+        margin: PropTypes.object
+    };
+
+    return BaseChart;
+};
 
 initializeChart.propTypes = {
     Chart: PropTypes.element

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import Legend from '../Utilities/Legend';
-import { pfmulti } from '../Utilities/colors';
+import { getColorForNames } from '../Utilities/colors';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -12,8 +12,6 @@ const Wrapper = styled.div`
   flex-wrap: nowrap;
   flex-shrink: 0;
 `;
-
-const color = d3.scaleOrdinal(pfmulti);
 
 class Tooltip {
     constructor(props) {
@@ -160,6 +158,7 @@ const GroupedBarChart = (props) => {
     const [ selected, setSelected ] = useState([]);
     const [ time, setTime ] = useState(null);
     const orgsList = props.data[0].orgs;
+    const colorToNames = getColorForNames(orgsList.map(el => ({ name: el.org_name })));
     let selection = [];
 
     const draw = () => {
@@ -295,7 +294,7 @@ const GroupedBarChart = (props) => {
             return x1(d.org_name);
         }) // unsorted
         .style('fill', function(d) {
-            return color(d.org_name);
+            return colorToNames[d.org_name];
         })
         .attr('y', function(d) {
             return y(d.value);
@@ -304,12 +303,12 @@ const GroupedBarChart = (props) => {
             return height - y(d.value);
         })
         .on('mouseover', function(d) {
-            d3.select(this).style('fill', d3.rgb(color(d.org_name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(colorToNames[d.org_name]).darker(1));
             tooltip.handleMouseOver();
         })
         .on('mousemove', tooltip.handleMouseOver)
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.org_name));
+            d3.select(this).style('fill', colorToNames[d.org_name]);
             tooltip.handleMouseOut();
         });
         bars = bars.merge(subEnter);
@@ -336,17 +335,8 @@ const GroupedBarChart = (props) => {
             });
         }
 
-        // create our colors array to send to the Legend component
-        const colors = orgsList.reduce((colors, org) => {
-            colors.push({
-                name: org.org_name,
-                value: color(org.org_name),
-                id: org.id
-            });
-            return colors;
-        }, []);
-
-        setColors(colors);
+        const legend = orgsList.map(el => ({ name: el.org_name, value: colorToNames[el.org_name], id: el.id }));
+        setColors(legend);
         draw();
     };
 

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -1,50 +1,18 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import initializeChart from './BaseChart';
 import PropTypes from 'prop-types';
 import Tooltip from '../Utilities/Tooltip';
 import * as d3 from 'd3';
 
-class LineChart extends Component {
-    constructor(props) {
-        super(props);
-        this.init = this.init.bind(this);
-        this.draw = this.draw.bind(this);
-        this.resize = this.resize.bind(this);
-        this.updateCluster = this.updateCluster.bind(this);
-        this.state = {
-            formattedData: [],
-            timeout: null
-        };
-    }
+const LineChart = (props) => {
+    const [ time, setTime ] = useState(null);
 
-    resize() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        this.setState({
-            timeout: setTimeout(() => { this.init(); }, 500)
-        });
-    }
-
-    getTickCount() {
-        const { value } = this.props;
-        if (value > 20) {
-            return (value / 2);
-        } else {
-            return value;
-        }
-    }
-    updateCluster() {
-        this.init();
-    }
-    init() {
-        this.draw();
-    }
     // Methods
-    draw() {
+    const draw = () => {
     // Clear our chart container element first
-        d3.selectAll('#' + this.props.id + ' > *').remove();
-        const width = this.props.getWidth();
-        const height = this.props.getHeight();
+        d3.selectAll('#' + props.id + ' > *').remove();
+        const width = props.getWidth();
+        const height = props.getHeight();
 
         function transition(path) {
             path
@@ -67,26 +35,26 @@ class LineChart extends Component {
         //[success, fail, total]
         let colors = d3.scaleOrdinal([ '#6EC664', '#A30000', '#06C' ]);
         const svg = d3
-        .select('#' + this.props.id)
+        .select('#' + props.id)
         .append('svg')
-        .attr('width', width + this.props.margin.left + this.props.margin.right)
-        .attr('height', height + this.props.margin.top + this.props.margin.bottom)
+        .attr('width', width + props.margin.left + props.margin.right)
+        .attr('height', height + props.margin.top + props.margin.bottom)
         .attr('z', 100)
         .append('g')
         .attr(
             'transform',
             'translate(' +
-          this.props.margin.left +
+          props.margin.left +
           ',' +
-          this.props.margin.top +
+          props.margin.top +
           ')'
         );
         // Tooltip
         const tooltip = new Tooltip({
-            svg: '#' + this.props.id,
+            svg: '#' + props.id,
             colors
         });
-        const { data: unformattedData, value } = this.props;
+        const { data: unformattedData, value } = props;
         const parseTime = d3.timeParse('%Y-%m-%d');
 
         const data = unformattedData.reduce((formatted, { created, successful, failed }) => {
@@ -147,7 +115,7 @@ class LineChart extends Component {
         svg
         .append('text')
         .attr('transform', 'rotate(-90)')
-        .attr('y', 0 - this.props.margin.left)
+        .attr('y', 0 - props.margin.left)
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
@@ -184,7 +152,7 @@ class LineChart extends Component {
             'translate(' +
                 width / 2 +
                 ' ,' +
-                (height + this.props.margin.top + 20) +
+                (height + props.margin.top + 20) +
                 ')'
         )
         .style('text-anchor', 'middle')
@@ -277,30 +245,33 @@ class LineChart extends Component {
         .on('mouseover', handleMouseOver)
         .on('mousemove', handleMouseMove)
         .on('mouseout', handleMouseOut);
-    }
+    };
 
-    componentDidMount() {
-        this.updateCluster();
+    const resize = () => {
+        clearTimeout(time);
+        setTime(setTimeout(() => { draw(); }, 500));
+    };
+
+    useEffect(() => {
+        draw();
         // Call the resize function whenever a resize event occurs
-        window.addEventListener('resize', this.resize);
-    }
+        window.addEventListener('resize', resize);
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.value !== this.props.value) {
-            this.updateCluster();
-        }
-    }
+        return () => {
+            clearTimeout(time);
+            window.removeEventListener('resize', resize);
+        };
+    }, []);
 
-    componentWillUnmount() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        window.removeEventListener('resize', this.resize);
-    }
+    // FIXME: Cound't verify if this is needed (works without it as well)
+    // It should be called if ANY prop chages. Even if it is needed the
+    // `props` should be replaced with the exact values we should watch for.
+    useEffect(() => draw(), [ props ]);
 
-    render() {
-        return <div id={ this.props.id } />;
-    }
-}
+    return (
+        <div id={ props.id } />
+    );
+};
 
 LineChart.propTypes = {
     id: PropTypes.string,

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -1,5 +1,5 @@
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import * as d3 from 'd3';
 import initializeChart from './BaseChart';
 import { getTotal } from '../Utilities/helpers';
@@ -127,74 +127,28 @@ class Tooltip {
   };
 }
 
-class PieChart extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            colors: [],
-            timeout: null
-        };
-        this.draw = this.draw.bind(this);
-        this.init = this.init.bind(this);
-        this.resize = this.resize.bind(this);
-    }
-    // Methods
-    resize() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        this.setState({
-            timeout: setTimeout(() => { this.init(); }, 500)
-        });
-    }
-    sortDescending(data) {
-    // descending
-        data.sort((a, b) =>
-            d3.descending(parseFloat(a.count), parseFloat(b.count))
-        );
-    }
-    init() {
-        const { data } = this.props;
-        const color = d3.scaleOrdinal(pfmulti);
-        // create our colors array to send to the Legend component
-        const colors = data.reduce((colors, org) => {
-            // format complement slice as "Others"
-            if (org.id === -1) {
-                colors.push({
-                    name: 'Others',
-                    value: color(org.name),
-                    count: Math.round(org.count)
-                });
-            } else {
-                colors.push({
-                    name: org.name,
-                    value: color(org.name),
-                    count: Math.round(org.count)
-                });
-            }
+const PieChart = (props) => {
+    const [ colors, setColors ] = useState([]);
+    const [ time, setTime ] = useState(null);
 
-            return colors;
-        }, []);
-        this.setState({ colors });
-        this.draw();
-    }
-    draw() {
+    const draw = () => {
         const color = d3.scaleOrdinal(pfmulti);
 
-        d3.selectAll('#' + this.props.id + ' > *').remove();
-        const width = this.props.getWidth();
-        const height = this.props.getHeight();
+        d3.selectAll('#' + props.id + ' > *').remove();
+        const width = props.getWidth();
+        const height = props.getHeight();
         const svg = d3
-        .select('#' + this.props.id)
+        .select('#' + props.id)
         .append('svg')
-        .attr('width', width + this.props.margin.left + this.props.margin.right)
-        .attr('height', height + this.props.margin.bottom)
+        .attr('width', width + props.margin.left + props.margin.right)
+        .attr('height', height + props.margin.bottom)
         .append('g');
 
         svg.append('g').attr('class', 'slices');
         svg.append('g').attr('class', 'labels');
         svg.append('g').attr('class', 'lines');
         const radius = Math.min(width, height) / 2;
-        let { data: unfilteredData } = this.props;
+        let { data: unfilteredData } = props;
         const data = unfilteredData.filter(datum => datum.id !== -1);
         const total = getTotal(data);
         data.forEach(function(d) {
@@ -202,7 +156,7 @@ class PieChart extends Component {
             d.percent = +Math.round((d.count / total) * 100);
         });
         const donutTooltip = new Tooltip({
-            svg: '#' + this.props.id
+            svg: '#' + props.id
         });
         const pie = d3
         .pie()
@@ -216,9 +170,9 @@ class PieChart extends Component {
         svg.attr(
             'transform',
             'translate(' +
-        (width + this.props.margin.left + this.props.margin.right) / 2 +
+        (width + props.margin.left + props.margin.right) / 2 +
         ',' +
-        (height + this.props.margin.top + this.props.margin.bottom) / 2 +
+        (height + props.margin.top + props.margin.bottom) / 2 +
         ')'
         );
 
@@ -244,43 +198,70 @@ class PieChart extends Component {
 
         svg.append('g').classed('labels', true);
         svg.append('g').classed('lines', true);
-    }
+    };
 
-    componentDidMount() {
-        this.init();
+    const init = () => {
+        const { data } = props;
+        const color = d3.scaleOrdinal(pfmulti);
+
+        // create our colors array to send to the Legend component
+        const calculatedColors = data.reduce((colors, org) => {
+            // format complement slice as "Others"
+            if (org.id === -1) {
+                colors.push({
+                    name: 'Others',
+                    value: color(org.name),
+                    count: Math.round(org.count)
+                });
+            } else {
+                colors.push({
+                    name: org.name,
+                    value: color(org.name),
+                    count: Math.round(org.count)
+                });
+            }
+
+            return colors;
+        }, []);
+
+        setColors(calculatedColors);
+        draw();
+    };
+
+    const resize = () => {
+        clearTimeout(time);
+        setTime(setTimeout(() => { init(); }, 500));
+    };
+
+    useEffect(() => {
+        init();
         // Call the resize function whenever a resize event occurs
-        window.addEventListener('resize', this.resize);
-    }
+        window.addEventListener('resize', resize);
 
-    componentWillUnmount() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        window.removeEventListener('resize', this.resize);
-    }
-    componentDidUpdate(prevProps) {
-        if (prevProps.data !== this.props.data) {
-            this.init();
-        }
-    }
+        return () => {
+            clearTimeout(time);
+            window.removeEventListener('resize', resize);
+        };
+    }, []);
 
-    render() {
-        const { colors } = this.state;
-        return (
-            <Wrapper>
-                <div id={ this.props.id } />
-                { colors.length > 0 && (
-                    <Legend
-                        id="d3-grouped-bar-legend"
-                        data={ colors }
-                        selected={ null }
-                        onToggle={ null }
-                        height="300px"
-                    />
-                ) }
-            </Wrapper>
-        );
-    }
-}
+    // FIXME: Verify if it is needed.
+    useEffect(() => init(), [ props ]);
+
+    return (
+        <Wrapper>
+            <div id={ props.id } />
+            { colors.length > 0 && (
+                <Legend
+                    id="d3-grouped-bar-legend"
+                    data={ colors }
+                    selected={ null }
+                    onToggle={ null }
+                    height="300px"
+                />
+            ) }
+        </Wrapper>
+    );
+};
 
 PieChart.propTypes = {
     id: PropTypes.string,

--- a/src/Utilities/colors.js
+++ b/src/Utilities/colors.js
@@ -1,3 +1,5 @@
+import { scaleOrdinal } from 'd3';
+
 const pfmulti = [
     '#06C',
     '#4CB140',
@@ -13,5 +15,22 @@ const pfmulti = [
     '#8F4700',
     '#002F5D'
 ];
+
+/**
+ * Creates a color map to names: for same data generates same colors.
+ * @param  {[{ name }]} data    Array of objects with name options to map to.
+ * @return {{ [name]: color }}  Object where the keys are the names an the values are the colors.
+ */
+export const getColorForNames = (data) => {
+    const colorFnc = scaleOrdinal(pfmulti);
+    const compObj = prop => (a, b) => (a[prop] > b[prop]) ? 1 : ((b[prop] > a[prop]) ? -1 : 0);
+
+    const colors = data.sort(compObj('name')).reduce((colors, org) => {
+        colors[org.name] = colorFnc(org.name);
+        return colors;
+    }, {});
+
+    return colors;
+};
 
 export { pfmulti };


### PR DESCRIPTION
Closes: #81 

Builds on: https://github.com/RedHatInsights/tower-analytics-frontend/pull/143

Generating the colours to use in the start for each "name" which are ordered first to keep the same arrays same colours. It may not work if there are different arrays with the same names, but it should solve the problems in the Organisation Statistics page.

**Before**
![Screenshot from 2020-05-19 17-25-47](https://user-images.githubusercontent.com/8531681/82345741-e79bb500-99f5-11ea-8304-9b7a62ac2bac.png)

**After**
![Screenshot from 2020-05-19 17-24-40](https://user-images.githubusercontent.com/8531681/82345764-f08c8680-99f5-11ea-932f-3bff3bf48049.png)
