### PR TITLE
Converting charts to functional components

### DIFF
--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -1,37 +1,18 @@
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
 import Tooltip from '../Utilities/Tooltip';
 
-class BarChart extends Component {
-    constructor(props) {
-        super(props);
-        this.draw = this.draw.bind(this);
-        this.init = this.init.bind(this);
-        this.resize = this.resize.bind(this);
-        this.state = {
-            formattedData: [],
-            timeout: null
-        };
-    }
-    resize() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        this.setState({
-            timeout: setTimeout(() => { this.init(); }, 500)
-        });
-    }
+export const BarChart = (props) => {
+    let time = null;
 
-    init() {
-        this.draw();
-    }
     // Methods
-    draw() {
+    const draw = () => {
         // Clear our chart container element first
-        d3.selectAll('#' + this.props.id + ' > *').remove();
+        d3.selectAll('#' + props.id + ' > *').remove();
         const parseTime = d3.timeParse('%Y-%m-%d');
-        let { data: unformattedData, value } = this.props;
+        let { data: unformattedData, value } = props;
         const data = unformattedData.reduce((formatted, { created, successful, failed }) => {
             let DATE = parseTime(created) || new Date();
             let RAN = +successful || 0;
@@ -39,8 +20,8 @@ class BarChart extends Component {
             let TOTAL = +successful + failed || 0;
             return formatted.concat({ DATE, RAN, FAIL, TOTAL });
         }, []);
-        const width = this.props.getWidth();
-        const height = this.props.getHeight();
+        const width = props.getWidth();
+        const height = props.getHeight();
         const x = d3
         .scaleBand()
         .rangeRound([ 0, width ])
@@ -48,24 +29,24 @@ class BarChart extends Component {
         const y = d3.scaleLinear().range([ height, 0 ]);
 
         const svg = d3
-        .select('#' + this.props.id)
+        .select('#' + props.id)
         .append('svg')
-        .attr('width', width + this.props.margin.left + this.props.margin.right)
-        .attr('height', height + this.props.margin.top + this.props.margin.bottom)
+        .attr('width', width + props.margin.left + props.margin.right)
+        .attr('height', height + props.margin.top + props.margin.bottom)
         .append('g')
         .attr(
             'transform',
             'translate(' +
-                this.props.margin.left +
+                props.margin.left +
                 ',' +
-                this.props.margin.top +
+                props.margin.top +
                 ')'
         );
         //[fail, success]
         let colors = d3.scaleOrdinal([ '#6EC664', '#A30000' ]);
 
         const barTooltip = new Tooltip({
-            svg: '#' + this.props.id,
+            svg: '#' + props.id,
             colors
         });
         const status = [ 'FAIL', 'RAN' ];
@@ -97,7 +78,7 @@ class BarChart extends Component {
         svg
         .append('text')
         .attr('transform', 'rotate(-90)')
-        .attr('y', 0 - this.props.margin.left)
+        .attr('y', 0 - props.margin.left)
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
@@ -134,7 +115,7 @@ class BarChart extends Component {
             'translate(' +
                 width / 2 +
                 ' ,' +
-                (height + this.props.margin.top + 20) +
+                (height + props.margin.top + 20) +
                 ')'
         )
         .style('text-anchor', 'middle')
@@ -166,30 +147,30 @@ class BarChart extends Component {
         .on('mouseover', barTooltip.handleMouseOver)
         .on('mousemove', barTooltip.handleMouseOver)
         .on('mouseout', barTooltip.handleMouseOut);
-    }
+    };
 
-    componentDidMount() {
-        this.init();
+    const resize = () => {
+        clearTimeout(time);
+        time = setTimeout(() => { draw(); }, 500);
+    };
+
+    useEffect(() => {
+        draw();
         // Call the resize function whenever a resize event occurs
-        window.addEventListener('resize', this.resize);
-    }
+        window.addEventListener('resize', resize);
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.value !== this.props.value) {
-            this.init();
-        }
-    }
+        return () => {
+            clearTimeout(time);
+            window.removeEventListener('resize', resize);
+        };
+    }, []);
 
-    componentWillUnmount() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        window.removeEventListener('resize', this.resize);
-    }
+    useEffect(() => draw(), [ props.value ]);
 
-    render() {
-        return <div id={ this.props.id } />;
-    }
-}
+    return (
+        <div id={ props.id } />
+    );
+};
 
 BarChart.propTypes = {
     id: PropTypes.string,

--- a/src/Charts/BaseChart.js
+++ b/src/Charts/BaseChart.js
@@ -1,51 +1,43 @@
-/* eslint react/prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
-function initializeChart(Chart) {
-    return class BaseChart extends React.Component {
-        constructor(props) {
-            super(props);
-            this.getWidth = this.getWidth.bind(this);
-            this.getHeight = this.getHeight.bind(this);
-        }
+const initializeChart = Chart => {
+    const BaseChart = (props) => {
+        const { id, margin } = props;
 
-        propTypes = {
-            id: PropTypes.string,
-            margin: PropTypes.object
-        }
-
-        // Methods
-        getWidth() {
+        const getWidth = () => {
             let width;
             width =
-            parseInt(d3.select('#' + this.props.id).style('width')) -
-            this.props.margin.left -
-            this.props.margin.right || 700;
+            parseInt(d3.select('#' + id).style('width')) -
+                margin.left - margin.right || 700;
             return width;
-        }
+        };
 
-        getHeight() {
+        const getHeight = () => {
             let height;
             height =
-            parseInt(d3.select('#' + this.props.id).style('height')) -
-            this.props.margin.top -
-            this.props.margin.bottom || 450;
+            parseInt(d3.select('#' + id).style('height')) -
+                margin.top - margin.bottom || 450;
             return height;
-        }
+        };
 
-        render() {
-            return (
-                <Chart
-                    { ...this.props }
-                    getWidth={ this.getWidth }
-                    getHeight={ this.getHeight }
-                />
-            );
-        }
+        return (
+            <Chart
+                { ...props }
+                getWidth={ getWidth }
+                getHeight={ getHeight }
+            />
+        );
     };
-}
+
+    BaseChart.propTypes = {
+        id: PropTypes.string,
+        margin: PropTypes.object
+    };
+
+    return BaseChart;
+};
 
 initializeChart.propTypes = {
     Chart: PropTypes.element

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -155,7 +155,7 @@ class Tooltip {
   };
 }
 
-const GroupedBarChart = (props) => {
+export const GroupedBarChart = (props) => {
     const [ colors, setColors ] = useState([]);
     const [ selected, setSelected ] = useState([]);
     const [ updater, setUpdater ] = useState(0);

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -1,5 +1,5 @@
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import Legend from '../Utilities/Legend';
@@ -155,71 +155,18 @@ class Tooltip {
   };
 }
 
-class GroupedBarChart extends Component {
-    constructor(props) {
-        super(props);
-        this.init = this.init.bind(this);
-        this.handleToggle = this.handleToggle.bind(this);
-        this.draw = this.draw.bind(this);
-        this.resize = this.resize.bind(this);
-        this.orgsList = props.data[0].orgs;
-        this.selection = [];
-        this.state = {
-            colors: [],
-            selected: [],
-            formattedData: [],
-            timeout: null
-        };
-    }
+const GroupedBarChart = (props) => {
+    const [ colors, setColors ] = useState([]);
+    const [ selected, setSelected ] = useState([]);
+    const [ updater, setUpdater ] = useState(0);
+    const updaterRef = useRef(updater);
+    let time = null;
+    const orgsList = props.data[0].orgs;
 
-    // Methods
-    resize() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        this.setState({
-            timeout: setTimeout(() => { this.init(); }, 500)
-        });
-    }
-
-    handleToggle(selectedId) {
-        if (this.selection.indexOf(selectedId) === -1) {
-            this.selection = [ ...this.selection, selectedId ];
-        } else if (this.selection.includes(selectedId)) {
-            this.selection = [ ...this.selection ].filter(s => s !== selectedId);
-        }
-
-        this.setState({ selected: this.selection });
-        this.draw();
-    }
-
-    init() {
-        // create the first 8 selected data points
-        if (this.selection.length === 0) {
-            this.orgsList.forEach((org, index) => {
-                if (index <= 7) {
-                    this.handleToggle(org.id);
-                }
-            });
-        }
-
-        // create our colors array to send to the Legend component
-        const colors = this.orgsList.reduce((colors, org) => {
-            colors.push({
-                name: org.org_name,
-                value: color(org.org_name),
-                id: org.id
-            });
-            return colors;
-        }, []);
-        this.setState({ colors });
-        this.draw();
-    }
-
-    draw() {
+    const draw = () => {
         // Clear our chart container element first
-        d3.selectAll('#' + this.props.id + ' > *').remove();
-        let { data: unformattedData, timeFrame } = this.props;
-        const selected = this.selection;
+        d3.selectAll('#' + props.id + ' > *').remove();
+        let { data: unformattedData, timeFrame } = props;
         const parseTime = d3.timeParse('%Y-%m-%d');
         const data = unformattedData.reduce((formatted, { date, orgs: orgsList }) => {
             date = parseTime(date);
@@ -229,8 +176,8 @@ class GroupedBarChart extends Component {
             });
             return formatted.concat({ date, selectedOrgs });
         }, []);
-        const width = this.props.getWidth();
-        const height = this.props.getHeight();
+        const width = props.getWidth();
+        const height = props.getHeight();
         // x scale of entire chart
         const x0 = d3
         .scaleBand()
@@ -259,24 +206,24 @@ class GroupedBarChart extends Component {
         .tickSize(-width, 0, 0);
 
         const svg = d3
-        .select('#' + this.props.id)
+        .select('#' + props.id)
         .append('svg')
-        .attr('width', width + this.props.margin.left + this.props.margin.right)
-        .attr('height', height + this.props.margin.bottom + this.props.margin.top)
+        .attr('width', width + props.margin.left + props.margin.right)
+        .attr('height', height + props.margin.bottom + props.margin.top)
         .append('g')
         .attr(
             'transform',
             'translate(' +
-          this.props.margin.left +
+          props.margin.left +
           ',' +
-          this.props.margin.top +
+          props.margin.top +
           ')'
         );
 
         const dates = data.map(d => d.date);
         const selectedOrgNames = data[0].selectedOrgs.map(d => d.org_name);
         const tooltip = new Tooltip({
-            svg: '#' + this.props.id
+            svg: '#' + props.id
         });
         x0.domain(dates);
         x1.domain(selectedOrgNames).range([ 0, x0.bandwidth() ]); // unsorted
@@ -302,7 +249,7 @@ class GroupedBarChart extends Component {
         svg
         .append('text')
         .attr('transform', 'rotate(-90)')
-        .attr('y', 0 - this.props.margin.left)
+        .attr('y', 0 - props.margin.left)
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
@@ -320,7 +267,7 @@ class GroupedBarChart extends Component {
         .append('text')
         .attr(
             'transform',
-            'translate(' + width / 2 + ' ,' + (height + this.props.margin.top + 25) + ')'
+            'translate(' + width / 2 + ' ,' + (height + props.margin.top + 25) + ')'
         )
         .style('text-anchor', 'middle')
         .text('Date');
@@ -368,36 +315,79 @@ class GroupedBarChart extends Component {
         bars = bars.merge(subEnter);
     };
 
-    componentDidMount() {
-        this.init();
+    const handleToggle = selectedId => {
+        if (selected.indexOf(selectedId) === -1) {
+            setSelected([ ...selected, selectedId ]);
+        } else if (selected.includes(selectedId)) {
+            setSelected([ ...selected ].filter(s => s !== selectedId));
+        }
+    };
+
+    const initSelected = (num) => {
+        let sel = [];
+        orgsList.forEach((org, index) => {
+            if (index < num) {
+                sel = [ ...sel, org.id ];
+            }
+        });
+        setSelected(sel);
+    };
+
+    const init = () => {
+        if (selected.length === 0) {
+            initSelected(8);
+        }
+
+        // create our colors array to send to the Legend component
+        const colors = orgsList.reduce((colors, org) => {
+            colors.push({
+                name: org.org_name,
+                value: color(org.org_name),
+                id: org.id
+            });
+            return colors;
+        }, []);
+
+        setColors(colors);
+        draw();
+    };
+
+    const resize = () => {
+        clearTimeout(time);
+        time = setTimeout(() => { setUpdater(updaterRef.current + 1); }, 500);
+    };
+
+    useEffect(() => {
+        init();
         // Call the resize function whenever a resize event occurs
-        window.addEventListener('resize', this.resize);
-    }
+        window.addEventListener('resize', resize);
 
-    componentWillUnmount() {
-        const { timeout } = this.state;
-        clearTimeout(timeout);
-        window.removeEventListener('resize', this.resize);
-    }
+        return () => {
+            clearTimeout(time);
+            window.removeEventListener('resize', resize);
+        };
+    }, []);
 
-    render() {
-        const { colors, selected } = this.state;
-        return (
-            <Wrapper>
-                <div id={ this.props.id } />
-                { colors.length > 0 && (
-                    <Legend
-                        id="d3-grouped-bar-legend"
-                        data={ colors }
-                        selected={ selected }
-                        onToggle={ this.handleToggle }
-                        height="350px"
-                    />
-                ) }
-            </Wrapper>
-        );
-    }
-}
+    useEffect(() => {
+        draw();
+        updaterRef.current = updater;
+    }, [ selected, updater ]);
+
+    return (
+        <Wrapper>
+            <div id={ props.id } />
+            { colors.length > 0 && (
+                <Legend
+                    id="d3-grouped-bar-legend"
+                    data={ colors }
+                    selected={ selected }
+                    onToggle={ handleToggle }
+                    height="350px"
+                />
+            ) }
+        </Wrapper>
+    );
+};
 
 GroupedBarChart.propTypes = {
     id: PropTypes.string,

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Tooltip from '../Utilities/Tooltip';
 import * as d3 from 'd3';
 
-const LineChart = (props) => {
+export const LineChart = (props) => {
     let time = null;
 
     // Methods

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -127,7 +127,7 @@ class Tooltip {
   };
 }
 
-const PieChart = (props) => {
+export const PieChart = (props) => {
     const [ colors, setColors ] = useState([]);
     let time = null;
 

--- a/src/Charts/tests/Chart.test.js
+++ b/src/Charts/tests/Chart.test.js
@@ -1,0 +1,185 @@
+/*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
+import { act } from 'react-dom/test-utils';
+import { BarChart } from '../BarChart';
+import { GroupedBarChart } from '../GroupedBarChart';
+import { LineChart } from '../LineChart';
+import { PieChart } from '../PieChart';
+
+const getWidth = () => 700;
+const getHeight = () => 450;
+const margins = { top: 20, right: 20, bottom: 50, left: 70 };
+
+const groupedBarChartData = [{
+    date: '2020-04-20',
+    orgs: [{ id: 1, org_name: 'Default', value: 108, successful_count: 59, failed_count: 49, success_rate: 55 }]
+}];
+
+let eventMap;
+let realAddEventListener;
+let realRemoveEventListener;
+
+beforeEach(() => {
+    realAddEventListener = window.addEventListener;
+    realRemoveEventListener = window.removeEventListener;
+    eventMap = {};
+
+    window.addEventListener = jest.fn((eventName, callback) => {
+        eventMap[eventName] = callback;
+    });
+
+    window.removeEventListener = jest.fn(eventName => {
+        delete eventMap[eventName];
+    });
+});
+
+afterEach(() => {
+    window.addEventListener = realAddEventListener;
+    window.removeEventListener = realRemoveEventListener;
+});
+
+// FIXME: With jsdom cannot test the SVG output itself.
+// therefore these tests are only testing if the mount and umnount correctly.
+
+it('should render BarChart correctly', () => {
+    const wrapper = render(
+        <BarChart
+            margin={ margins }
+            id="d3-bar-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+});
+
+it('should add/remove listener to BarChart', () => {
+    const wrapper = mount(
+        <BarChart
+            margin={ margins }
+            id="d3-bar-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    act(() => {
+        wrapper.update();
+    });
+    expect(eventMap.hasOwnProperty('resize')).toBeTruthy();
+
+    wrapper.unmount();
+    expect(eventMap.hasOwnProperty('resize')).toBeFalsy();
+});
+
+it('should render GroupedBarChart correctly', () => {
+    const wrapper = render(
+        <GroupedBarChart
+            margin={ margins }
+            id="d3-grouped-bar-chart-root"
+            data={ groupedBarChartData }
+            timeFrame={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+});
+
+it('should add/remove listener to GroupedBarChart', () => {
+    const wrapper = mount(
+        <GroupedBarChart
+            margin={ margins }
+            id="d3-grouped-bar-chart-root"
+            data={ groupedBarChartData }
+            timeFrame={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    act(() => {
+        wrapper.update();
+    });
+    expect(eventMap.hasOwnProperty('resize')).toBeTruthy();
+
+    wrapper.unmount();
+    expect(eventMap.hasOwnProperty('resize')).toBeFalsy();
+});
+
+it('should render LineChart correctly', () => {
+    const wrapper = render(
+        <LineChart
+            margin={ margins }
+            id="d3-line-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+});
+
+it('should add/remove listener to LineChart', () => {
+    const wrapper = mount(
+        <LineChart
+            margin={ margins }
+            id="d3-line-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    act(() => {
+        wrapper.update();
+    });
+    expect(eventMap.hasOwnProperty('resize')).toBeTruthy();
+
+    wrapper.unmount();
+    expect(eventMap.hasOwnProperty('resize')).toBeFalsy();
+});
+
+it('should render PieChart correctly', () => {
+    const wrapper = render(
+        <PieChart
+            margin={ margins }
+            id="d3-pie-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+});
+
+it('should add/remove listener to PieChart', () => {
+    const wrapper = mount(
+        <PieChart
+            margin={ margins }
+            id="d3-pie-chart-root"
+            data={ [] }
+            value={ 31 }
+            getWidth={ getWidth }
+            getHeight={ getHeight }
+        />
+    );
+
+    act(() => {
+        wrapper.update();
+    });
+    expect(eventMap.hasOwnProperty('resize')).toBeTruthy();
+
+    wrapper.unmount();
+    expect(eventMap.hasOwnProperty('resize')).toBeFalsy();
+});

--- a/src/Charts/tests/__snapshots__/Chart.test.js.snap
+++ b/src/Charts/tests/__snapshots__/Chart.test.js.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render BarChart correctly 1`] = `
+initialize {
+  "0": Object {
+    "attribs": Object {
+      "id": "d3-bar-chart-root",
+    },
+    "children": Array [],
+    "name": "div",
+    "namespace": "http://www.w3.org/1999/xhtml",
+    "next": null,
+    "parent": null,
+    "prev": null,
+    "root": Object {
+      "attribs": Object {},
+      "children": Array [
+        [Circular],
+      ],
+      "name": "root",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "next": null,
+      "parent": null,
+      "prev": null,
+      "type": "root",
+      "x-attribsNamespace": Object {},
+      "x-attribsPrefix": Object {},
+    },
+    "type": "tag",
+    "x-attribsNamespace": Object {
+      "id": undefined,
+    },
+    "x-attribsPrefix": Object {
+      "id": undefined,
+    },
+  },
+  "_root": [Circular],
+  "length": 1,
+  "options": Object {
+    "decodeEntities": true,
+    "normalizeWhitespace": false,
+    "withDomLvl1": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`should render GroupedBarChart correctly 1`] = `
+initialize {
+  "0": Object {
+    "attribs": Object {
+      "class": "sc-gzVnrw gnbfCq",
+    },
+    "children": Array [
+      Object {
+        "attribs": Object {
+          "id": "d3-grouped-bar-chart-root",
+        },
+        "children": Array [],
+        "name": "div",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": null,
+        "parent": [Circular],
+        "prev": null,
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "id": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "id": undefined,
+        },
+      },
+    ],
+    "name": "div",
+    "namespace": "http://www.w3.org/1999/xhtml",
+    "next": null,
+    "parent": null,
+    "prev": null,
+    "root": Object {
+      "attribs": Object {},
+      "children": Array [
+        [Circular],
+      ],
+      "name": "root",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "next": null,
+      "parent": null,
+      "prev": null,
+      "type": "root",
+      "x-attribsNamespace": Object {},
+      "x-attribsPrefix": Object {},
+    },
+    "type": "tag",
+    "x-attribsNamespace": Object {
+      "class": undefined,
+    },
+    "x-attribsPrefix": Object {
+      "class": undefined,
+    },
+  },
+  "_root": [Circular],
+  "length": 1,
+  "options": Object {
+    "decodeEntities": true,
+    "normalizeWhitespace": false,
+    "withDomLvl1": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`should render LineChart correctly 1`] = `
+initialize {
+  "0": Object {
+    "attribs": Object {
+      "id": "d3-line-chart-root",
+    },
+    "children": Array [],
+    "name": "div",
+    "namespace": "http://www.w3.org/1999/xhtml",
+    "next": null,
+    "parent": null,
+    "prev": null,
+    "root": Object {
+      "attribs": Object {},
+      "children": Array [
+        [Circular],
+      ],
+      "name": "root",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "next": null,
+      "parent": null,
+      "prev": null,
+      "type": "root",
+      "x-attribsNamespace": Object {},
+      "x-attribsPrefix": Object {},
+    },
+    "type": "tag",
+    "x-attribsNamespace": Object {
+      "id": undefined,
+    },
+    "x-attribsPrefix": Object {
+      "id": undefined,
+    },
+  },
+  "_root": [Circular],
+  "length": 1,
+  "options": Object {
+    "decodeEntities": true,
+    "normalizeWhitespace": false,
+    "withDomLvl1": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`should render PieChart correctly 1`] = `
+initialize {
+  "0": Object {
+    "attribs": Object {
+      "class": "sc-htoDjs kqvubf",
+    },
+    "children": Array [
+      Object {
+        "attribs": Object {
+          "id": "d3-pie-chart-root",
+        },
+        "children": Array [],
+        "name": "div",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": null,
+        "parent": [Circular],
+        "prev": null,
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "id": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "id": undefined,
+        },
+      },
+    ],
+    "name": "div",
+    "namespace": "http://www.w3.org/1999/xhtml",
+    "next": null,
+    "parent": null,
+    "prev": null,
+    "root": Object {
+      "attribs": Object {},
+      "children": Array [
+        [Circular],
+      ],
+      "name": "root",
+      "namespace": "http://www.w3.org/1999/xhtml",
+      "next": null,
+      "parent": null,
+      "prev": null,
+      "type": "root",
+      "x-attribsNamespace": Object {},
+      "x-attribsPrefix": Object {},
+    },
+    "type": "tag",
+    "x-attribsNamespace": Object {
+      "class": undefined,
+    },
+    "x-attribsPrefix": Object {
+      "class": undefined,
+    },
+  },
+  "_root": [Circular],
+  "length": 1,
+  "options": Object {
+    "decodeEntities": true,
+    "normalizeWhitespace": false,
+    "withDomLvl1": true,
+    "xml": false,
+  },
+}
+`;


### PR DESCRIPTION
Closes: #94 closes #102 closes #103 and closes #104

Converts the `BarChart`, `GruppedBarChart`, `LineChart`, `PieChart` to a functional component.
Coverts `BaseChart` to a functional component and fixes a console error where the `propTypes` were declared inside the component instead of after.

No UI changes as far as I tested it well.