### PR TITLE
Orgs in charts share color

### DIFF
--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import Legend from '../Utilities/Legend';
-import { pfmulti } from '../Utilities/colors';
+import { getColorForNames } from '../Utilities/colors';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -12,8 +12,6 @@ const Wrapper = styled.div`
   flex-wrap: nowrap;
   flex-shrink: 0;
 `;
-
-const color = d3.scaleOrdinal(pfmulti);
 
 class Tooltip {
     constructor(props) {
@@ -162,6 +160,7 @@ export const GroupedBarChart = (props) => {
     const updaterRef = useRef(updater);
     let time = null;
     const orgsList = props.data[0].orgs;
+    const colorToNames = getColorForNames(orgsList.map(el => ({ name: el.org_name })));
 
     const draw = () => {
         // Clear our chart container element first
@@ -295,7 +294,7 @@ export const GroupedBarChart = (props) => {
             return x1(d.org_name);
         }) // unsorted
         .style('fill', function(d) {
-            return color(d.org_name);
+            return colorToNames[d.org_name];
         })
         .attr('y', function(d) {
             return y(d.value);
@@ -304,12 +303,12 @@ export const GroupedBarChart = (props) => {
             return height - y(d.value);
         })
         .on('mouseover', function(d) {
-            d3.select(this).style('fill', d3.rgb(color(d.org_name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(colorToNames[d.org_name]).darker(1));
             tooltip.handleMouseOver();
         })
         .on('mousemove', tooltip.handleMouseOver)
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.org_name));
+            d3.select(this).style('fill', colorToNames[d.org_name]);
             tooltip.handleMouseOut();
         });
         bars = bars.merge(subEnter);
@@ -338,17 +337,8 @@ export const GroupedBarChart = (props) => {
             initSelected(8);
         }
 
-        // create our colors array to send to the Legend component
-        const colors = orgsList.reduce((colors, org) => {
-            colors.push({
-                name: org.org_name,
-                value: color(org.org_name),
-                id: org.id
-            });
-            return colors;
-        }, []);
-
-        setColors(colors);
+        const legend = orgsList.map(el => ({ name: el.org_name, value: colorToNames[el.org_name], id: el.id }));
+        setColors(legend);
         draw();
     };
 

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 import initializeChart from './BaseChart';
 import { getTotal } from '../Utilities/helpers';
 import Legend from '../Utilities/Legend';
-import { pfmulti } from '../Utilities/colors';
+import { getColorForNames } from '../Utilities/colors';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -143,10 +143,9 @@ class Tooltip {
 export const PieChart = (props) => {
     const [ colors, setColors ] = useState([]);
     let time = null;
+    const colorToNames = getColorForNames(props.data);
 
     const draw = () => {
-        const color = d3.scaleOrdinal(pfmulti);
-
         d3.selectAll('#' + props.id + ' > *').remove();
         const width = props.getWidth();
         const height = props.getHeight();
@@ -188,23 +187,23 @@ export const PieChart = (props) => {
         (height + props.margin.top + props.margin.bottom) / 2 +
         ')'
         );
-
+        /* eslint-disable */
         svg
         .selectAll('path')
         .data(pie(data))
         .enter()
         .append('path')
         .attr('d', arc)
-        .attr('fill', (d, i) => color(i));
+        .attr('fill', (d) => colorToNames[d.data.name]);
 
         svg
         .selectAll('path')
-        .on('mouseover', function(d, i) {
-            d3.select(this).style('fill', d3.rgb(color(i)).darker(1));
+        .on('mouseover', function(d) {
+            d3.select(this).style('fill', d3.rgb(colorToNames[d.data.name]).darker(1));
             donutTooltip.handleMouseOver();
         })
-        .on('mouseout', function(d, i) {
-            d3.select(this).style('fill', color(i));
+        .on('mouseout', function(d) {
+            d3.select(this).style('fill', colorToNames[d.data.name]);
             donutTooltip.handleMouseOut();
         })
         .on('mousemove', donutTooltip.handleMouseOver);
@@ -215,29 +214,8 @@ export const PieChart = (props) => {
 
     const init = () => {
         const { data } = props;
-        const color = d3.scaleOrdinal(pfmulti);
-
-        // create our colors array to send to the Legend component
-        const calculatedColors = data.reduce((colors, org) => {
-            // format complement slice as "Others"
-            if (org.id === -1) {
-                colors.push({
-                    name: 'Others',
-                    value: color(org.name),
-                    count: Math.round(org.count)
-                });
-            } else {
-                colors.push({
-                    name: org.name,
-                    value: color(org.name),
-                    count: Math.round(org.count)
-                });
-            }
-
-            return colors;
-        }, []);
-
-        setColors(calculatedColors);
+        const legend = data.map(el => ({ name: el.name, value: colorToNames[el.name], count: Math.round(el.count) }));
+        setColors(legend.sort((a, b) => (a.count > b.count) ? -1 : ((b.count > a.count) ? 1 : 0)));
         draw();
     };
 

--- a/src/Utilities/colors.js
+++ b/src/Utilities/colors.js
@@ -1,3 +1,5 @@
+import { scaleOrdinal } from 'd3';
+
 const pfmulti = [
     '#06C',
     '#4CB140',
@@ -13,5 +15,22 @@ const pfmulti = [
     '#8F4700',
     '#002F5D'
 ];
+
+/**
+ * Creates a color map to names: for same data generates same colors.
+ * @param  {[{ name }]} data    Array of objects with name options to map to.
+ * @return {{ [name]: color }}  Object where the keys are the names an the values are the colors.
+ */
+export const getColorForNames = (data) => {
+    const colorFnc = scaleOrdinal(pfmulti);
+    const compObj = prop => (a, b) => (a[prop] > b[prop]) ? 1 : ((b[prop] > a[prop]) ? -1 : 0);
+
+    const colors = data.sort(compObj('name')).reduce((colors, org) => {
+        colors[org.name] = colorFnc(org.name);
+        return colors;
+    }, {});
+
+    return colors;
+};
 
 export { pfmulti };

--- a/src/Utilities/colors.test.js
+++ b/src/Utilities/colors.test.js
@@ -1,4 +1,3 @@
-
 import { pfmulti } from './colors.js';
 
 describe('Utilities/colors', () => {


### PR DESCRIPTION
Closes: #81 

Generating the colours to use in the start for each "name" which are ordered first to keep the same arrays same colours. It may not work if there are different arrays with the same names, but it should solve the problems in the Organisation Statistics page.

**Before**
![Screenshot from 2020-05-19 17-25-47](https://user-images.githubusercontent.com/8531681/82345741-e79bb500-99f5-11ea-8304-9b7a62ac2bac.png)

**After**
![Screenshot from 2020-05-19 17-24-40](https://user-images.githubusercontent.com/8531681/82345764-f08c8680-99f5-11ea-932f-3bff3bf48049.png)
