### PR TITLE
more sentence casing

### DIFF
--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -306,7 +306,7 @@ class GroupedBarChart extends Component {
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
-        .text('Jobs Across Orgs');
+        .text('Jobs across orgs');
 
         // add x axis
         svg

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -151,7 +151,7 @@ class LineChart extends Component {
         .attr('x', 0 - height / 2)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
-        .text('Job Runs');
+        .text('Job runs');
         // Add the X Axis
         let ticks;
         const maxTicks = Math.round(data.length / (value / 2));

--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -62,14 +62,14 @@ class Tooltip {
         .attr('font-size', 12)
         .attr('x', 20)
         .attr('y', 16)
-        .text('Manual Cost $0');
+        .text('Manual cost $0');
         this.automationCost = this.toolTipBase
         .append('text')
         .attr('fill', 'white')
         .attr('font-size', 12)
         .attr('x', 20)
         .attr('y', 34)
-        .text('Automation Cost $0');
+        .text('Automation cost $0');
     }
 
     handleMouseOver = d => {

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -202,27 +202,27 @@ const TemplatesList = ({ templates, isLoading, queryParams }) => {
                   >
                       <DataListFocus>
                           <div aria-labelledby="job runs">
-                              <b style={ { marginRight: '10px' } }>Number of Runs</b>
+                              <b style={ { marginRight: '10px' } }>Number of runs</b>
                               { selectedTemplate.total_run_count ?
                                   selectedTemplate.total_run_count : 'Unavailable' }
                           </div>
                           <div aria-labelledby="total time">
-                              <b style={ { marginRight: '10px' } }>Total Time</b>
+                              <b style={ { marginRight: '10px' } }>Total time</b>
                               { selectedTemplate.total_run ?
                                   selectedTemplate.total_run : 'Unavailable' }
                           </div>
                           <div aria-labelledby="Avg Time">
-                              <b style={ { marginRight: '10px' } }>Avg Time</b>
+                              <b style={ { marginRight: '10px' } }>Avg time</b>
                               { selectedTemplate.average_run ?
                                   selectedTemplate.average_run : 'Unavailable' }
                           </div>
                           <div aria-labelledby="success rate">
-                              <b style={ { marginRight: '10px' } }>Success Rate</b>
+                              <b style={ { marginRight: '10px' } }>Success rate</b>
                               { selectedTemplate.success_rate ?
                                   formatPercentage(selectedTemplate.success_rate) : 'Unavailable' }
                           </div>
                           <div aria-labelledby="most failed task">
-                              <b style={ { marginRight: '10px' } }>Most Failed Task</b>
+                              <b style={ { marginRight: '10px' } }>Most failed task</b>
                               { selectedTemplate.most_failed_tasks ?
                                   formatTopFailedTask(selectedTemplate.most_failed_tasks) : 'Unavailable' }
                           </div>

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -398,14 +398,14 @@ const AutomationCalculator = () => {
                           <CardTitle>Automation formula</CardTitle>
                           <CardBody>
                               <p>
-                                  <b>Manual cost for template X</b> =
+                                  <b>Manual cost for template x</b> =
                                   <em>
                         (time for a manual run on one host * (sum of all hosts
                         across all job runs) ) * cost per hour
                                   </em>
                               </p>
                               <p>
-                                  <b>Automation cost for template X</b> =
+                                  <b>Automation cost for template x</b> =
                                   <em>
                         cost of automation per hour * sum of total elapsed hours
                         for a template
@@ -556,7 +556,7 @@ const AutomationCalculator = () => {
                                                               { data.failed_elapsed_sum.toFixed(2) }s
                                                           </p>
                                                           <p>
-                                                              <b>Automation Percentage</b>:{ ' ' }
+                                                              <b>Automation percentage</b>:{ ' ' }
                                                               { formatPercentage(
                                                                   data.template_automation_percentage.toFixed(
                                                                       2

--- a/src/Utilities/Tooltip.js
+++ b/src/Utilities/Tooltip.js
@@ -76,7 +76,7 @@ class Tooltip {
         .attr('y', -21)
         .attr('font-size', 12)
         .attr('text-anchor', 'end')
-        .text('No Jobs');
+        .text('No jobs');
         this.successful = this.toolTipBase
         .append('text')
         .attr('fill', 'white')
@@ -145,7 +145,7 @@ class Tooltip {
             this.date.text(formatTooltipDate(d.data.DATE || null));
         }
 
-        this.jobs.text('' + total + ' Jobs');
+        this.jobs.text('' + total + ' jobs');
         this.jobsWidth = this.jobs.node().getComputedTextLength();
         this.failed.text('' + fail);
         this.successful.text('' + success);


### PR DESCRIPTION
Addresses https://github.com/RedHatInsights/tower-analytics-frontend/issues/65

I hacked together a quick pyscript to look for more instances of strings that are not in sentence case:
https://gist.github.com/jctanner/96f8035d69f3ecad4d2d43e65ea51206

It's not perfect and I'm not sure if -every- string was supposed to be sentence cased, but hopefully this PR can be reviewed and I can fix what isn't correct.