### PR TITLE
Fixes padding issue on templates list and modules list

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -7,8 +7,6 @@
 // js generates class '.page__{rootClass}' that wraps the content in your page added to the root tag
 // Found in Routes.js as the rootClass
 .pf-c-data-list__cell {
-  --pf-c-data-list__cell--PaddingTop: 10px;
-  --pf-c-data-list__cell-cell--PaddingTop: 10px;
   --pf-c-data-list__cell--PaddingBottom: 10px;
 }
 

--- a/src/Components/ModulesList.js
+++ b/src/Components/ModulesList.js
@@ -20,7 +20,7 @@ const DataListItem = styled(PFDataListItem)`
   display: flex;
   flex-direction: row;
   justify-content: space-around;
-  padding: 10px 15px;
+  padding: 0 15px 10px 15px;
 `;
 
 const DataCellEnd = styled(DataListCell)`

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -44,8 +44,9 @@ const DataListItem = styled(PFDataListItem)`
   display: flex;
   flex-direction: row;
   justify-content: space-around;
-  padding: 10px 15px;
+  padding: 0 15px 10px 15px;
   justify-content: center;
+  align-items: center;
 `;
 const DataListItemCompact = styled(DataListItem)`
   padding: 0;


### PR DESCRIPTION
This fixes #166 Fixes a vertical alignment issue on the templates and modules list.
![Screen Shot 2020-06-19 at 11 42 53 AM](https://user-images.githubusercontent.com/39280967/85151677-10e07880-b222-11ea-9e6d-f269bca0d451.png)

