### PR TITLE
Fix padding on template details modal

### DIFF
--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -61,7 +61,7 @@ const DataListFocus = styled.div`
     display: grid;
     grid-template-columns: repeat(3, auto);
     grid-gap: 10px;
-    padding: var(--pf-c-data-list__cell-cell--PaddingTop);
+    padding: var(--pf-global--spacer--lg);
     background: #ebebeb;
     border: 1px solid #ccc;
     border-top: none;


### PR DESCRIPTION
This PR fixes issue #167. @AlexSCorey's fix for #166 has been merged into this PR which fixes the template details modal datalist header alignments also mentioned in #167.