### PR TITLE
Fix(css): switch extra height css removed to display correctly

### DIFF
--- a/src/Utilities/Legend.js
+++ b/src/Utilities/Legend.js
@@ -49,7 +49,6 @@ const SubTitle = styled.span`
 `;
 
 const Switch = styled(PFSwitch)`
-  --pf-c-switch--Height: 15px;
   margin-left: 20px;
 
   svg {


### PR DESCRIPTION
Closes #180 

Fixed the switch display problem. I could not test on other OS just on Fedora and since it was a specific bug to fedora (on OSX was nice looking) it needs testing.

**Before** on Fedora:
![Screenshot from 2020-07-08 15-17-23](https://user-images.githubusercontent.com/8531681/86930678-8b245e80-c137-11ea-987c-bc8044016843.png)

**After** on Fedora
![Screenshot from 2020-07-08 16-41-13](https://user-images.githubusercontent.com/8531681/86932620-e48d8d00-c139-11ea-8036-ed7aeeeafc7a.png)

**Before** on OSX:
![image](https://user-images.githubusercontent.com/8531681/86930823-ba3ad000-c137-11ea-9454-429c91bb407f.png)
