### PR TITLE
Fix: base chart prop type error fixed

### DIFF
--- a/src/Charts/BaseChart.js
+++ b/src/Charts/BaseChart.js
@@ -1,51 +1,43 @@
-/* eslint react/prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
-function initializeChart(Chart) {
-    return class BaseChart extends React.Component {
-        constructor(props) {
-            super(props);
-            this.getWidth = this.getWidth.bind(this);
-            this.getHeight = this.getHeight.bind(this);
-        }
+const initializeChart = Chart => {
+    const BaseChart = (props) => {
+        const { id, margin } = props;
 
-        propTypes = {
-            id: PropTypes.string,
-            margin: PropTypes.object
-        }
-
-        // Methods
-        getWidth() {
+        const getWidth = () => {
             let width;
             width =
-            parseInt(d3.select('#' + this.props.id).style('width')) -
-            this.props.margin.left -
-            this.props.margin.right || 700;
+            parseInt(d3.select('#' + id).style('width')) -
+                margin.left - margin.right || 700;
             return width;
-        }
+        };
 
-        getHeight() {
+        const getHeight = () => {
             let height;
             height =
-            parseInt(d3.select('#' + this.props.id).style('height')) -
-            this.props.margin.top -
-            this.props.margin.bottom || 450;
+            parseInt(d3.select('#' + id).style('height')) -
+                margin.top - margin.bottom || 450;
             return height;
-        }
+        };
 
-        render() {
-            return (
-                <Chart
-                    { ...this.props }
-                    getWidth={ this.getWidth }
-                    getHeight={ this.getHeight }
-                />
-            );
-        }
+        return (
+            <Chart
+                { ...props }
+                getWidth={ getWidth }
+                getHeight={ getHeight }
+            />
+        );
     };
-}
+
+    BaseChart.propTypes = {
+        id: PropTypes.string,
+        margin: PropTypes.object
+    };
+
+    return BaseChart;
+};
 
 initializeChart.propTypes = {
     Chart: PropTypes.element


### PR DESCRIPTION
It was annoying me, this fix will make a console error go away. Technically just move the prop type outside the class and to do this I changed to a functional component.

**Before**
![Screenshot from 2020-07-10 17-16-31](https://user-images.githubusercontent.com/8531681/87170194-4d5b3d80-c2d1-11ea-916c-1c14dbbea008.png)

**After**
![Screenshot from 2020-07-10 17-16-48](https://user-images.githubusercontent.com/8531681/87170205-51875b00-c2d1-11ea-90c7-6cf78494bd6e.png)


Note that difference in the `console.errors` (3rd from the bottom)