### PR TITLE
Feature: Hosts tab for org stats with groupped bar chart

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -3,6 +3,7 @@
 const barChartEndpoint = '/api/tower-analytics/chart30/';
 const clustersEndpoint = '/api/tower-analytics/clusters/';
 const groupedBarChartEndpoint = '/api/tower-analytics/jobs_by_date_and_org_30/';
+const hostsEndpoint = '/api/tower-analytics/hosts_by_date_and_org/';
 const modulesEndpoint = '/api/tower-analytics/modules/';
 const notificationsEndPoint = '/api/tower-analytics/notifications/';
 const pieChart1Endpoint = '/api/tower-analytics/job_runs_by_org_30/';
@@ -69,6 +70,15 @@ export const readChart30 = ({ params = {}}) => {
 export const readJobsByDateAndOrg = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(groupedBarChartEndpoint, formattedUrl);
+    Object.keys(params).forEach(key =>
+        url.searchParams.append(key, params[key])
+    );
+    return fetch(url).then(handleResponse);
+};
+
+export const readHostsByDateAndOrg = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(hostsEndpoint, formattedUrl);
     Object.keys(params).forEach(key =>
         url.searchParams.append(key, params[key])
     );

--- a/src/App.scss
+++ b/src/App.scss
@@ -59,7 +59,7 @@ h2 {
   color: #393f44;
 }
 
-#d3-grouped-bar-chart-root, #d3-line-chart-root, #d3-bar-chart-root, #d3-pie-1-chart-root, #d3-roi-chart-root {
+#d3-hosts-chart-root, #d3-grouped-bar-chart-root, #d3-line-chart-root, #d3-bar-chart-root, #d3-pie-1-chart-root, #d3-roi-chart-root {
   min-height: 450px;
   min-width: 75%;
 }
@@ -79,4 +79,3 @@ h2 {
 section#refTab1Section, section#refTab2Section {
   outline: none;
 }
-

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import Legend from '../Utilities/Legend';
-import { pfmulti } from '../Utilities/colors';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -12,8 +11,6 @@ const Wrapper = styled.div`
   flex-wrap: nowrap;
   flex-shrink: 0;
 `;
-
-const color = d3.scaleOrdinal(pfmulti);
 
 class Tooltip {
     constructor(props) {
@@ -193,6 +190,7 @@ class GroupedBarChart extends Component {
     }
 
     init() {
+        const { colorToNames } = this.props;
         // create the first 8 selected data points
         if (this.selection.length === 0) {
             this.orgsList.forEach((org, index) => {
@@ -202,20 +200,13 @@ class GroupedBarChart extends Component {
             });
         }
 
-        // create our colors array to send to the Legend component
-        const colors = this.orgsList.reduce((colors, org) => {
-            colors.push({
-                name: org.org_name,
-                value: color(org.org_name),
-                id: org.id
-            });
-            return colors;
-        }, []);
-        this.setState({ colors });
+        const legend = this.orgsList.map(el => ({ name: el.org_name, value: colorToNames[el.org_name], id: el.id }));
+        this.setState({ colors: legend });
         this.draw();
     }
 
     draw() {
+        const { colorToNames } = this.props;
         // Clear our chart container element first
         d3.selectAll('#' + this.props.id + ' > *').remove();
         let { data: unformattedData, timeFrame } = this.props;
@@ -348,7 +339,7 @@ class GroupedBarChart extends Component {
             return x1(d.org_name);
         }) // unsorted
         .style('fill', function(d) {
-            return color(d.org_name);
+            return colorToNames[d.org_name];
         })
         .attr('y', function(d) {
             return y(d.value);
@@ -357,12 +348,12 @@ class GroupedBarChart extends Component {
             return height - y(d.value);
         })
         .on('mouseover', function(d) {
-            d3.select(this).style('fill', d3.rgb(color(d.org_name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(colorToNames[d.org_name]).darker(1));
             tooltip.handleMouseOver();
         })
         .on('mousemove', tooltip.handleMouseOver)
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.org_name));
+            d3.select(this).style('fill', colorToNames[d.org_name]);
             tooltip.handleMouseOut();
         });
         bars = bars.merge(subEnter);
@@ -407,7 +398,8 @@ GroupedBarChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
-    timeFrame: PropTypes.number
+    timeFrame: PropTypes.number,
+    colorToNames: PropTypes.object
 };
 
 export default initializeChart(GroupedBarChart);

--- a/src/Charts/HostsBarChart.js
+++ b/src/Charts/HostsBarChart.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import initializeChart from './BaseChart';
 import * as d3 from 'd3';
 import Legend from '../Utilities/Legend';
-import { pfmulti } from '../Utilities/colors';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -12,8 +11,6 @@ const Wrapper = styled.div`
   flex-wrap: nowrap;
   flex-shrink: 0;
 `;
-
-const color = d3.scaleOrdinal(pfmulti);
 
 class Tooltip {
     constructor(props) {
@@ -193,6 +190,7 @@ class HostsBarChart extends Component {
     }
 
     init() {
+        const { colorToNames } = this.props;
         // create the first 8 selected data points
         if (this.selection.length === 0) {
             this.orgsList.forEach((org, index) => {
@@ -202,20 +200,13 @@ class HostsBarChart extends Component {
             });
         }
 
-        // create our colors array to send to the Legend component
-        const colors = this.orgsList.reduce((colors, org) => {
-            colors.push({
-                name: org.name,
-                value: color(org.name),
-                id: org.id
-            });
-            return colors;
-        }, []);
-        this.setState({ colors });
+        const legend = this.orgsList.map(el => ({ name: el.name, value: colorToNames[el.name], id: el.id }));
+        this.setState({ colors: legend });
         this.draw();
     }
 
     draw() {
+        const { colorToNames } = this.props;
         // Clear our chart container element first
         d3.selectAll('#' + this.props.id + ' > *').remove();
         let { data: unformattedData, timeFrame } = this.props;
@@ -348,7 +339,7 @@ class HostsBarChart extends Component {
             return x1(d.name);
         }) // unsorted
         .style('fill', function(d) {
-            return color(d.name);
+            return colorToNames[d.name];
         })
         .attr('y', function(d) {
             return y(d.count);
@@ -357,12 +348,12 @@ class HostsBarChart extends Component {
             return height - y(d.count);
         })
         .on('mouseover', function(d) {
-            d3.select(this).style('fill', d3.rgb(color(d.name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(colorToNames[d.name]).darker(1));
             tooltip.handleMouseOver();
         })
         .on('mousemove', tooltip.handleMouseOver)
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.name));
+            d3.select(this).style('fill', colorToNames[d.name]);
             tooltip.handleMouseOut();
         });
         bars = bars.merge(subEnter);
@@ -407,7 +398,8 @@ HostsBarChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
-    timeFrame: PropTypes.number
+    timeFrame: PropTypes.number,
+    colorToNames: PropTypes.object
 };
 
 export default initializeChart(HostsBarChart);

--- a/src/Charts/HostsBarChart.js
+++ b/src/Charts/HostsBarChart.js
@@ -1,0 +1,413 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import initializeChart from './BaseChart';
+import * as d3 from 'd3';
+import Legend from '../Utilities/Legend';
+import { pfmulti } from '../Utilities/colors';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+`;
+
+const color = d3.scaleOrdinal(pfmulti);
+
+class Tooltip {
+    constructor(props) {
+        this.svg = props.svg;
+        this.draw();
+    }
+
+    draw() {
+        this.width = 125;
+        this.toolTipBase = d3.select(this.svg + '> svg').append('g');
+        this.toolTipBase.attr('id', 'svg-chart-Tooltip.base-' + this.svg.slice(1));
+        this.toolTipBase.attr('overflow', 'visible');
+        this.toolTipBase.style('opacity', 0);
+        this.toolTipBase.style('pointer-events', 'none');
+        this.toolTipBase.attr('transform', 'translate(100, 100)');
+        this.boxWidth = 125;
+        this.textWidthThreshold = 20;
+
+        this.toolTipPoint = this.toolTipBase
+        .append('rect')
+        .attr('transform', 'translate(10, -10) rotate(45)')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('height', 20)
+        .attr('width', 20)
+        .attr('fill', '#393f44');
+        this.boundingBox = this.toolTipBase
+        .append('rect')
+        .attr('x', 10)
+        .attr('y', -23)
+        .attr('rx', 2)
+        .attr('height', 52)
+        .attr('width', this.boxWidth)
+        .attr('fill', '#393f44');
+        this.date = this.toolTipBase
+        .append('text')
+        .attr('x', 20)
+        .attr('y', 14)
+        .attr('font-size', 12)
+        .attr('fill', 'white')
+        .text('Date');
+        this.jobs = this.toolTipBase
+        .append('text')
+        .attr('fill', 'white')
+        .attr('font-size', 12)
+        .attr('x', 72)
+        .attr('y', 14)
+        .text('0 Hosts');
+        this.orgName = this.toolTipBase
+        .append('text')
+        .attr('fill', 'white')
+        .attr('font-weight', 800)
+        .attr('x', 20)
+        .attr('y', -1)
+        .attr('font-size', 12)
+        .text('Org');
+    }
+
+  handleMouseOver = d => {
+      let date;
+      let orgName;
+      let jobs;
+      const x =
+      d3.event.pageX -
+      d3
+      .select(this.svg)
+      .node()
+      .getBoundingClientRect().x +
+      10;
+      const y =
+      d3.event.pageY -
+      d3
+      .select(this.svg)
+      .node()
+      .getBoundingClientRect().y -
+      10;
+      if (!d) {
+          return;
+      } else {
+          const maxLength = 16;
+          date = d.date;
+          orgName = d.name;
+          jobs = d.count;
+          if (d.name.length > maxLength) {
+              orgName = d.name.slice(0, maxLength).concat('...');
+          }
+      }
+
+      const formatTooltipDate = d3.timeFormat('%m/%d');
+      const toolTipWidth = this.toolTipBase.node().getBoundingClientRect().width;
+      const chartWidth = d3
+      .select(this.svg + '> svg')
+      .node()
+      .getBoundingClientRect().width;
+      const overflow = 100 - (toolTipWidth / chartWidth) * 100;
+      const flipped = overflow < (x / chartWidth) * 100;
+
+      this.date.text('' + formatTooltipDate(date));
+      this.orgName.text('' + orgName);
+      this.jobs.text('' + jobs + ' Hosts');
+      this.jobsWidth = this.jobs.node().getComputedTextLength();
+
+      const maxTextPerc = this.jobsWidth / this.boxWidth * 100;
+      const threshold = 45;
+      const overage = maxTextPerc / threshold;
+      let adjustedWidth;
+      if (maxTextPerc > threshold) {
+          adjustedWidth = this.boxWidth * overage;
+      } else {
+          adjustedWidth = this.boxWidth;
+      }
+
+      this.boundingBox.attr('width', adjustedWidth);
+      this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
+      if (flipped) {
+          this.toolTipPoint.attr('transform', 'translate(-20, -10) rotate(45)');
+          this.boundingBox.attr('x', -adjustedWidth - 20);
+          this.jobs.attr('x', -this.jobsWidth - 20 - 7);
+          this.orgName.attr('x', -adjustedWidth - 7);
+          this.date.attr('x', -adjustedWidth - 7);
+      } else {
+          this.toolTipPoint.attr('transform', 'translate(10, -10) rotate(45)');
+          this.boundingBox.attr('x', 10);
+          this.orgName.attr('x', 20);
+          this.jobs.attr('x', adjustedWidth / 2);
+          this.date.attr('x', 20);
+      }
+
+      this.toolTipBase.style('opacity', 1);
+      this.toolTipBase.interrupt();
+  };
+
+  handleMouseOut = () => {
+      this.toolTipBase
+      .transition()
+      .delay(15)
+      .style('opacity', 0)
+      .style('pointer-events', 'none');
+  };
+}
+
+class HostsBarChart extends Component {
+    constructor(props) {
+        super(props);
+        this.init = this.init.bind(this);
+        this.handleToggle = this.handleToggle.bind(this);
+        this.draw = this.draw.bind(this);
+        this.resize = this.resize.bind(this);
+        this.orgsList = props.data[0].orgs;
+        this.selection = [];
+        this.state = {
+            colors: [],
+            selected: [],
+            formattedData: [],
+            timeout: null
+        };
+    }
+
+    // Methods
+    resize() {
+        const { timeout } = this.state;
+        clearTimeout(timeout);
+        this.setState({
+            timeout: setTimeout(() => { this.init(); }, 500)
+        });
+    }
+
+    handleToggle(selectedId) {
+        if (this.selection.indexOf(selectedId) === -1) {
+            this.selection = [ ...this.selection, selectedId ];
+        } else if (this.selection.includes(selectedId)) {
+            this.selection = [ ...this.selection ].filter(s => s !== selectedId);
+        }
+
+        this.setState({ selected: this.selection });
+        this.draw();
+    }
+
+    init() {
+        // create the first 8 selected data points
+        if (this.selection.length === 0) {
+            this.orgsList.forEach((org, index) => {
+                if (index <= 7) {
+                    this.handleToggle(org.id);
+                }
+            });
+        }
+
+        // create our colors array to send to the Legend component
+        const colors = this.orgsList.reduce((colors, org) => {
+            colors.push({
+                name: org.name,
+                value: color(org.name),
+                id: org.id
+            });
+            return colors;
+        }, []);
+        this.setState({ colors });
+        this.draw();
+    }
+
+    draw() {
+        // Clear our chart container element first
+        d3.selectAll('#' + this.props.id + ' > *').remove();
+        let { data: unformattedData, timeFrame } = this.props;
+        const selected = this.selection;
+        const parseTime = d3.timeParse('%Y-%m-%d');
+        const data = unformattedData.reduce((formatted, { date, orgs: orgsList }) => {
+            date = parseTime(date);
+            const selectedOrgs = orgsList.filter(({ id }) => selected.includes(id));
+            selectedOrgs.map(org => {
+                org.date = date;
+            });
+            return formatted.concat({ date, selectedOrgs });
+        }, []);
+        const width = this.props.getWidth();
+        const height = this.props.getHeight();
+        // x scale of entire chart
+        const x0 = d3
+        .scaleBand()
+        .range([ 0, width ])
+        .padding(0.35);
+        // x scale of individual grouped bars
+        const x1 = d3.scaleBand();
+        const y = d3.scaleLinear().range([ height, 0 ]);
+        // format our X Axis ticks
+        let ticks;
+        const maxTicks = Math.round(data.length / (timeFrame / 2));
+        ticks = data.map(d => d.date);
+        if (timeFrame === 31) {
+            ticks = data.map((d, i) =>
+                i % maxTicks === 0 ? d.date : undefined).filter(item => item);
+        }
+
+        const xAxis = d3
+        .axisBottom(x0)
+        .tickValues(ticks)
+        .tickFormat(d3.timeFormat('%-m/%-d'));
+
+        const yAxis = d3
+        .axisLeft(y)
+        .ticks(8)
+        .tickSize(-width, 0, 0);
+
+        const svg = d3
+        .select('#' + this.props.id)
+        .append('svg')
+        .attr('width', width + this.props.margin.left + this.props.margin.right)
+        .attr('height', height + this.props.margin.bottom + this.props.margin.top)
+        .append('g')
+        .attr(
+            'transform',
+            'translate(' +
+          this.props.margin.left +
+          ',' +
+          this.props.margin.top +
+          ')'
+        );
+
+        const dates = data.map(d => d.date);
+        const selectedOrgNames = data[0].selectedOrgs.map(d => d.name);
+        const tooltip = new Tooltip({
+            svg: '#' + this.props.id
+        });
+        x0.domain(dates);
+        x1.domain(selectedOrgNames).range([ 0, x0.bandwidth() ]); // unsorted
+        y.domain([
+            0,
+            d3.max(data, date => d3.max(date.selectedOrgs, d => d.count * 1.15)) || 8
+        ]);
+
+        // add y axis
+        svg
+        .append('g')
+        .attr('class', 'y axis')
+        .call(yAxis)
+        .selectAll('line')
+        .attr('stroke', '#d7d7d7')
+        .append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('y', 6)
+        .attr('dy', '.71em')
+        .style('text-anchor', 'end')
+        .style('font-weight', 'bold')
+        .text('Value');
+        svg
+        .append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('y', 0 - this.props.margin.left)
+        .attr('x', 0 - height / 2)
+        .attr('dy', '1em')
+        .style('text-anchor', 'middle')
+        .text('Hosts across orgs');
+
+        // add x axis
+        svg
+        .append('g')
+        .attr('class', 'x axis')
+        .attr('transform', 'translate(0,' + height + ')')
+        .call(xAxis)
+        .selectAll('line')
+        .attr('stroke', '#d7d7d7');
+        svg
+        .append('text')
+        .attr(
+            'transform',
+            'translate(' + width / 2 + ' ,' + (height + this.props.margin.top + 25) + ')'
+        )
+        .style('text-anchor', 'middle')
+        .text('Date');
+        // add the groups
+        let slice = svg.selectAll('.slice').data(data);
+        slice.exit().remove();
+
+        const enter = slice
+        .enter()
+        .append('g')
+        .attr('class', 'g foo')
+        .attr('transform', d => 'translate(' + x0(d.date) + ',0)');
+        slice = slice.merge(enter);
+        // add the individual bars
+        let bars = slice.selectAll('rect').data(function(d) {
+            return d.selectedOrgs;
+        });
+        bars.exit().remove();
+
+        const subEnter = bars
+        .enter()
+        .append('rect')
+        .attr('width', x1.bandwidth())
+        .attr('x', function(d) {
+            return x1(d.name);
+        }) // unsorted
+        .style('fill', function(d) {
+            return color(d.name);
+        })
+        .attr('y', function(d) {
+            return y(d.count);
+        })
+        .attr('height', function(d) {
+            return height - y(d.count);
+        })
+        .on('mouseover', function(d) {
+            d3.select(this).style('fill', d3.rgb(color(d.name)).darker(1));
+            tooltip.handleMouseOver();
+        })
+        .on('mousemove', tooltip.handleMouseOver)
+        .on('mouseout', function(d) {
+            d3.select(this).style('fill', color(d.name));
+            tooltip.handleMouseOut();
+        });
+        bars = bars.merge(subEnter);
+    };
+
+    componentDidMount() {
+        this.init();
+        // Call the resize function whenever a resize event occurs
+        window.addEventListener('resize', this.resize);
+    }
+
+    componentWillUnmount() {
+        const { timeout } = this.state;
+        clearTimeout(timeout);
+        window.removeEventListener('resize', this.resize);
+    }
+
+    render() {
+        const { colors, selected } = this.state;
+        return (
+            <Wrapper>
+                <div id={ this.props.id } />
+                { colors.length > 0 && (
+                    <Legend
+                        id="d3-hosts-bar-legend"
+                        data={ colors }
+                        selected={ selected }
+                        onToggle={ this.handleToggle }
+                        height="350px"
+                    />
+                ) }
+            </Wrapper>
+        );
+    }
+}
+
+HostsBarChart.propTypes = {
+    id: PropTypes.string,
+    isAccessible: PropTypes.bool,
+    data: PropTypes.array,
+    value: PropTypes.array,
+    margin: PropTypes.object,
+    getHeight: PropTypes.func,
+    getWidth: PropTypes.func,
+    timeFrame: PropTypes.number
+};
+
+export default initializeChart(HostsBarChart);

--- a/src/Charts/HostsBarChart.test.js
+++ b/src/Charts/HostsBarChart.test.js
@@ -1,0 +1,12 @@
+
+import { shallow } from 'enzyme';
+import HostsBarChart from './HostsBarChart.js';
+
+describe('Charts/HostsBarChart', () => {
+    it('HostsBarChart loads', () => {
+        expect(HostsBarChart).toBeTruthy();
+    });
+    it('should render successfully', () => {
+        shallow(<HostsBarChart />);
+    });
+});

--- a/src/Charts/PieChart.test.js
+++ b/src/Charts/PieChart.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable */ 
+/* eslint-disable */
 import { mount, shallow } from 'enzyme';
 import PieChart from './PieChart.js';
 
@@ -30,6 +30,14 @@ const dataWithoutSuccess = [
     { name: 'maxcorp3', count: 5000 },
     { name: 'maxcorp4', count: 5000 }
 ];
+
+const coloursForData = {
+    maxcorp0: '#111',
+    maxcorp1: '#222',
+    maxcorp2: '#333',
+    maxcorp3: '#444',
+    maxcorp4: '#555',
+};
 
 describe('Charts/PieChart', () => {
     it('PieChart loads', () => {
@@ -79,9 +87,11 @@ describe('Charts/PieChart/Tooltip', () => {
         let props1 = { ...baseprops };
         props1.id = thisid1;
         props1.data = dataWithSuccess;
+        props1.colorToNames = coloursForData;
         let props2 = { ...baseprops };
         props2.id = thisid2;
         props2.data = dataWithoutSuccess;
+        props2.colorToNames = coloursForData;
 
         // mount+init the piecharts ...
         wrapper1 = mount(<PieChart { ...props1 } />);

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -1,9 +1,11 @@
 /*eslint camelcase: ["error", {properties: "never"}]*/
+/* eslint-disable */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import moment from 'moment';
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
+import { getColorForNames } from '../../Utilities/colors';
 
 import LoadingState from '../../Components/LoadingState';
 import NoData from '../../Components/NoData';
@@ -111,6 +113,7 @@ const OrganizationStatistics = () => {
     const [ sortOrder, setSortOrder ] = useState('count:desc');
     const [ isLoading, setIsLoading ] = useState(true);
     const [ activeTabKey, setActiveTabKey ] = useState(0);
+    const [ colorToNames, setColorToNames ] = useState({});
     const {
         queryParams,
         setEndDate,
@@ -133,6 +136,17 @@ const OrganizationStatistics = () => {
     // Toggle currently active tab
     const handleTabClick = (event, tabIndex) => {
         setActiveTabKey(tabIndex);
+    };
+
+    const getColorForAllNames = (groupedBarChartData, pieChart1Data, pieChart2Data, hostsChartData) => {
+        // Get the unique names from the data for orgs
+        const namesToMap = [...new Set([
+            ...groupedBarChartData[0].orgs.map(el => el.org_name),
+            ...hostsChartData[0].orgs.map(el => el.name),
+            ...pieChart1Data.map(el => el.name),
+            ...pieChart2Data.map(el => el.name)
+        ])];
+        setColorToNames(getColorForNames(namesToMap.map(el => ({ name: el }))));
     };
 
     // First render
@@ -163,6 +177,7 @@ const OrganizationStatistics = () => {
                 setPieChart1Data(pieChart1Data);
                 setPieChart2Data(pieChart2Data);
                 setHostsChartData(hostsChartData);
+                getColorForAllNames(groupedBarChartData, pieChart1Data, pieChart2Data, hostsChartData);
                 setIsLoading(false);
             })
         );
@@ -247,6 +262,7 @@ const OrganizationStatistics = () => {
                                       margin={ { top: 20, right: 20, bottom: 50, left: 50 } }
                                       id="d3-grouped-bar-chart-root"
                                       data={ groupedBarChartData }
+                                      colorToNames={ colorToNames }
                                       timeFrame={ timeframe }
                                   />
                               ) }
@@ -261,6 +277,7 @@ const OrganizationStatistics = () => {
                                       margin={ { top: 20, right: 20, bottom: 50, left: 50 } }
                                       id="d3-hosts-chart-root"
                                       data={ hostsChartData }
+                                      colorToNames={ colorToNames }
                                       timeFrame={ timeframe }
                                   />
                               ) }
@@ -283,6 +300,7 @@ const OrganizationStatistics = () => {
                                   margin={ { top: 20, right: 20, bottom: 0, left: 20 } }
                                   id="d3-donut-1-chart-root"
                                   data={ pieChart1Data }
+                                  colorToNames={ colorToNames }
                                   timeFrame={ timeframe }
                               />
                           ) }
@@ -302,6 +320,7 @@ const OrganizationStatistics = () => {
                                   margin={ { top: 20, right: 20, bottom: 0, left: 20 } }
                                   id="d3-donut-2-chart-root"
                                   data={ pieChart2Data }
+                                  colorToNames={ colorToNames }
                                   timeFrame={ timeframe }
                               />
                           ) }

--- a/src/Utilities/colors.js
+++ b/src/Utilities/colors.js
@@ -1,3 +1,5 @@
+import { scaleOrdinal } from 'd3';
+
 const pfmulti = [
     '#06C',
     '#4CB140',
@@ -13,5 +15,22 @@ const pfmulti = [
     '#8F4700',
     '#002F5D'
 ];
+
+/**
+ * Creates a color map to names: for same data generates same colors.
+ * @param  {[{ name }]} data    Array of objects with name options to map to.
+ * @return {{ [name]: color }}  Object where the keys are the names an the values are the colors.
+ */
+export const getColorForNames = (data) => {
+    const colorFnc = scaleOrdinal(pfmulti);
+    const compObj = prop => (a, b) => (a[prop] > b[prop]) ? 1 : ((b[prop] > a[prop]) ? -1 : 0);
+
+    const colors = data.sort(compObj('name')).reduce((colors, org) => {
+        colors[org.name] = colorFnc(org.name);
+        return colors;
+    }, {});
+
+    return colors;
+};
 
 export { pfmulti };


### PR DESCRIPTION
## Host chart tab

Issue: https://github.com/RedHatInsights/tower-analytics-backend/issues/59

It adds 2 tabs: Jobs and Hosts. The `Jobs` tab contains the original chart, the `Hosts` tab contains a similar chart with the host data - according to the mockup: https://tower-mockups.testing.ansible.com/examples/analytics/orgs/analytics-hosts/

The chart contained hardcoded strings and the data has instead of `value` -> `count` and `org_name` -> `name` therefore is the duplication (the hostsBarChart is near identical to the grouppedBarChart). When using tabs the charts are forced to render when changing tabs. Without it, their size will be always the default. 

Additionally simplified the code for fetching data with the help of better hooks.

**The tabs:**
![Screenshot from 2020-07-23 14-54-13](https://user-images.githubusercontent.com/8531681/88288687-6c57c780-ccf4-11ea-9e0b-1a1ff9976514.png)
![Screenshot from 2020-07-23 14-54-24](https://user-images.githubusercontent.com/8531681/88288692-6e218b00-ccf4-11ea-83c5-6c3ea8c59a4b.png)

## Orgs colour fix: same orgs same colour across all charts
Issue: #81

**Before:**
![Screenshot from 2020-07-10 19-09-23](https://user-images.githubusercontent.com/8531681/87180783-7aafe780-c2e1-11ea-8ddb-7b54c9103eb9.png)
![Screenshot from 2020-07-10 19-09-38](https://user-images.githubusercontent.com/8531681/87180786-7b487e00-c2e1-11ea-82d8-f7df09b61224.png)

**After:** See the screenshots under the first section.