### PR TITLE
Brumik link top templates to job expoler

### DIFF
--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -1,9 +1,12 @@
+/*eslint camelcase: ["error", {allow: ["template_id", "job_type", "cluster_id", "start_date", "end_date"]}]*/
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { formatDateTime, formatSeconds, formatPercentage } from '../Utilities/helpers';
 import styled from 'styled-components';
 import LoadingState from '../Components/LoadingState';
 import NoData from '../Components/NoData';
+import { Paths } from '../paths';
+import { formatQueryStrings } from '../Utilities/formatQueryStrings';
 
 import {
     Badge,
@@ -11,7 +14,8 @@ import {
     DataList,
     DataListItem as PFDataListItem,
     DataListCell as PFDataListCell,
-    Modal
+    Modal,
+    Label
 } from '@patternfly/react-core';
 
 import { CircleIcon } from '@patternfly/react-icons';
@@ -40,6 +44,11 @@ const DataListCell = styled(PFDataListCell)`
   --pf-c-data-list__cell-cell--MarginRight: 0;
 `;
 
+const PFDataListItemNoBorder = styled(PFDataListItem)`
+    border-bottom: none;
+    margin-bottom: -20px;
+`;
+
 const DataListItem = styled(PFDataListItem)`
   display: flex;
   flex-direction: row;
@@ -48,6 +57,7 @@ const DataListItem = styled(PFDataListItem)`
   justify-content: center;
   align-items: center;
 `;
+
 const DataListItemCompact = styled(DataListItem)`
   padding: 0;
   > .pf-c-data-list__cell {
@@ -58,6 +68,11 @@ const DataListItemCompact = styled(DataListItem)`
     border-bottom: none;
   }
 `;
+
+const DataListCellCompact = styled(DataListCell)`
+    padding: 7px;
+`;
+
 const DataListFocus = styled.div`
     display: grid;
     grid-template-columns: repeat(3, auto);
@@ -75,6 +90,10 @@ const DataCellEnd = styled(DataListCell)`
   align-items: center;
 `;
 
+const DataCellEndCompact = styled(DataCellEnd)`
+    padding: 7px !important;
+`;
+
 const formatTopFailedTask = data => {
     if (!data) {
         return;
@@ -88,7 +107,7 @@ const formatTopFailedTask = data => {
     return `Unavailable`;
 };
 
-const TemplatesList = ({ templates, isLoading, queryParams }) => {
+const TemplatesList = ({ history, templates, isLoading, queryParams }) => {
     const [ isModalOpen, setIsModalOpen ] = useState(false);
     const [ selectedId, setSelectedId ] = useState(null);
     const [ selectedTemplate, setSelectedTemplate ] = useState([]);
@@ -113,6 +132,24 @@ const TemplatesList = ({ templates, isLoading, queryParams }) => {
 
         ;
     }, [ selectedId ]);
+
+    const redirectToJobExplorer = () => {
+        const { jobExplorer } = Paths;
+        const initialQueryParams = {
+            template_id: selectedId,
+            status: [ 'successful', 'failed', 'new', 'pending', 'waiting', 'error', 'canceled', 'running' ],
+            job_type: [ 'job' ],
+            start_date: queryParams.startDate,
+            end_date: queryParams.endDate
+        };
+
+        const { strings, stringify } = formatQueryStrings(initialQueryParams);
+        const search = stringify(strings);
+        history.push({
+            pathname: jobExplorer,
+            search
+        });
+    };
 
     return (
     <>
@@ -198,7 +235,7 @@ const TemplatesList = ({ templates, isLoading, queryParams }) => {
               ] }
           >
               <DataList aria-label="Selected Template Details">
-                  <PFDataListItem
+                  <PFDataListItemNoBorder
                       aria-labelledby="Selected Template Statistics"
                   >
                       <DataListFocus>
@@ -228,16 +265,22 @@ const TemplatesList = ({ templates, isLoading, queryParams }) => {
                                   formatTopFailedTask(selectedTemplate.most_failed_tasks) : 'Unavailable' }
                           </div>
                       </DataListFocus>
-                  </PFDataListItem>
+                  </PFDataListItemNoBorder>
+                  <DataListItemCompact>
+                      <DataListCellCompact key="last5jobs">
+                          <Label variant="outline">Last 5 jobs</Label>
+                      </DataListCellCompact>,
+                      <DataCellEndCompact>
+                          <Button component="a" onClick={ redirectToJobExplorer } variant="link">
+                              View all jobs
+                          </Button>
+                      </DataCellEndCompact>
+                  </DataListItemCompact>
                   <DataListItemCompact aria-labelledby="datalist header">
                       <PFDataListCell key="job heading">Id/Name</PFDataListCell>
                       <PFDataListCell key="cluster heading">Cluster</PFDataListCell>
-                      <PFDataListCell key="start time heading">
-                Start Time
-                      </PFDataListCell>
-                      <PFDataListCell key="total time heading">
-                Total Time
-                      </PFDataListCell>
+                      <PFDataListCell key="start time heading">Start Time</PFDataListCell>
+                      <PFDataListCell key="total time heading">Total Time</PFDataListCell>
                   </DataListItemCompact>
                   { relatedJobs.length <= 0 && <LoadingState /> }
                   { relatedJobs.length > 0 &&

--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -208,10 +208,10 @@ const TemplatesList = ({ history, templates, isLoading, queryParams }) => {
               </DataListItem>
           )) }
       </DataList>
-      { selectedTemplate && (
+      { selectedTemplate && selectedTemplate !== [] && (
           <Modal
               width={ '80%' }
-              title={ selectedTemplate.name ? selectedTemplate.name : '' }
+              title={ selectedTemplate.name ? selectedTemplate.name : 'no-template-name' }
               isOpen={ isModalOpen }
               onClose={ () => {
                   setIsModalOpen(false);

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -95,7 +95,7 @@ const initialQueryParams = {
     endDate: moment.utc().format('YYYY-MM-DD')
 };
 
-const Clusters = () => {
+const Clusters = ({ history }) => {
     const [ preflightError, setPreFlightError ] = useState(null);
     const [ barChartData, setBarChartData ] = useState([]);
     const [ lineChartData, setLineChartData ] = useState([]);
@@ -104,95 +104,46 @@ const Clusters = () => {
     const [ clusterOptions, setClusterOptions ] = useState([]);
     const [ clusterTimeFrame, setClusterTimeFrame ] = useState(31);
     const [ selectedCluster, setSelectedCluster ] = useState('all');
-    const [ firstRender, setFirstRender ] = useState(true);
     const [ isLoading, setIsLoading ] = useState(true);
     const { queryParams, setEndDate, setStartDate, setId } = useQueryParams(
         initialQueryParams
     );
 
     useEffect(() => {
-        if (firstRender) {
-            return;
-        }
-
-        const fetchEndpoints = () => {
-            return Promise.all(
-                [
-                    readChart30({ params: queryParams }),
-                    readModules({ params: queryParams }),
-                    readTemplates({ params: queryParams })
-                ].map(p => p.catch(() => []))
-            );
-        };
-
-        const update = async () => {
-            setIsLoading(true);
-            await window.insights.chrome.auth.getUser();
-            fetchEndpoints().then(
-                ([
-                    { data: chartData = []},
-                    { modules: modulesData = []},
-                    { templates: templatesData = []}
-                ]) => {
-                    if (queryParams.id) {
-                        setLineChartData(chartData);
-                    } else {
-                        setBarChartData(chartData);
-                    }
-
-                    setModulesData(modulesData);
-                    setTemplatesData(templatesData);
+        setIsLoading(true);
+        window.insights.chrome.auth.getUser().then(() =>
+            preflightRequest().then(() =>
+                readClusters().then(({ templates: clustersData = []}) => {
+                    const clusterOptions = formatClusterName(clustersData);
+                    setClusterOptions(clusterOptions);
                     setIsLoading(false);
-                }
-            );
-        };
-
-        update();
-    }, [ queryParams ]);
-
-    useEffect(() => {
-        let ignore = false;
-        const getData = () => {
-            return Promise.all(
-                [
-                    readChart30({ params: queryParams }),
-                    readClusters(),
-                    readModules({ params: queryParams }),
-                    readTemplates({ params: queryParams })
-                ].map(p => p.catch(() => []))
-            );
-        };
-
-        async function initializeWithPreflight() {
-            setIsLoading(true);
-            await window.insights.chrome.auth.getUser();
-            await preflightRequest().catch(error => {
+                })
+            ).catch((error) => {
                 setPreFlightError({ preflightError: error });
-            });
-            getData().then(
-                ([
-                    { data: barChartData = []},
-                    { templates: clustersData = []},
-                    { modules: modulesData = []},
-                    { templates: templatesData = []}
-                ]) => {
-                    if (!ignore) {
-                        const clusterOptions = formatClusterName(clustersData);
-
-                        setBarChartData(barChartData);
-                        setClusterOptions(clusterOptions);
-                        setModulesData(modulesData);
-                        setTemplatesData(templatesData);
-                        setFirstRender(false);
-                        setIsLoading(false);
-                    }
-                }
-            );
-        }
-
-        initializeWithPreflight();
-        return () => (ignore = true);
+            })
+        );
     }, []);
+
+    // Get and update the data
+    useEffect(() => {
+        setIsLoading(true);
+        window.insights.chrome.auth.getUser().then(() =>
+            Promise.all([
+                readChart30({ params: queryParams }),
+                readModules({ params: queryParams }),
+                readTemplates({ params: queryParams })
+            ]).then(([
+                { data: chartData = []},
+                { modules: modulesData = []},
+                { templates: templatesData = []}
+            ]) => {
+                queryParams.id ? setLineChartData(chartData) : setBarChartData(chartData);
+                setModulesData(modulesData);
+                setTemplatesData(templatesData);
+                setIsLoading(false);
+            })
+        );
+    }, [ queryParams ]);
 
     return (
         <React.Fragment>
@@ -291,6 +242,7 @@ const Clusters = () => {
                   style={ { display: 'flex', marginTop: '20px' } }
               >
                   <TemplatesList
+                      history={ history }
                       queryParams={ queryParams }
                       templates={ templatesData.slice(0, 10) }
                       isLoading={ isLoading }


### PR DESCRIPTION
#183 

Adds a link to the top templates modal for the job-explorer page. Build on top of: `jo_job-explorer-list-view` branch.

Additionally fixes a console error: when `clusters` page was loaded it automatically loaded the modal window as well because of a wrong if statement and throw a `Modal needs a title or ...` error in the console. 

**Before**:
![Screenshot from 2020-07-22 16-57-12](https://user-images.githubusercontent.com/8531681/88192071-69010500-cc3c-11ea-95ae-dc2ab5ff1df6.png)

**After**:
![Screenshot from 2020-07-24 15-14-39](https://user-images.githubusercontent.com/8531681/88394891-7c3cdd80-cdc0-11ea-8275-1f2fa233297f.png)


**After clicking on `View all jobs`:**
![Screenshot from 2020-07-23 13-52-36](https://user-images.githubusercontent.com/8531681/88283546-df107500-cceb-11ea-9d17-9e36e79b4e95.png)
