### PR TITLE
Quickfix job expoler switch default value error

### DIFF
--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -417,7 +417,7 @@ const FilterableToolbar = ({
                         id="showRootWorkflowJobs"
                         label="Ignore nested workflows and jobs"
                         labelOff="Ignore nested workflows and jobs"
-                        isChecked={ passedFilters.showRootWorkflows }
+                        isChecked={ !!passedFilters.showRootWorkflows }
                         onChange={ val => {
                             handleFilters({
                                 ...passedFilters,


### PR DESCRIPTION
Solves #186 by passing `!!var` to make it always `true` or `false` value.

The error happened at the first hard refresh after turning the switch on. (Bookmarking is not working after 2 hard refreshes.)