### PR TITLE
Fix: switching back from custom date in job expoler works properly

### DIFF
--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -205,9 +205,13 @@ const JobExplorer = props => {
 
         setQuickDateRange(filters.date);
 
-        setStart_Date(filters.startDate);
-
-        setEnd_Date(filters.endDate);
+        if (filters.date !== 'custom') {
+            setStart_Date(null);
+            setEnd_Date(null);
+        } else {
+            setStart_Date(filters.startDate);
+            setEnd_Date(filters.endDate);
+        }
     }, [ filters ]);
 
     useEffect(() => {


### PR DESCRIPTION
#209 

**Before**: See issue ^

**After**:
![Screencast from 07-29-2020 01_19_15 PM](https://user-images.githubusercontent.com/8531681/88794209-65bacb80-d19e-11ea-8ebd-0f193be98c9d.gif)