### PR TITLE
Convert fetch request to /job_explorer_options to POST.

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -102,10 +102,10 @@ export const readNotifications = ({ params = {}}) => {
 export const readJobExplorerOptions = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerOptionsEndpoint, formattedUrl);
-    const { strings, stringify } = formatQueryStrings(params);
-    const qs = stringify(strings);
-    url.search = qs;
-    return fetch(url).then(handleResponse);
+    return fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(params)
+    }).then(handleResponse);
 };
 
 export const readJobExplorer = ({ params = {}}) => {


### PR DESCRIPTION
Related #232 

Convert request to `/job_explorer_options` endpoint to POST and include attributes object.

Before:
![Screen Shot 2020-08-05 at 11 10 45 AM](https://user-images.githubusercontent.com/2293210/89430326-a2da0d00-d70c-11ea-9910-d1c6c53c6b79.png)


After:
![Screen Shot 2020-08-05 at 11 12 36 AM](https://user-images.githubusercontent.com/2293210/89430306-9ce42c00-d70c-11ea-8700-e415915fa903.png)
