### PR TITLE
Job Explorer UI Cleanup: update pagination and page title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7782,8 +7782,10 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7805,14 +7807,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7827,18 +7832,24 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7967,8 +7978,10 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7982,6 +7995,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7998,20 +8012,24 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8032,6 +8050,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8125,8 +8144,10 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8140,6 +8161,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8233,8 +8255,10 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8276,6 +8300,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8297,6 +8322,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8343,13 +8369,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Api.js
+++ b/src/Api.js
@@ -1,12 +1,18 @@
+<<<<<<< HEAD
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 /*eslint max-len: ["error", { "ignoreTemplateLiterals": true }]*/
+=======
+/* eslint-disable max-len */
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
+>>>>>>> Squashed commit of the following:
 /*eslint max-len: ["error", { "ignoreStrings": true }]*/
 /*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
 
 import { formatQueryStrings } from './Utilities/formatQueryStrings';
 
+<<<<<<< HEAD
 const apiVersion = 'v0';
 const barChartEndpoint = `/api/tower-analytics/${apiVersion}/chart30/`;
 const clustersEndpoint = `/api/tower-analytics/${apiVersion}/clusters/`;
@@ -19,6 +25,19 @@ const preflightEndpoint = `/api/tower-analytics/${apiVersion}/authorized/`;
 const templateJobsEndpoint = `/api/tower-analytics/${apiVersion}/template_jobs/`;
 const templatesEndPoint = `/api/tower-analytics/${apiVersion}/templates/`;
 const roiEndpoint = `/api/tower-analytics/${apiVersion}/roi_templates/`;
+=======
+const barChartEndpoint = '/api/tower-analytics/chart30/';
+const clustersEndpoint = '/api/tower-analytics/clusters/';
+const groupedBarChartEndpoint = '/api/tower-analytics/jobs_by_date_and_org_30/';
+const modulesEndpoint = '/api/tower-analytics/modules/';
+const notificationsEndPoint = '/api/tower-analytics/notifications/';
+const pieChart1Endpoint = '/api/tower-analytics/job_runs_by_org_30/';
+const pieChart2Endpoint = '/api/tower-analytics/job_events_by_org_30/';
+const preflightEndpoint = '/api/tower-analytics/authorized/';
+const templateJobsEndpoint = '/api/tower-analytics/template_jobs/';
+const templatesEndPoint = '/api/tower-analytics/templates/';
+const roiEndpoint = '/api/tower-analytics/roi_templates/';
+>>>>>>> Squashed commit of the following:
 const jobExplorerEndpoint = '/api/tower-analytics/v1/job_explorer/';
 const jobExplorerOptionsEndpoint =
   '/api/tower-analytics/v1/job_explorer_options/';
@@ -98,6 +117,7 @@ export const readNotifications = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(notificationsEndPoint, formattedUrl);
     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
+<<<<<<< HEAD
     return fetch(url).then(handleResponse);
 };
 
@@ -117,6 +137,23 @@ export const readJobExplorer = ({ params = {}}) => {
         sort_by
     };
     const { strings, stringify } = formatQueryStrings(paginationParams);
+=======
+    return fetch(url).then(handleResponse);
+};
+
+export const readJobExplorerOptions = ({ params = {}}) => {
+    const formattedUrl = getAbsoluteUrl();
+    let url = new URL(jobExplorerOptionsEndpoint, formattedUrl);
+    const { strings, stringify } = formatQueryStrings(params);
+    const qs = stringify(strings);
+    url.search = qs;
+    return fetch(url).then(handleResponse);
+};
+
+export const readJobExplorer = ({ params = {}}) => {
+    const { attributes: ignored, ...rest } = params;
+    const { strings, stringify } = formatQueryStrings(rest);
+>>>>>>> Squashed commit of the following:
     const qs = stringify(strings);
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerEndpoint, formattedUrl);

--- a/src/Api.js
+++ b/src/Api.js
@@ -1,4 +1,7 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Add paginationParams to request URL for job explorer endpoint.
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
@@ -151,9 +154,18 @@ export const readJobExplorerOptions = ({ params = {}}) => {
 };
 
 export const readJobExplorer = ({ params = {}}) => {
+<<<<<<< HEAD
     const { attributes: ignored, ...rest } = params;
     const { strings, stringify } = formatQueryStrings(rest);
 >>>>>>> Squashed commit of the following:
+=======
+    const { limit, sort_by } = params;
+    const paginationParams = {
+        limit,
+        sort_by
+    };
+    const { strings, stringify } = formatQueryStrings(paginationParams);
+>>>>>>> Add paginationParams to request URL for job explorer endpoint.
     const qs = stringify(strings);
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerEndpoint, formattedUrl);

--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -31,8 +31,12 @@ class BarChart extends Component {
         const initialQueryParams = {
             start_date: formattedDate,
             end_date: formattedDate,
+<<<<<<< HEAD
             quick_date_range: 'custom',
             status: [ 'failed', 'successful' ]
+=======
+            quick_date_range: 'custom'
+>>>>>>> Squashed commit of the following:
         };
         const { strings, stringify } = formatQueryStrings(initialQueryParams);
         const search = stringify(strings);

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -201,12 +201,21 @@ class GroupedBarChart extends Component {
 
     redirectToJobExplorer({ date, id }) {
         let org_id;
+<<<<<<< HEAD
         if (id === -1) {
             // disable clicking on "others" block
             return;
         }
 
         org_id = id;
+=======
+        if (id === null) {
+            org_id = -2;
+        } else {
+            org_id = id;
+        }
+
+>>>>>>> Squashed commit of the following:
         const { jobExplorer } = Paths;
         const formattedDate = formatDate(date);
         const initialQueryParams = {

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -28,6 +28,7 @@ class LineChart extends Component {
     redirectToJobExplorer({ DATE: date }) {
         const { jobExplorer } = Paths;
         const formattedDate = formatDate(date);
+<<<<<<< HEAD
         const { clusterId } = this.props;
         const initialQueryParams = {
             start_date: formattedDate,
@@ -35,6 +36,12 @@ class LineChart extends Component {
             quick_date_range: 'custom',
             status: [ 'failed', 'successful' ],
             cluster_id: clusterId
+=======
+        const initialQueryParams = {
+            start_date: formattedDate,
+            end_date: formattedDate,
+            quick_date_range: 'custom'
+>>>>>>> Squashed commit of the following:
         };
         const { strings, stringify } = formatQueryStrings(initialQueryParams);
         const search = stringify(strings);
@@ -338,8 +345,12 @@ LineChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
+<<<<<<< HEAD
     history: PropTypes.object,
     clusterId: PropTypes.number
+=======
+    history: PropTypes.object
+>>>>>>> Squashed commit of the following:
 };
 
 export default initializeChart(withRouter(LineChart));

--- a/src/Components/JobExplorerList.js
+++ b/src/Components/JobExplorerList.js
@@ -14,9 +14,15 @@ import {
 
 import { ArrowIcon as PFArrowIcon } from '@patternfly/react-icons';
 
+<<<<<<< HEAD
 import LoadingState from '../Components/LoadingState';
 import { formatDateTime, formatJobType } from '../Utilities/helpers';
 import JobStatus from './JobStatus';
+=======
+import StatusIcon from '../Icons/StatusIcon/StatusIcon';
+import LoadingState from '../Components/LoadingState';
+import { formatDateTime, formatJobType, formatJobStatus } from '../Utilities/helpers';
+>>>>>>> Squashed commit of the following:
 
 const headerLabels = [
     'Id/Name',
@@ -73,7 +79,11 @@ const buildListRow = (items, ariaLabel, ariaLabelledBy) => {
                                         </a>
                                     </DataListCell>,
                                     <DataListCell key={ count++ }>
+<<<<<<< HEAD
                                         <JobStatus status={ item.status } />
+=======
+                                        <StatusIcon status={ item.status } />{ formatJobStatus(item.status) }
+>>>>>>> Squashed commit of the following:
                                     </DataListCell>,
                                     <DataListCell key={ count++ }>
                                         { item.cluster_name }
@@ -115,9 +125,15 @@ const AllJobsTemplate = ({ jobs }) => {
 
 const JobExplorerList = ({ jobs }) => (
   <>
+<<<<<<< HEAD
     { jobs.length <= 0 && <LoadingState /> }
     <>
       { buildHeader(headerLabels) }
+=======
+    {jobs.length <= 0 && <LoadingState />}
+    <>
+      {buildHeader(headerLabels)}
+>>>>>>> Squashed commit of the following:
       <AllJobsTemplate jobs={ jobs } />
     </>
   </>

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState, useEffect } from 'react';
 import moment from 'moment';
 

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -259,9 +259,12 @@ const JobExplorer = props => {
 
     useEffect(() => {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> Squashed commit of the following:
+=======
+>>>>>>> Add paginationParams to request URL for job explorer endpoint.
         insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
         updateURL();
     }, []);

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -2,15 +2,18 @@
 /*eslint camelcase: ["error", {allow: ["setStart_Date","setEnd_Date","cluster_id","org_id","job_type","template_id","quick_date_range","sort_by"]}]*/
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+<<<<<<< HEAD
 =======
 /* eslint-disable camelcase */
 import React, { useState, useEffect } from 'react';
 >>>>>>> Squashed commit of the following:
+=======
+import styled from 'styled-components';
+>>>>>>> Add compact pagination to top of list. Add styles to align toolbar and compact pagination. Update page title.
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
 import { formatQueryStrings } from '../../Utilities/formatQueryStrings';
 
-import styled from 'styled-components';
 import LoadingState from '../../Components/LoadingState';
 import EmptyState from '../../Components/EmptyState';
 import NoResults from '../../Components/NoResults';
@@ -33,6 +36,7 @@ import {
 } from '@redhat-cloud-services/frontend-components';
 
 import {
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
     DataToolbar,
@@ -57,12 +61,18 @@ import {
     CardHeader as PFCardHeader,
     Pagination,
 <<<<<<< HEAD
+=======
+    Card,
+    CardBody,
+    Pagination as PFPagination,
+>>>>>>> Add compact pagination to top of list. Add styles to align toolbar and compact pagination. Update page title.
     PaginationVariant
 } from '@patternfly/react-core';
 
 import JobExplorerList from '../../Components/JobExplorerList';
 import FilterableToolbar from '../../Components/Toolbar';
 
+<<<<<<< HEAD
 =======
     PaginationVariant,
     Select,
@@ -91,24 +101,27 @@ const DataToolbarGroup = styled(PFDataToolbarGroup)`
 `;
 >>>>>>> Squashed commit of the following:
 const CardHeader = styled(PFCardHeader)`
+=======
+const CompactPagination = styled(PFPagination)`
+>>>>>>> Add compact pagination to top of list. Add styles to align toolbar and compact pagination. Update page title.
+  display: flex;
+  align-items: flex-start;
+  margin: 0;
+`;
+
+const Pagination = styled(PFPagination)`
+  margin-top: 20px;
+`;
+
+const ToolbarContainer = styled('div')`
   display: flex;
   justify-content: space-between;
-
-  @media screen and (max-width: 1035px) {
-    display: block;
-  }
 `;
-
-const TitleWithBadge = styled.div`
-  display: flex;
-  align-items: center;
-
-  h2 {
-    margin-right: 10px;
-  }
-`;
+<<<<<<< HEAD
 
 <<<<<<< HEAD
+=======
+>>>>>>> Add compact pagination to top of list. Add styles to align toolbar and compact pagination. Update page title.
 const perPageOptions = [
     { title: '5', value: 5 },
     { title: '10', value: 10 },
@@ -784,7 +797,7 @@ const JobExplorer = props => {
       Automation Analytics
             <span style={ { fontSize: '16px' } }>
                 { ' ' }
-                <span style={ { margin: '0 10px' } }>|</span> All Jobs
+                <span style={ { margin: '0 10px' } }>|</span> Jobs explorer
             </span>
         </span>
     );
@@ -835,15 +848,8 @@ const JobExplorer = props => {
         <>
           <Main>
               <Card>
-                  <CardHeader>
-                      <TitleWithBadge>
-                          <h2>
-                              <strong>Total Jobs</strong>
-                          </h2>
-                          <Badge isRead>{ meta.count ? meta.count : 0 }</Badge>
-                      </TitleWithBadge>
-                  </CardHeader>
                   <CardBody>
+<<<<<<< HEAD
 <<<<<<< HEAD
                       <FilterableToolbar
                           orgs={ orgIds }
@@ -857,6 +863,38 @@ const JobExplorer = props => {
                           passedFilters={ filters }
                           handleFilters={ setFilters }
                       />
+=======
+                      <ToolbarContainer>
+                          <FilterableToolbar
+                              orgs={ orgIds }
+                              statuses={ statuses }
+                              clusters={ clusterIds }
+                              templates={ templateIds }
+                              types={ jobTypes }
+                              sortables={ sortBy }
+                              dateRanges={ quickDateRanges }
+                              onDelete={ onDelete }
+                              passedFilters={ filters }
+                              handleFilters={ setFilters }
+                          />
+                          <CompactPagination
+                              itemCount={ meta.count ? meta.count : 0 }
+                              widgetId="pagination-options-menu-top"
+                              perPageOptions={ perPageOptions }
+                              perPage={ queryParams.limit }
+                              page={ currPage }
+                              variant={ PaginationVariant.bottom }
+                              dropDirection={ 'up' }
+                              onPerPageSelect={ (_event, perPage, page) => {
+                                  handlePerPageSelect(perPage, page);
+                              } }
+                              onSetPage={ (_event, pageNumber) => {
+                                  handleSetPage(pageNumber);
+                              } }
+                              isCompact
+                          />
+                      </ToolbarContainer>
+>>>>>>> Add compact pagination to top of list. Add styles to align toolbar and compact pagination. Update page title.
                       { apiError && <ApiErrorState message={ apiError } /> }
                       { !apiError && isLoading && <LoadingState /> }
                       { !apiError && !isLoading && jobExplorerData.length <= 0 && <NoResults /> }
@@ -993,7 +1031,6 @@ const JobExplorer = props => {
                         onSetPage={ (_event, pageNumber) => {
                             handleSetPage(pageNumber);
                         } }
-                        style={ { marginTop: '20px' } }
                     />
                   </>
                       ) }

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -1,6 +1,11 @@
+<<<<<<< HEAD
 /*eslint camelcase: ["error", {allow: ["setStart_Date","setEnd_Date","cluster_id","org_id","job_type","template_id","quick_date_range","sort_by"]}]*/
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+=======
+/* eslint-disable camelcase */
+import React, { useState, useEffect } from 'react';
+>>>>>>> Squashed commit of the following:
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
 import { formatQueryStrings } from '../../Utilities/formatQueryStrings';
@@ -9,7 +14,10 @@ import styled from 'styled-components';
 import LoadingState from '../../Components/LoadingState';
 import EmptyState from '../../Components/EmptyState';
 import NoResults from '../../Components/NoResults';
+<<<<<<< HEAD
 import ApiErrorState from '../../Components/ApiErrorState';
+=======
+>>>>>>> Squashed commit of the following:
 import {
     preflightRequest,
     readJobExplorer,
@@ -25,17 +33,63 @@ import {
 } from '@redhat-cloud-services/frontend-components';
 
 import {
+<<<<<<< HEAD
+=======
+    DataToolbar,
+    DataToolbarContent as PFDataToolbarContent,
+    DataToolbarFilter,
+    DataToolbarToggleGroup,
+    DataToolbarGroup as PFDataToolbarGroup,
+    DataToolbarItem
+} from '@patternfly/react-core/dist/esm/experimental';
+
+import {
+    FilterIcon,
+    CalendarAltIcon,
+    QuestionCircleIcon
+} from '@patternfly/react-icons';
+
+import {
+>>>>>>> Squashed commit of the following:
     Badge,
     Card,
     CardBody,
     CardHeader as PFCardHeader,
     Pagination,
+<<<<<<< HEAD
     PaginationVariant
 } from '@patternfly/react-core';
 
 import JobExplorerList from '../../Components/JobExplorerList';
 import FilterableToolbar from '../../Components/Toolbar';
 
+=======
+    PaginationVariant,
+    Select,
+    SelectOption,
+    SelectVariant,
+    DropdownPosition,
+    Dropdown,
+    DropdownToggle,
+    DropdownItem,
+    InputGroup,
+    InputGroupText,
+    TextInput,
+    Switch as PFSwitch,
+    Tooltip,
+    TooltipPosition
+} from '@patternfly/react-core';
+
+import JobExplorerList from '../../Components/JobExplorerList';
+
+const DataToolbarGroup = styled(PFDataToolbarGroup)`
+  button {
+    .pf-c-select__toggle-wrapper {
+      flex-wrap: nowrap;
+    }
+  }
+`;
+>>>>>>> Squashed commit of the following:
 const CardHeader = styled(PFCardHeader)`
   display: flex;
   justify-content: space-between;
@@ -54,6 +108,7 @@ const TitleWithBadge = styled.div`
   }
 `;
 
+<<<<<<< HEAD
 const perPageOptions = [
     { title: '5', value: 5 },
     { title: '10', value: 10 },
@@ -65,6 +120,31 @@ const perPageOptions = [
 const initialQueryParams = {
     ...jobExplorer.defaultParams,
     attributes: jobExplorer.attributes
+=======
+const Switch = styled(PFSwitch)`
+    &&& {
+        margin: 0 15px;
+    }
+`;
+
+const DataToolbarContent = styled(PFDataToolbarContent)`
+    .pf-c-data-toolbar__content-section {
+        justify-content: space-between;
+    }
+`;
+
+const perPageOptions = [
+    { title: '5', value: 5 },
+    { title: '10', value: 10 },
+    { title: '20', value: 20 },
+    { title: '50', value: 50 },
+    { title: '100', value: 100 }
+];
+
+const initialQueryParams = {
+    attributes: jobExplorer.attributes,
+    limit: 5
+>>>>>>> Squashed commit of the following:
 };
 
 const initialOptionsParams = {
@@ -73,16 +153,36 @@ const initialOptionsParams = {
 
 const JobExplorer = props => {
     const [ preflightError, setPreFlightError ] = useState(null);
+<<<<<<< HEAD
     const [ apiError, setApiError ] = useState(null);
+=======
+>>>>>>> Squashed commit of the following:
     const [ jobExplorerData, setJobExplorerData ] = useState([]);
     const [ firstRender, setFirstRender ] = useState(true);
     const [ isLoading, setIsLoading ] = useState(true);
     const [ meta, setMeta ] = useState({});
     const [ currPage, setCurrPage ] = useState(1);
+<<<<<<< HEAD
     const [ orgIds, setOrgIds ] = useState([]);
     const [ clusterIds, setClusterIds ] = useState([]);
     const [ templateIds, setTemplateIds ] = useState([]);
     const [ sortBy, setSortBy ] = useState(null);
+=======
+    const [ statusIsExpanded, setStatusIsExpanded ] = useState(false);
+    const [ dateRangeIsExpanded, setDateRangeIsExpanded ] = useState(false);
+    const [ jobTypeIsExpanded, setJobTypeIsExpanded ] = useState(false);
+    const [ orgIsExpanded, setOrgIsExpanded ] = useState(false);
+    const [ isCategoryExpanded, setIsCategoryExpanded ] = useState(false);
+    const [ clusterIsExpanded, setClusterIsExpanded ] = useState(false);
+    const [ templateIsExpanded, setTemplateIsExpanded ] = useState(false);
+    const [ sortByIsExpanded, setSortByIsExpanded ] = useState(false);
+    const [ currentCategory, setCurrentCategory ] = useState('Status');
+
+    const [ orgIds, setOrgIds ] = useState([]);
+    const [ clusterIds, setClusterIds ] = useState([]);
+    const [ templateIds, setTemplateIds ] = useState([]);
+    const [ sortBy, setSortBy ] = useState([]);
+>>>>>>> Squashed commit of the following:
     const [ statuses, setStatuses ] = useState([]);
     const [ jobTypes, setJobTypes ] = useState([]);
     const [ quickDateRanges, setQuickDateRanges ] = useState([]);
@@ -92,7 +192,11 @@ const JobExplorer = props => {
         location: { search }
     } = props;
     let initialSearchParams = parse(search, { arrayFormat: 'bracket' });
+<<<<<<< HEAD
     let combined = { ...initialQueryParams, ...initialSearchParams };
+=======
+    let combined = { ...initialSearchParams, ...initialQueryParams };
+>>>>>>> Squashed commit of the following:
     const {
         queryParams,
         setLimit,
@@ -130,10 +234,17 @@ const JobExplorer = props => {
         org: queryParams.org_id ? formattedArray(queryParams.org_id) : [],
         cluster: queryParams.cluster_id ? formattedArray(queryParams.cluster_id) : [],
         template: queryParams.template_id ? formattedArray(queryParams.template_id) : [],
+<<<<<<< HEAD
         sortby: queryParams.sort_by ? queryParams.sort_by : null,
         startDate: queryParams.start_date ? queryParams.start_date : null,
         endDate: queryParams.end_date ? queryParams.end_date : null,
         date: queryParams.quick_date_range ? queryParams.quick_date_range : 'last_30_days',
+=======
+        sortby: queryParams.sort_by ? formattedArray(queryParams.sort_by) : [],
+        startDate: queryParams.start_date ? queryParams.start_date : null,
+        endDate: queryParams.end_date ? queryParams.end_date : null,
+        date: queryParams.quick_date_range ? queryParams.quick_date_range : null,
+>>>>>>> Squashed commit of the following:
         showRootWorkflows: queryParams.only_root_workflows_and_standalone_jobs ? queryParams.only_root_workflows_and_standalone_jobs : false
     });
     const updateURL = () => {
@@ -147,6 +258,10 @@ const JobExplorer = props => {
     };
 
     useEffect(() => {
+<<<<<<< HEAD
+=======
+
+>>>>>>> Squashed commit of the following:
         insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
         updateURL();
     }, []);
@@ -161,14 +276,22 @@ const JobExplorer = props => {
         };
 
         const update = async () => {
+<<<<<<< HEAD
             setApiError(null);
+=======
+>>>>>>> Squashed commit of the following:
             setIsLoading(true);
             await window.insights.chrome.auth.getUser();
             getData().then(([{ items: jobExplorerData = [], meta }]) => {
                 setJobExplorerData(jobExplorerData);
                 setMeta(meta);
+<<<<<<< HEAD
             }).catch(e => setApiError(e.error)
             ).finally(() => setIsLoading(false));
+=======
+                setIsLoading(false);
+            });
+>>>>>>> Squashed commit of the following:
         };
 
         update();
@@ -200,13 +323,20 @@ const JobExplorer = props => {
             setTemplate(filters.template);
         }
 
+<<<<<<< HEAD
         // The filter can change back to null too.
         setSortBy2(filters.sortby);
+=======
+        if (filters.sortby) {
+            setSortBy2(filters.sortby);
+        }
+>>>>>>> Squashed commit of the following:
 
         setRootWorkflowsAndJobs(filters.showRootWorkflows);
 
         setQuickDateRange(filters.date);
 
+<<<<<<< HEAD
         if (filters.date !== 'custom') {
             setStart_Date(null);
             setEnd_Date(null);
@@ -214,6 +344,11 @@ const JobExplorer = props => {
             setStart_Date(filters.startDate);
             setEnd_Date(filters.endDate);
         }
+=======
+        setStart_Date(filters.startDate);
+
+        setEnd_Date(filters.endDate);
+>>>>>>> Squashed commit of the following:
     }, [ filters ]);
 
     useEffect(() => {
@@ -270,6 +405,35 @@ const JobExplorer = props => {
         return () => (ignore = true);
     }, []);
 
+<<<<<<< HEAD
+=======
+    const handleChips = (item, comparator) => {
+        return item.reduce((acc, i) => {
+            Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
+            comparator.forEach(item => {
+                if (item.key === i) {
+                    acc.push(item.value);
+                }
+            });
+            return acc;
+        }, []);
+    };
+
+    const handleDateChips = (date, comparator) => {
+        if (date && typeof date === 'string') {
+            let val;
+            comparator.forEach(i => {
+                if (i.key === date) {
+                    val = i.value;
+                }
+            });
+            return new Array(val);
+        }
+
+        return new Array();
+    };
+
+>>>>>>> Squashed commit of the following:
     const onDelete = (type, val) => {
         let filtered;
         Number.isInteger(val) ? (val = parseInt(val)) : val;
@@ -294,6 +458,13 @@ const JobExplorer = props => {
             filtered = templateIds.filter(template => template.value === val);
         }
 
+<<<<<<< HEAD
+=======
+        if (type === 'SortBy') {
+            filtered = sortBy.filter(attr => attr.value === val);
+        }
+
+>>>>>>> Squashed commit of the following:
         if (type) {
             if (type === 'Date') {
                 setFilters({
@@ -302,11 +473,14 @@ const JobExplorer = props => {
                     startDate: null,
                     endDate: null
                 });
+<<<<<<< HEAD
             } else if (type === 'SortBy') {
                 setFilters({
                     ...filters,
                     sortby: null
                 });
+=======
+>>>>>>> Squashed commit of the following:
             } else {
                 setFilters({
                     ...filters,
@@ -322,15 +496,281 @@ const JobExplorer = props => {
                 org: [],
                 cluster: [],
                 template: [],
+<<<<<<< HEAD
                 sortby: null,
                 date: null,
                 startDate: null,
                 endDate: null,
                 showRootWorkflows: false
+=======
+                sortby: [],
+                date: null,
+                startDate: null,
+                endDate: null
+>>>>>>> Squashed commit of the following:
             });
         }
     };
 
+<<<<<<< HEAD
+=======
+    const buildCategoryDropdown = () => {
+        return (
+            <DataToolbarItem>
+                <Dropdown
+                    onSelect={ e => {
+                        setCurrentCategory(e.target.innerText);
+                        setIsCategoryExpanded(!isCategoryExpanded);
+                    } }
+                    position={ DropdownPosition.left }
+                    toggle={
+                        <DropdownToggle
+                            onToggle={ () => {
+                                setIsCategoryExpanded(!isCategoryExpanded);
+                            } }
+                            style={ { width: '100%' } }
+                        >
+                            <FilterIcon />
+              &nbsp;{ currentCategory }
+                        </DropdownToggle>
+                    }
+                    isOpen={ isCategoryExpanded }
+                    dropdownItems={ [
+                        <DropdownItem key="cat0">Status</DropdownItem>,
+                        <DropdownItem key="cat6">Date</DropdownItem>,
+                        <DropdownItem key="cat1">Job type</DropdownItem>,
+                        <DropdownItem key="cat2">Organization</DropdownItem>,
+                        <DropdownItem key="cat3">Cluster</DropdownItem>,
+                        <DropdownItem key="cat4">Template</DropdownItem>,
+                        <DropdownItem key="cat5">Sort by</DropdownItem>
+                    ] }
+                    style={ { width: '100%' } }
+                />
+            </DataToolbarItem>
+        );
+    };
+
+    const buildFilterDropdown = () => {
+        const organizationIdMenuItems = orgIds.map(({ key, value }) => (
+            <SelectOption key={ key } value={ `${key}` }>
+                { value }
+            </SelectOption>
+        ));
+
+        const statusMenuItems = statuses.map(({ key, value }) => (
+            <SelectOption key={ key } value={ key }>
+                { value }
+            </SelectOption>
+        ));
+
+        const jobTypeMenuItems = jobTypes.map(({ key, value }) => (
+            <SelectOption key={ key } value={ key }>
+                { value }
+            </SelectOption>
+        ));
+
+        const clusterIdMenuItems = clusterIds.map(({ key, value }) => (
+            <SelectOption key={ key } value={ `${key}` }>
+                { value }
+            </SelectOption>
+        ));
+
+        const templateIdMenuItems = templateIds.map(({ key, value }) => (
+            <SelectOption key={ key } value={ `${key}` }>
+                { value }
+            </SelectOption>
+        ));
+
+        const sortByMenuItems = sortBy.map(({ key, value }) => (
+            <SelectOption key={ key } value={ key }>
+                { value }
+            </SelectOption>
+        ));
+
+        const dateRangeMenuItems = quickDateRanges.map(({ key, value }) => (
+            <SelectOption key={ key } value={ key }>
+                { value }
+            </SelectOption>
+        ));
+
+        const onSelect = (type, event, selection) => {
+            const checked = event.target.checked;
+
+            setFilters({
+                ...filters,
+                [type]: checked
+                    ? [ ...filters[type], selection ]
+                    : filters[type].filter(value => value !== selection)
+            });
+        };
+
+        const onDateSelect = (_event, selection) => {
+            setFilters({
+                ...filters,
+                date: selection
+            });
+            setDateRangeIsExpanded(!dateRangeIsExpanded);
+        };
+
+        return (
+            <React.Fragment>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Status' }
+                    chips={ handleChips(filters.status, statuses) }
+                    categoryName="Status"
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        variant={ SelectVariant.checkbox }
+                        aria-label="Status"
+                        onToggle={ () => {
+                            setStatusIsExpanded(!statusIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onSelect('status', event, selection);
+                        } }
+                        selections={ filters.status }
+                        isExpanded={ statusIsExpanded }
+                        placeholderText="Filter by job status"
+                    >
+                        { statusMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Date' }
+                    categoryName="Date"
+                    chips={ handleDateChips(filters.date, quickDateRanges) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        variant={ SelectVariant.single }
+                        aria-label="Date"
+                        onToggle={ () => {
+                            setDateRangeIsExpanded(!dateRangeIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onDateSelect(event, selection);
+                        } }
+                        selections={ filters.date }
+                        isExpanded={ dateRangeIsExpanded }
+                        placeholderText="Filter by date range"
+                    >
+                        { dateRangeMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Job type' }
+                    categoryName="Type"
+                    chips={ handleChips(filters.type, jobTypes) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        aria-label="Type"
+                        variant={ SelectVariant.checkbox }
+                        onToggle={ () => {
+                            setJobTypeIsExpanded(!jobTypeIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onSelect('type', event, selection);
+                        } }
+                        selections={ filters.type }
+                        isExpanded={ jobTypeIsExpanded }
+                        placeholderText="Filter by job type"
+                    >
+                        { jobTypeMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Organization' }
+                    categoryName="Org"
+                    chips={ handleChips(filters.org, orgIds) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        aria-label="Filter by Org"
+                        variant={ SelectVariant.checkbox }
+                        onToggle={ () => {
+                            setOrgIsExpanded(!orgIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onSelect('org', event, selection);
+                        } }
+                        selections={ filters.org }
+                        isExpanded={ orgIsExpanded }
+                        placeholderText="Filter by organization"
+                    >
+                        { organizationIdMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Cluster' }
+                    categoryName="Cluster"
+                    chips={ handleChips(filters.cluster, clusterIds) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        aria-label="Filter by Cluster"
+                        variant={ SelectVariant.checkbox }
+                        onToggle={ () => {
+                            setClusterIsExpanded(!clusterIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onSelect('cluster', event, selection);
+                        } }
+                        selections={ filters.cluster }
+                        isExpanded={ clusterIsExpanded }
+                        placeholderText="Filter by cluster"
+                    >
+                        { clusterIdMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Template' }
+                    categoryName="Template"
+                    chips={ handleChips(filters.template, templateIds) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        aria-label="Filter by template"
+                        variant={ SelectVariant.checkbox }
+                        onToggle={ () => setTemplateIsExpanded(!templateIsExpanded) }
+                        onSelect={ (event, selection) => {
+                            onSelect('template', event, selection);
+                        } }
+                        selections={ filters.template }
+                        isExpanded={ templateIsExpanded }
+                        placeholderText="Filter by template"
+                    >
+                        { templateIdMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+                <DataToolbarFilter
+                    showToolbarItem={ currentCategory === 'Sort by' }
+                    categoryName="SortBy"
+                    chips={ handleChips(filters.sortby, sortBy) }
+                    deleteChip={ onDelete }
+                >
+                    <Select
+                        aria-label="Sort by"
+                        variant={ SelectVariant.checkbox }
+                        onToggle={ () => {
+                            setSortByIsExpanded(!sortByIsExpanded);
+                        } }
+                        onSelect={ (event, selection) => {
+                            onSelect('sortby', event, selection);
+                        } }
+                        selections={ filters.sortby }
+                        isExpanded={ sortByIsExpanded }
+                        placeholderText="Sort by attribute"
+                    >
+                        { sortByMenuItems }
+                    </Select>
+                </DataToolbarFilter>
+            </React.Fragment>
+        );
+    };
+
+>>>>>>> Squashed commit of the following:
     const returnOffsetVal = page => {
         let offsetVal = (page - 1) * queryParams.limit;
         return offsetVal;
@@ -359,6 +799,23 @@ const JobExplorer = props => {
         setCurrPage(page);
     };
 
+<<<<<<< HEAD
+=======
+    const handleStartDate = e => {
+        setFilters({
+            ...filters,
+            startDate: e
+        });
+    };
+
+    const handleEndDate = e => {
+        setFilters({
+            ...filters,
+            endDate: e
+        });
+    };
+
+>>>>>>> Squashed commit of the following:
     return (
         <React.Fragment>
             <PageHeader>
@@ -384,6 +841,7 @@ const JobExplorer = props => {
                       </TitleWithBadge>
                   </CardHeader>
                   <CardBody>
+<<<<<<< HEAD
                       <FilterableToolbar
                           orgs={ orgIds }
                           statuses={ statuses }
@@ -400,6 +858,122 @@ const JobExplorer = props => {
                       { !apiError && isLoading && <LoadingState /> }
                       { !apiError && !isLoading && jobExplorerData.length <= 0 && <NoResults /> }
                       { !apiError && !isLoading && jobExplorerData.length > 0 && (
+=======
+                      <DataToolbar
+                          id="data-toolbar-with-chip-groups"
+                          clearAllFilters={ onDelete }
+                          collapseListedFiltersBreakpoint="xl"
+                      >
+                          <DataToolbarContent>
+                              <DataToolbarToggleGroup
+                                  toggleIcon={ <FilterIcon /> }
+                                  breakpoint="xl"
+                              >
+                                  { quickDateRanges.length > 0 && (
+                                      <DataToolbarGroup variant="filter-group">
+                                          { buildCategoryDropdown() }
+                                          { buildFilterDropdown() }
+                                          { /* { filters.type.includes('workflowjob') && (
+                            <>
+                              <Switch
+                                  id="showRootWorkflowJobs"
+                                  label="Ignore nested workflows and jobs"
+                                  labelOff="Ignore nested workflows and jobs"
+                                  isChecked={ filters.showRootWorkflows }
+                                  onChange={ () => {
+                                      setFilters({
+                                          ...filters,
+                                          showRootWorkflows: !filters.showRootWorkflows
+                                      });
+                                  } }
+                              />
+                              <Tooltip
+                                  position={ TooltipPosition.top }
+                                  content={
+                                      <div>
+                                          { ' ' }
+                                    If enabled, nested workflows and jobs
+                                    will not be included in the overall totals.
+                                    Enable this option to filter out duplicate entries.
+                                      </div>
+                                  }
+                              >
+                                  <QuestionCircleIcon />
+                              </Tooltip>
+                            </>
+                                          ) } */ }
+                                          { filters.date === 'custom' && (
+                            <>
+                              <InputGroup>
+                                  <InputGroupText
+                                      component="label"
+                                      htmlFor="startDate"
+                                  >
+                                      <CalendarAltIcon />
+                                  </InputGroupText>
+                                  <TextInput
+                                      name="startDate"
+                                      id="startDate"
+                                      type="date"
+                                      aria-label="Start Date"
+                                      value={ filters.startDate }
+                                      onChange={ e => handleStartDate(e) }
+                                  />
+                              </InputGroup>
+                              <InputGroup>
+                                  <InputGroupText
+                                      component="label"
+                                      htmlFor="endDate"
+                                  >
+                                      <CalendarAltIcon />
+                                  </InputGroupText>
+                                  <TextInput
+                                      name="endDate"
+                                      id="endDate"
+                                      type="date"
+                                      aria-label="End Date"
+                                      value={ filters.endDate }
+                                      onChange={ e => handleEndDate(e) }
+                                  />
+                              </InputGroup>
+                            </>
+                                          ) }
+                                      </DataToolbarGroup>
+                                  ) }
+                              </DataToolbarToggleGroup>
+                              <div>
+                                  <Switch
+                                      id="showRootWorkflowJobs"
+                                      label="Ignore nested workflows and jobs"
+                                      labelOff="Ignore nested workflows and jobs"
+                                      isChecked={ filters.showRootWorkflows }
+                                      onChange={ () => {
+                                          setFilters({
+                                              ...filters,
+                                              showRootWorkflows: !filters.showRootWorkflows
+                                          });
+                                      } }
+                                  />
+                                  <Tooltip
+                                      position={ TooltipPosition.top }
+                                      content={
+                                          <div>
+                                              { ' ' }
+                                    If enabled, nested workflows and jobs
+                                    will not be included in the overall totals.
+                                    Enable this option to filter out duplicate entries.
+                                          </div>
+                                      }
+                                  >
+                                      <QuestionCircleIcon />
+                                  </Tooltip>
+                              </div>
+                          </DataToolbarContent>
+                      </DataToolbar>
+                      { isLoading && <LoadingState /> }
+                      { !isLoading && jobExplorerData.length <= 0 && <NoResults /> }
+                      { !isLoading && jobExplorerData.length > 0 && (
+>>>>>>> Squashed commit of the following:
                   <>
                     <JobExplorerList jobs={ jobExplorerData } />
                     <Pagination
@@ -429,9 +1003,12 @@ const JobExplorer = props => {
     );
 };
 
+<<<<<<< HEAD
 JobExplorer.propTypes = {
     location: PropTypes.object,
     history: PropTypes.object
 };
 
+=======
+>>>>>>> Squashed commit of the following:
 export default JobExplorer;

--- a/src/Containers/JobExplorer/JobExplorer.test.js
+++ b/src/Containers/JobExplorer/JobExplorer.test.js
@@ -9,6 +9,7 @@ describe('Containers/Clusters', () => {
     });
     it('should render successfully', () => {
         shallow(<JobExplorer location={ { search: '&foo=bar' } } />);
+<<<<<<< HEAD
 =======
 /*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
 import { mount } from 'enzyme';
@@ -19,5 +20,7 @@ describe('Components/JobExplorer', () => {
     it('should render successfully', () => {
         mount(<JobExplorer />);
 >>>>>>> Squashed commit of the following:
+=======
+>>>>>>> Add paginationParams to request URL for job explorer endpoint.
     });
 });

--- a/src/Containers/JobExplorer/JobExplorer.test.js
+++ b/src/Containers/JobExplorer/JobExplorer.test.js
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 
 import { shallow } from 'enzyme';
 import JobExplorer from './JobExplorer';
@@ -8,5 +9,15 @@ describe('Containers/Clusters', () => {
     });
     it('should render successfully', () => {
         shallow(<JobExplorer location={ { search: '&foo=bar' } } />);
+=======
+/*eslint camelcase: ["error", {properties: "never", ignoreDestructuring: true}]*/
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import JobExplorer from './JobExplorer';
+
+describe('Components/JobExplorer', () => {
+    it('should render successfully', () => {
+        mount(<JobExplorer />);
+>>>>>>> Squashed commit of the following:
     });
 });

--- a/src/Icons/StatusIcon/StatusIcon.js
+++ b/src/Icons/StatusIcon/StatusIcon.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import { string } from 'prop-types';
+import styled, { keyframes } from 'styled-components';
+
+const Pulse = keyframes`
+  from {
+    -webkit-transform:scale(1);
+  }
+  to {
+    -webkit-transform:scale(0);
+  }
+`;
+
+const Wrapper = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  height: 14px;
+  margin: 5px 0;
+  width: 14px;
+`;
+
+const WhiteTop = styled.div`
+  border: 1px solid #b7b7b7;
+  border-bottom: 0;
+  background: #ffffff;
+`;
+
+const WhiteBottom = styled.div`
+  border: 1px solid #b7b7b7;
+  border-top: 0;
+  background: #ffffff;
+`;
+
+const RunningJob = styled(Wrapper)`
+  background-color: #5cb85c;
+  padding-right: 0px;
+  text-shadow: -1px -1px 0 #ffffff, 1px -1px 0 #ffffff, -1px 1px 0 #ffffff,
+    1px 1px 0 #ffffff;
+  animation: ${Pulse} 1.5s linear infinite alternate;
+`;
+
+const WaitingJob = styled(Wrapper)`
+  border: 1px solid #d7d7d7;
+`;
+
+const FinishedJob = styled(Wrapper)`
+  flex: 0 1 auto;
+  > * {
+    width: 14px;
+    height: 7px;
+  }
+`;
+
+const SuccessfulTop = styled.div`
+  background-color: #5cb85c;
+`;
+const SuccessfulBottom = styled(WhiteBottom)``;
+
+const FailedTop = styled(WhiteTop)``;
+const FailedBottom = styled.div`
+  background-color: #d9534f;
+`;
+
+const UnreachableTop = styled(WhiteTop)``;
+const UnreachableBottom = styled.div`
+  background-color: #ff0000;
+`;
+
+const ChangedTop = styled(WhiteTop)``;
+const ChangedBottom = styled.div`
+  background-color: #ff9900;
+`;
+
+const SkippedTop = styled(WhiteTop)``;
+const SkippedBottom = styled.div`
+  background-color: #2dbaba;
+`;
+
+const FinishedTop = styled(WhiteTop)``;
+const FinishedBottom = styled.div`
+  background-color: 'pink';
+`;
+
+const StatusIcon = ({ status, ...props }) => {
+    return (
+        <div { ...props }>
+            { status === 'running' && <RunningJob /> }
+            { (status === 'new' ||
+        status === 'pending' ||
+        status === 'waiting' ||
+        status === 'never updated') && <WaitingJob /> }
+            { (status === 'failed' || status === 'error' || status === 'canceled') && (
+                <FinishedJob>
+                    <FailedTop />
+                    <FailedBottom />
+                </FinishedJob>
+            ) }
+            { (status === 'successful' || status === 'ok') && (
+                <FinishedJob>
+                    <SuccessfulTop />
+                    <SuccessfulBottom />
+                </FinishedJob>
+            ) }
+            { status === 'changed' && (
+                <FinishedJob>
+                    <ChangedTop />
+                    <ChangedBottom />
+                </FinishedJob>
+            ) }
+            { status === 'skipped' && (
+                <FinishedJob>
+                    <SkippedTop />
+                    <SkippedBottom />
+                </FinishedJob>
+            ) }
+            { status === 'unreachable' && (
+                <FinishedJob>
+                    <UnreachableTop />
+                    <UnreachableBottom />
+                </FinishedJob>
+            ) }
+            { status === 'finished' && (
+                <FinishedJob>
+                    <FinishedTop />
+                    <FinishedBottom />
+                </FinishedJob>
+            ) }
+        </div>
+    );
+};
+
+StatusIcon.propTypes = {
+    status: string.isRequired
+};
+
+export default StatusIcon;

--- a/src/Icons/StatusIcon/StatusIcon.test.js
+++ b/src/Icons/StatusIcon/StatusIcon.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import StatusIcon from './StatusIcon';
+
+describe('StatusIcon', () => {
+    test('renders the successful status', () => {
+        const wrapper = mount(<StatusIcon status="successful" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SuccessfulTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SuccessfulBottom')).toHaveLength(1);
+    });
+    test('renders running status', () => {
+        const wrapper = mount(<StatusIcon status="running" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__RunningJob')).toHaveLength(1);
+    });
+    test('renders waiting status', () => {
+        const wrapper = mount(<StatusIcon status="waiting" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__WaitingJob')).toHaveLength(1);
+    });
+    test('renders failed status', () => {
+        const wrapper = mount(<StatusIcon status="failed" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__FailedTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__FailedBottom')).toHaveLength(1);
+    });
+    test('renders a successful status when host status is "ok"', () => {
+        const wrapper = mount(<StatusIcon status="ok" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SuccessfulTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SuccessfulBottom')).toHaveLength(1);
+    });
+    test('renders "failed" host status', () => {
+        const wrapper = mount(<StatusIcon status="failed" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__FailedTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__FailedBottom')).toHaveLength(1);
+    });
+    test('renders "changed" host status', () => {
+        const wrapper = mount(<StatusIcon status="changed" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__ChangedTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__ChangedBottom')).toHaveLength(1);
+    });
+    test('renders "skipped" host status', () => {
+        const wrapper = mount(<StatusIcon status="skipped" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SkippedTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__SkippedBottom')).toHaveLength(1);
+    });
+    test('renders "unreachable" host status', () => {
+        const wrapper = mount(<StatusIcon status="unreachable" />);
+        expect(wrapper).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__UnreachableTop')).toHaveLength(1);
+        expect(wrapper.find('StatusIcon__UnreachableBottom')).toHaveLength(1);
+    });
+});

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -83,7 +83,11 @@ export const Routes = (props) => {
             <InsightsRoute path={ Paths.automationCalculator } component={ AutomationCalculator } rootClass="automationCalculator"/>
             <InsightsRoute path={ Paths.jobExplorer } component={ JobExplorer } rootClass="jobExplorer"/>
             { /* Finally, catch all unmatched routes and redirect to Clusters page */ }
+<<<<<<< HEAD
             <Route render={ () => some(Paths, p => p === path) ? null : (<Redirect to={ Paths.clusters } />) } />
+=======
+            <InsightsRoute path={ () => some(Paths, p => p === path) ? null : (<Redirect to={ Paths.clusters }/>) }/>
+>>>>>>> Squashed commit of the following:
         </Switch>
     );
 };

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,5 +1,8 @@
+<<<<<<< HEAD
 /* eslint-disable camelcase */
 
+=======
+>>>>>>> Squashed commit of the following:
 export const jobExplorer = {
     attributes: [
         'id',
@@ -12,6 +15,7 @@ export const jobExplorer = {
         'cluster_name',
         'org_name',
         'most_failed_tasks'
+<<<<<<< HEAD
     ],
     defaultParams: {
         status: [ 'successful', 'failed' ],
@@ -32,3 +36,7 @@ export const toolbarCategories = [
     { name: 'Template', id: 6 },
     { name: 'Sort by', id: 7 }
 ];
+=======
+    ]
+};
+>>>>>>> Squashed commit of the following:

--- a/src/Utilities/formatQueryStrings.js
+++ b/src/Utilities/formatQueryStrings.js
@@ -96,6 +96,7 @@ export const formatQueryStrings = ({
             return sortBy
             .map(attr => {
 <<<<<<< HEAD
+<<<<<<< HEAD
                 return `sort_by=${encodeURIComponent(attr)}`;
             })
             .join('&');
@@ -103,6 +104,9 @@ export const formatQueryStrings = ({
             return `sort_by=${encodeURIComponent(sortBy)}`;
 =======
                 return `sort_by[]=${encodeURIComponent(attr)}`;
+=======
+                return `sort_by=${encodeURIComponent(attr)}`;
+>>>>>>> Add paginationParams to request URL for job explorer endpoint.
             })
             .join('&');
         } else {

--- a/src/Utilities/formatQueryStrings.js
+++ b/src/Utilities/formatQueryStrings.js
@@ -95,11 +95,19 @@ export const formatQueryStrings = ({
         if (Array.isArray(sortBy)) {
             return sortBy
             .map(attr => {
+<<<<<<< HEAD
                 return `sort_by=${encodeURIComponent(attr)}`;
             })
             .join('&');
         } else {
             return `sort_by=${encodeURIComponent(sortBy)}`;
+=======
+                return `sort_by[]=${encodeURIComponent(attr)}`;
+            })
+            .join('&');
+        } else {
+            return `sort_by[]=${encodeURIComponent(sortBy)}`;
+>>>>>>> Squashed commit of the following:
         }
     };
 

--- a/src/Utilities/formatQueryStrings.test.js
+++ b/src/Utilities/formatQueryStrings.test.js
@@ -9,6 +9,7 @@ const combined = {
     attributes: [ 'foo', 'bar' ],
     cluster_id: [ 'foo', 'bar' ],
     org_id: [ 'foo', 'bar' ],
+<<<<<<< HEAD
     template_id: [ 'foo', 'bar' ]
 };
 const expected = {
@@ -18,6 +19,19 @@ const expected = {
     cluster_id: 'cluster_id[]=foo&cluster_id[]=bar',
     org_id: 'org_id[]=foo&org_id[]=bar',
     template_id: 'template_id[]=foo&template_id[]=bar'
+=======
+    template_id: [ 'foo', 'bar' ],
+    sort_by: [ 'foo', 'bar' ]
+};
+const expected = {
+    status: 'status=foo&status=bar',
+    job_type: 'job_type=foo&job_type=bar',
+    attributes: 'attributes=foo&attributes=bar',
+    cluster_id: 'cluster_id=foo&cluster_id=bar',
+    org_id: 'org_id=foo&org_id=bar',
+    template_id: 'template_id=foo&template_id=bar',
+    sort_by: 'sort_by=foo&sort_by=bar'
+>>>>>>> Squashed commit of the following:
 };
 
 const combinedStrings = {
@@ -36,12 +50,21 @@ const combinedStrings = {
     only_root_workflows_and_standalone_jobs: 'baz'
 };
 const expectedStrings = {
+<<<<<<< HEAD
     status: 'status[]=baz',
     job_type: 'job_type[]=baz',
     attributes: 'attributes[]=baz',
     cluster_id: 'cluster_id[]=baz',
     org_id: 'org_id[]=baz',
     template_id: 'template_id[]=baz',
+=======
+    status: 'status=baz',
+    job_type: 'job_type=baz',
+    attributes: 'attributes=baz',
+    cluster_id: 'cluster_id=baz',
+    org_id: 'org_id=baz',
+    template_id: 'template_id=baz',
+>>>>>>> Squashed commit of the following:
     sort_by: 'sort_by=baz',
     limit: 'limit=baz',
     offset: 'offset=baz',
@@ -126,6 +149,14 @@ describe('Utilities/formatQueryStrings', () => {
         });
     });
     describe('parseSortBy method', () => {
+<<<<<<< HEAD
+=======
+        it('formats "sort_by" array as "sort_by=a&sort_by=b"', () => {
+            const { parseSortBy } = formatQueryStrings(combined);
+            const string = parseSortBy(combined.sort_by);
+            expect(string).toEqual(expected.sort_by);
+        });
+>>>>>>> Squashed commit of the following:
         it('formats "sort_by" string as "sort_by=a"', () => {
             const { parseSortBy } = formatQueryStrings(combinedStrings);
             const string = parseSortBy(combinedStrings.sort_by);

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -83,12 +83,20 @@ export const useQueryParams = initial => {
 
                 return { ...state, template_id: [ ...action.template ]};
             case 'SET_SORTBY':
+<<<<<<< HEAD
                 if (action.sortBy === null) {
+=======
+                if (action.sortBy.length <= 0) {
+>>>>>>> Squashed commit of the following:
                     const { sort_by: ignored, ...rest } = state;
                     return rest;
                 }
 
+<<<<<<< HEAD
                 return { ...state, sort_by: action.sortBy };
+=======
+                return { ...state, sort_by: [ ...action.sortBy ]};
+>>>>>>> Squashed commit of the following:
             case 'SET_ROOT_WORKFLOWS_AND_JOBS':
                 return { ...state, only_root_workflows_and_standalone_jobs: action.bool };
             case 'SET_QUICK_DATE_RANGE':
@@ -104,14 +112,22 @@ export const useQueryParams = initial => {
                     return rest;
                 }
 
+<<<<<<< HEAD
                 return { ...state, start_date: formatDate(action.date) };
+=======
+                return { ...state, start_date: action.date };
+>>>>>>> Squashed commit of the following:
             case 'SET_END_DATE':
                 if (action.date === null) {
                     const { end_date: ignored, ...rest } = state;
                     return rest;
                 }
 
+<<<<<<< HEAD
                 return { ...state, end_date: formatDate(action.date) };
+=======
+                return { ...state, end_date: action.date };
+>>>>>>> Squashed commit of the following:
             default:
                 throw new Error();
         }


### PR DESCRIPTION
This PR handles two TODOs from issue #238:

2. Update Pagination:
- Top of Job Explorer page should have the minimized pagination component.
- Bottom of Job Explorer page should have the default pagination component.
- Remove "Total Count" badge from the top header.

3. Update page header title to "Automation Analytics | Jobs explorer".