### PR TITLE
Fixes the date query error from the template modal to job exproler

### DIFF
--- a/src/Components/TemplatesList.js
+++ b/src/Components/TemplatesList.js
@@ -1,4 +1,4 @@
-/*eslint camelcase: ["error", {allow: ["template_id", "job_type", "cluster_id", "start_date", "end_date"]}]*/
+/*eslint camelcase: ["error", {allow: ["template_id", "job_type", "cluster_id", "start_date", "end_date", "quick_date_range"]}]*/
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { formatDateTime, formatSeconds, formatPercentage } from '../Utilities/helpers';
@@ -141,6 +141,7 @@ const TemplatesList = ({ history, clusterId, templates, isLoading, queryParams }
             job_type: [ 'job' ],
             start_date: queryParams.startDate,
             end_date: queryParams.endDate,
+            quick_date_range: 'custom',
             cluster_id: clusterId
         };
 


### PR DESCRIPTION
#261 

@kialam We need to pass the quick date selector field to the query for custom dates. First I wanted to change it up but it seems that in the job explorer it is used in the other way (so if a quick date is selected the start and end dates are nulled). Maybe we should consider preferring `start_date` and `end_date` fields over `quick_date_selector` field?

Otherwise, this pr fixes the issue from the templates modal.