### PR TITLE
Job Explorer UI Cleanup

### DIFF
--- a/src/Components/JobExplorerList.js
+++ b/src/Components/JobExplorerList.js
@@ -160,8 +160,8 @@ const AllJobsTemplate = ({ jobs }) => {
     const onResize = () => setWindowWidth(window.innerWidth);
 
     useEffect(() => {
-        window.addEventListener('resize', onResize());
-        return () => window.removeEventListener('resize', onResize());
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
     }, []);
 
     return buildListRow(jobs, 'All jobs view', 'all-jobs', windowWidth);
@@ -173,8 +173,8 @@ const JobExplorerList = ({ jobs }) => {
     const onResize = () => setWindowWidth(window.innerWidth);
 
     useEffect(() => {
-        window.addEventListener('resize', onResize());
-        return () => window.removeEventListener('resize', onResize());
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
     }, []);
 
     return (

--- a/src/Components/JobExplorerList.js
+++ b/src/Components/JobExplorerList.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+/* eslint-disable no-console */
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -7,12 +8,12 @@ import {
     DataListContent,
     DataList,
     DataListItem,
-    DataListItemRow,
-    DataListItemCells,
+    DataListItemRow as PFDataListItemRow,
+    DataListItemCells as PFDataListItemCells,
     DataListToggle
 } from '@patternfly/react-core';
 
-import { ArrowIcon as PFArrowIcon } from '@patternfly/react-icons';
+import { ExternalLinkAltIcon as PFExternalLinkIcon } from '@patternfly/react-icons';
 
 import LoadingState from '../Components/LoadingState';
 import { formatDateTime, formatJobType } from '../Utilities/helpers';
@@ -26,22 +27,40 @@ const headerLabels = [
     'Type'
 ];
 
-const ArrowIcon = styled(PFArrowIcon)`
+const ExternalLinkIcon = styled(PFExternalLinkIcon)`
   margin-left: 7px;
+  color: var(--pf-global--Color--400);
 `;
+
+const DataListItemCells = styled(PFDataListItemCells)`
+align-items: center;
+margin-top: 5px;
+`;
+
+const DataListItemRow = styled(PFDataListItemRow)`
+align-items: center; 
+`;
+
+const mobileBreakpoint = 765;
 
 const buildHeader = labels => (
     <DataListItemRow style={ { paddingLeft: '94px', fontWeight: '800' } }>
         { labels.map(label => (
-            <DataListCell key={ label }>{ label }</DataListCell>
+            <DataListCell key={ label }>
+                { label }
+                { label === 'Id/Name' &&
+                    <ExternalLinkIcon />
+                }
+            </DataListCell>
         )) }
     </DataListItemRow>
 );
 
-const buildListRow = (items, ariaLabel, ariaLabelledBy) => {
+const buildListRow = (items, ariaLabel, ariaLabelledBy, windowWidth) => {
     const [ isExpanded, setIsExpanded ] = useState([]);
+
     return (
-        <DataList aria-label={ ariaLabel }>
+        <DataList aria-label={ ariaLabel } isCompact>
             { items.map((item, count) => {
                 const toggle = id => {
                     const expanded = isExpanded;
@@ -69,17 +88,44 @@ const buildListRow = (items, ariaLabel, ariaLabelledBy) => {
                                 dataListCells={ [
                                     <DataListCell key={ count++ }>
                                         <a href={ item.id.tower_link } target='_blank' rel='noopener noreferrer'>
-                                            { `${item.id.id} - ${item.id.template_name}` } <ArrowIcon />
+                                            { windowWidth < mobileBreakpoint &&
+                                             <span style={ { color: 'initial', fontWeight: 'bold' } }>
+                                                 Id/Name<ExternalLinkIcon />:
+                                             </span>
+                                            }
+                                            &nbsp;
+                                            { `${item.id.id} - ${item.id.template_name}` }
                                         </a>
                                     </DataListCell>,
                                     <DataListCell key={ count++ }>
+
+                                        { windowWidth <= mobileBreakpoint &&
+                                            <span style={ { color: 'initial', fontWeight: 'bold' } }>Status:</span>
+                                        }
+                                            &nbsp;
                                         <JobStatus status={ item.status } />
                                     </DataListCell>,
                                     <DataListCell key={ count++ }>
+                                        { windowWidth <= mobileBreakpoint &&
+                                         <span style={ { color: 'initial', fontWeight: 'bold' } }>Cluster:</span>
+                                        }
+                                        &nbsp;
                                         { item.cluster_name }
                                     </DataListCell>,
-                                    <DataListCell key={ count++ }>{ item.org_name }</DataListCell>,
-                                    <DataListCell key={ count++ }>{ formatJobType(item.job_type) }</DataListCell>
+                                    <DataListCell key={ count++ }>
+                                        { windowWidth <= mobileBreakpoint &&
+                                         <span style={ { color: 'initial', fontWeight: 'bold' } }>Organization:</span>
+                                        }
+                                        &nbsp;
+                                        { item.org_name }
+                                    </DataListCell>,
+                                    <DataListCell key={ count++ }>
+                                        { windowWidth <= mobileBreakpoint &&
+                                         <span style={ { color: 'initial', fontWeight: 'bold' } }>Type:</span>
+                                        }
+                                         &nbsp;
+                                        { formatJobType(item.job_type) }
+                                    </DataListCell>
                                 ] }
                             />
                         </DataListItemRow>
@@ -110,25 +156,41 @@ const buildListRow = (items, ariaLabel, ariaLabelledBy) => {
 };
 
 const AllJobsTemplate = ({ jobs }) => {
-    return buildListRow(jobs, 'All jobs view', 'all-jobs');
+    const [ windowWidth, setWindowWidth ] = useState(window.innerWidth);
+
+    useEffect(() => {
+        return window.addEventListener('resize', () => setWindowWidth(window.innerWidth));
+    }, [ windowWidth ]);
+
+    return buildListRow(jobs, 'All jobs view', 'all-jobs', windowWidth);
 };
 
-const JobExplorerList = ({ jobs }) => (
-  <>
-    { jobs.length <= 0 && <LoadingState /> }
-    <>
-      { buildHeader(headerLabels) }
-      <AllJobsTemplate jobs={ jobs } />
+const JobExplorerList = ({ jobs }) => {
+    const [ windowWidth, setWindowWidth ] = useState(window.innerWidth);
+
+    useEffect(() => {
+        return window.addEventListener('resize', () => setWindowWidth(window.innerWidth));
+    }, [ windowWidth ]);
+
+    return (
+        <>
+        {jobs.length <= 0 && <LoadingState />}
+        <>
+        { windowWidth >= mobileBreakpoint && buildHeader(headerLabels) }
+        <AllJobsTemplate jobs={ jobs } windowWidth={ windowWidth }/>
+        </>
     </>
-  </>
-);
+    );
+};
 
 JobExplorerList.propTypes = {
-    jobs: PropTypes.array
+    jobs: PropTypes.array,
+    windowWidth: PropTypes.number
 };
 
 AllJobsTemplate.propTypes = {
-    jobs: PropTypes.array
+    jobs: PropTypes.array,
+    windowWidth: PropTypes.number
 };
 
 export default JobExplorerList;

--- a/src/Components/JobExplorerList.js
+++ b/src/Components/JobExplorerList.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -158,9 +157,12 @@ const buildListRow = (items, ariaLabel, ariaLabelledBy, windowWidth) => {
 const AllJobsTemplate = ({ jobs }) => {
     const [ windowWidth, setWindowWidth ] = useState(window.innerWidth);
 
+    const onResize = () => setWindowWidth(window.innerWidth);
+
     useEffect(() => {
-        return window.addEventListener('resize', () => setWindowWidth(window.innerWidth));
-    }, [ windowWidth ]);
+        window.addEventListener('resize', onResize());
+        return () => window.removeEventListener('resize', onResize());
+    }, []);
 
     return buildListRow(jobs, 'All jobs view', 'all-jobs', windowWidth);
 };
@@ -168,18 +170,21 @@ const AllJobsTemplate = ({ jobs }) => {
 const JobExplorerList = ({ jobs }) => {
     const [ windowWidth, setWindowWidth ] = useState(window.innerWidth);
 
+    const onResize = () => setWindowWidth(window.innerWidth);
+
     useEffect(() => {
-        return window.addEventListener('resize', () => setWindowWidth(window.innerWidth));
-    }, [ windowWidth ]);
+        window.addEventListener('resize', onResize());
+        return () => window.removeEventListener('resize', onResize());
+    }, []);
 
     return (
         <>
-        {jobs.length <= 0 && <LoadingState />}
-        <>
-        { windowWidth >= mobileBreakpoint && buildHeader(headerLabels) }
-        <AllJobsTemplate jobs={ jobs } windowWidth={ windowWidth }/>
+            {jobs.length <= 0 && <LoadingState />}
+            <>
+                { windowWidth >= mobileBreakpoint && buildHeader(headerLabels) }
+                <AllJobsTemplate jobs={ jobs } windowWidth={ windowWidth }/>
+            </>
         </>
-    </>
     );
 };
 

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -300,6 +300,10 @@ const FilterableToolbar = ({
                         selections={ passedFilters.org }
                         isExpanded={ orgIsExpanded }
                         placeholderText="Filter by organization"
+                        style={ {
+                            maxHeight: 500,
+                            overflow: 'auto'
+                        } }
                     >
                         { organizationIdMenuItems }
                     </Select>
@@ -323,6 +327,10 @@ const FilterableToolbar = ({
                         selections={ passedFilters.cluster }
                         isExpanded={ clusterIsExpanded }
                         placeholderText="Filter by cluster"
+                        style={ {
+                            maxHeight: 500,
+                            overflow: 'auto'
+                        } }
                     >
                         { clusterIdMenuItems }
                     </Select>
@@ -343,7 +351,7 @@ const FilterableToolbar = ({
                         } }
                         selections={ passedFilters.template }
                         isExpanded={ templateIsExpanded }
-                        placeholderText="Filter by template"
+                        placeholderText="Filter by template"z
                     >
                         { templateIdMenuItems }
                     </Select>

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -351,7 +351,7 @@ const FilterableToolbar = ({
                         } }
                         selections={ passedFilters.template }
                         isExpanded={ templateIsExpanded }
-                        placeholderText="Filter by template"z
+                        placeholderText="Filter by template"
                     >
                         { templateIdMenuItems }
                     </Select>

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -25,11 +25,10 @@ import {
 } from '@redhat-cloud-services/frontend-components';
 
 import {
-    Badge,
     Card,
     CardBody,
     CardHeader as PFCardHeader,
-    Pagination,
+    Pagination as PFPagination,
     PaginationVariant
 } from '@patternfly/react-core';
 
@@ -45,13 +44,14 @@ const CardHeader = styled(PFCardHeader)`
   }
 `;
 
-const TitleWithBadge = styled.div`
+const CompactPagination = styled(PFPagination)`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  margin: 0;
+`;
 
-  h2 {
-    margin-right: 10px;
-  }
+const Pagination = styled(PFPagination)`
+  margin-top: 20px;
 `;
 
 const perPageOptions = [
@@ -341,7 +341,7 @@ const JobExplorer = props => {
       Automation Analytics
             <span style={ { fontSize: '16px' } }>
                 { ' ' }
-                <span style={ { margin: '0 10px' } }>|</span> All Jobs
+                <span style={ { margin: '0 10px' } }>|</span> Jobs explorer
             </span>
         </span>
     );
@@ -376,12 +376,6 @@ const JobExplorer = props => {
           <Main>
               <Card>
                   <CardHeader>
-                      <TitleWithBadge>
-                          <h2>
-                              <strong>Total Jobs</strong>
-                          </h2>
-                          <Badge isRead>{ meta.count ? meta.count : 0 }</Badge>
-                      </TitleWithBadge>
                   </CardHeader>
                   <CardBody>
                       <FilterableToolbar
@@ -395,6 +389,22 @@ const JobExplorer = props => {
                           onDelete={ onDelete }
                           passedFilters={ filters }
                           handleFilters={ setFilters }
+                      />
+                      <CompactPagination
+                          itemCount={ meta.count ? meta.count : 0 }
+                          widgetId="pagination-options-menu-top"
+                          perPageOptions={ perPageOptions }
+                          perPage={ queryParams.limit }
+                          page={ currPage }
+                          variant={ PaginationVariant.bottom }
+                          dropDirection={ 'up' }
+                          onPerPageSelect={ (_event, perPage, page) => {
+                              handlePerPageSelect(perPage, page);
+                          } }
+                          onSetPage={ (_event, pageNumber) => {
+                              handleSetPage(pageNumber);
+                          } }
+                          isCompact
                       />
                       { apiError && <ApiErrorState message={ apiError } /> }
                       { !apiError && isLoading && <LoadingState /> }
@@ -435,3 +445,4 @@ JobExplorer.propTypes = {
 };
 
 export default JobExplorer;
+


### PR DESCRIPTION
This PR handles 4 TODOs from issue #238:

2. Update Pagination:
- Top of Job Explorer page should have the minimized pagination component.
- Bottom of Job Explorer page should have the default pagination component.
- Remove "Total Count" badge from the top header.

3. Update page header title to "Automation Analytics | Jobs explorer".

4. Use the compact version of the datalist component

- remove the header labels when the window size is mobile. 
- Add DataCell item labels when window size is mobile.

![Screen Shot 2020-08-17 at 3 50 31 PM](https://user-images.githubusercontent.com/32466511/90438511-129fae80-e0a2-11ea-9ee9-23e34cbf9157.png)

5. Handle long dropdown menus by setting a max-height and auto scroll.
before:
![Screen Shot 2020-08-17 at 4 05 37 PM](https://user-images.githubusercontent.com/32466511/90439586-c9505e80-e0a3-11ea-9a55-e1acd0864899.png)
after:
![Screen Shot 2020-08-17 at 4 04 31 PM](https://user-images.githubusercontent.com/32466511/90439591-cb1a2200-e0a3-11ea-8063-5a1e7719dd90.png)
