### PR TITLE
Fix: Grouped bar chart now redirects to the job expoler correctly

### DIFF
--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -212,6 +212,7 @@ class GroupedBarChart extends Component {
         const initialQueryParams = {
             start_date: formattedDate,
             end_date: formattedDate,
+            status: [ 'successful', 'failed', 'new', 'pending', 'waiting', 'error', 'canceled', 'running' ],
             quick_date_range: 'custom',
             org_id
         };


### PR DESCRIPTION
#266 