### PR TITLE
hide date selectors if not filtering by date

### DIFF
--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -187,8 +187,7 @@ const FilterableToolbar = ({
         ));
 
         let sortByMenuItems = [];
-        if (sortables !== null) {
-
+        if (Array.isArray(sortables)) {
             sortByMenuItems = sortables.map(({ key, value }) => (
                 <SelectOption key={ key } value={ key }>
                     { value }

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -76,7 +76,7 @@ export const handleChips = (item, comparator) => {
  */
 export const handleDateChips = (date, comparator) => {
     if (date === null || date === undefined || comparator === null || comparator === undefined) {
-        return new Array();
+        return [];
     }
 
     if (date && typeof date === 'string') {
@@ -88,11 +88,11 @@ export const handleDateChips = (date, comparator) => {
         });
 
         if (val !== undefined) {
-            return new Array(val);
+            return [val];
         }
     }
 
-    return new Array();
+    return [];
 };
 
 const FilterableToolbar = ({

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -88,7 +88,7 @@ export const handleDateChips = (date, comparator) => {
         });
 
         if (val !== undefined) {
-            return [val];
+            return [ val ];
         }
     }
 

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -52,23 +52,23 @@ const Switch = styled(PFSwitch)`
  * Get comparator values if their key is in the item list
  */
 export const handleChips = (item, comparator) => {
-    if (item === null || item === undefined || comparator === null || comparator === undefined) {
-        return [];
+    if (item && comparator) {
+        const result = item.reduce((acc, i) => {
+            Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
+
+            comparator.forEach(cmpItem => {
+                if (cmpItem.key === i) {
+                    acc.push(cmpItem.value);
+                }
+            });
+
+            return acc;
+        }, []);
+
+        return result;
     }
 
-    const result = item.reduce((acc, i) => {
-        Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
-
-        comparator.forEach(cmpItem => {
-            if (cmpItem.key === i) {
-                acc.push(cmpItem.value);
-            }
-        });
-
-        return acc;
-    }, []);
-
-    return result;
+    return [];
 };
 
 /**

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -62,7 +62,8 @@ const handleChips = (item, comparator) => {
 };
 
 const handleDateChips = (date, comparator) => {
-    if (date && typeof date === 'string') {
+    // comparator can not be null or forEach will throw an error
+    if (date && typeof date === 'string' && comparator !== null) {
         let val;
         comparator.forEach(i => {
             console.log(i);
@@ -177,16 +178,14 @@ const FilterableToolbar = ({
             </SelectOption>
         ));
 
-        // sortables must be a map'able object ...
-        if ( sortables === null ) {
-            sortables = [];
+        let sortByMenuItems = [];
+        if ( sortables !== null ) {
+            sortByMenuItems = sortables.map(({ key, value }) => (
+                <SelectOption key={ key } value={ key }>
+                    { value }
+                </SelectOption>
+            ));
         };
-
-        const sortByMenuItems = sortables.map(({ key, value }) => (
-            <SelectOption key={ key } value={ key }>
-                { value }
-            </SelectOption>
-        ));
 
         const dateRangeMenuItems = dateRanges.map(({ key, value }) => (
             <SelectOption key={ key } value={ key }>

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -75,11 +75,7 @@ export const handleChips = (item, comparator) => {
  * Convert a list of objects to a list of the last value if defined
  */
 export const handleDateChips = (date, comparator) => {
-    if (date === null || date === undefined || comparator === null || comparator === undefined) {
-        return [];
-    }
-
-    if (date && typeof date === 'string') {
+    if (date && typeof date === 'string' && comparator) {
         let val;
         comparator.forEach(i => {
             if (i.key === date) {

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -49,30 +49,39 @@ const Switch = styled(PFSwitch)`
     }
 `;
 
-const handleChips = (item, comparator) => {
-    return item.reduce((acc, i) => {
+/**
+ * Get comparator values if their key is in the item list
+ */
+export const handleChips = (item, comparator) => {
+    if (item === null && comparator == null) {
+        return new Array();
+    };
+    const result = item.reduce((acc, i) => {
         Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
-        comparator.forEach(item => {
-            if (item.key === i) {
-                acc.push(item.value);
+        comparator.forEach(cmpItem => {
+            if (cmpItem.key === i) {
+                acc.push(cmpItem.value);
             }
         });
         return acc;
     }, []);
+    return result;
 };
 
-const handleDateChips = (date, comparator) => {
-    // comparator can not be null or forEach will throw an error
+/**
+ * Convert a list of objects to a list of the last value if defined
+ */
+export const handleDateChips = (date, comparator) => {
+    console.log('date', date);
+    console.log('comparator', comparator);
     if (date && typeof date === 'string' && comparator !== null) {
         let val;
         comparator.forEach(i => {
-            console.log(i);
             if (i.key === date) {
                 val = i.value;
             }
         });
 
-        // ToolbarFilter errors out on [undefined]
         if (val !== undefined) {
             return new Array(val);
         }
@@ -102,6 +111,8 @@ const FilterableToolbar = ({
     const [ templateIsExpanded, setTemplateIsExpanded ] = useState(false);
     const [ sortByIsExpanded, setSortByIsExpanded ] = useState(false);
     const [ currentCategory, setCurrentCategory ] = useState('Status');
+
+    console.log('FTB dr', dateRanges);
 
     const handleStartDate = e => {
         handleFilters({

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -62,8 +62,6 @@ const handleChips = (item, comparator) => {
 };
 
 const handleDateChips = (date, comparator) => {
-    console.log('handleDateChips date', date);
-    console.log('handleDateChips comparator', comparator);
     if (date && typeof date === 'string') {
         let val;
         comparator.forEach(i => {
@@ -72,15 +70,14 @@ const handleDateChips = (date, comparator) => {
                 val = i.value;
             }
         });
-        console.log('handleDateChips return 1');
-        //return new Array(val);
-        //return {};
-        return {val};
+
+        // ToolbarFilter errors out on [undefined]
+        if (val !== undefined) {
+            return new Array(val);
+        }
     }
 
-    console.log('handleDateChips return 2');
-    //return new Array();
-    return {};
+    return new Array();
 };
 
 const FilterableToolbar = ({

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -53,7 +53,7 @@ const Switch = styled(PFSwitch)`
  * Get comparator values if their key is in the item list
  */
 export const handleChips = (item, comparator) => {
-    if (item === null && comparator == null) {
+    if (item === null || item === undefined || comparator === null || comparator === undefined) {
         return new Array();
     };
     const result = item.reduce((acc, i) => {
@@ -72,9 +72,10 @@ export const handleChips = (item, comparator) => {
  * Convert a list of objects to a list of the last value if defined
  */
 export const handleDateChips = (date, comparator) => {
-    console.log('date', date);
-    console.log('comparator', comparator);
-    if (date && typeof date === 'string' && comparator !== null) {
+    if (date === null || date === undefined || comparator === null || comparator === undefined) {
+        return new Array();
+    };
+    if (date && typeof date === 'string') {
         let val;
         comparator.forEach(i => {
             if (i.key === date) {
@@ -86,7 +87,6 @@ export const handleDateChips = (date, comparator) => {
             return new Array(val);
         }
     }
-
     return new Array();
 };
 
@@ -111,8 +111,6 @@ const FilterableToolbar = ({
     const [ templateIsExpanded, setTemplateIsExpanded ] = useState(false);
     const [ sortByIsExpanded, setSortByIsExpanded ] = useState(false);
     const [ currentCategory, setCurrentCategory ] = useState('Status');
-
-    console.log('FTB dr', dateRanges);
 
     const handleStartDate = e => {
         handleFilters({

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -1,3 +1,4 @@
+/*eslint-disable */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -61,17 +62,25 @@ const handleChips = (item, comparator) => {
 };
 
 const handleDateChips = (date, comparator) => {
+    console.log('handleDateChips date', date);
+    console.log('handleDateChips comparator', comparator);
     if (date && typeof date === 'string') {
         let val;
         comparator.forEach(i => {
+            console.log(i);
             if (i.key === date) {
                 val = i.value;
             }
         });
-        return new Array(val);
+        console.log('handleDateChips return 1');
+        //return new Array(val);
+        //return {};
+        return {val};
     }
 
-    return new Array();
+    console.log('handleDateChips return 2');
+    //return new Array();
+    return {};
 };
 
 const FilterableToolbar = ({
@@ -171,6 +180,11 @@ const FilterableToolbar = ({
             </SelectOption>
         ));
 
+        // sortables must be a map'able object ...
+        if ( sortables === null ) {
+            sortables = [];
+        };
+
         const sortByMenuItems = sortables.map(({ key, value }) => (
             <SelectOption key={ key } value={ key }>
                 { value }
@@ -257,6 +271,7 @@ const FilterableToolbar = ({
                     >
                         { dateRangeMenuItems }
                     </Select>
+
                 </ToolbarFilter>
                 <ToolbarFilter
                     showToolbarItem={ currentCategory === 'Job' }
@@ -383,42 +398,40 @@ const FilterableToolbar = ({
         >
             <ToolbarContent>
                 <ToolbarToggleGroup toggleIcon={ <FilterIcon /> } breakpoint="xl">
-                    { dateRanges.length > 0 && (
-                        <ToolbarGroup variant="filter-group">
-                            { buildCategoryDropdown(toolbarCategories) }
-                            { buildFilterDropdown() }
-                            { passedFilters.date === 'custom' && (
-                <>
-                  <InputGroup>
-                      <InputGroupText component="label" htmlFor="startDate">
-                          <CalendarAltIcon />
-                      </InputGroupText>
-                      <TextInput
-                          name="startDate"
-                          id="startDate"
-                          type="date"
-                          aria-label="Start Date"
-                          value={ passedFilters.startDate || '' }
-                          onChange={ e => handleStartDate(e) }
-                      />
-                  </InputGroup>
-                  <InputGroup>
-                      <InputGroupText component="label" htmlFor="endDate">
-                          <CalendarAltIcon />
-                      </InputGroupText>
-                      <TextInput
-                          name="endDate"
-                          id="endDate"
-                          type="date"
-                          aria-label="End Date"
-                          value={ passedFilters.endDate || '' }
-                          onChange={ e => handleEndDate(e) }
-                      />
-                  </InputGroup>
-                </>
-                            ) }
-                        </ToolbarGroup>
-                    ) }
+                    <ToolbarGroup variant="filter-group">
+                        { buildCategoryDropdown(toolbarCategories) }
+                        { buildFilterDropdown() }
+                        { ( currentCategory === 'Date' && passedFilters.date === 'custom' ) && (
+                            <>
+                              <InputGroup>
+                                  <InputGroupText component="label" htmlFor="startDate">
+                                      <CalendarAltIcon />
+                                  </InputGroupText>
+                                  <TextInput
+                                      name="startDate"
+                                      id="startDate"
+                                      type="date"
+                                      aria-label="Start Date"
+                                      value={ passedFilters.startDate || '' }
+                                      onChange={ e => handleStartDate(e) }
+                                  />
+                              </InputGroup>
+                              <InputGroup>
+                                  <InputGroupText component="label" htmlFor="endDate">
+                                      <CalendarAltIcon />
+                                  </InputGroupText>
+                                  <TextInput
+                                      name="endDate"
+                                      id="endDate"
+                                      type="date"
+                                      aria-label="End Date"
+                                      value={ passedFilters.endDate || '' }
+                                      onChange={ e => handleEndDate(e) }
+                                  />
+                              </InputGroup>
+                            </>
+                        )}
+                    </ToolbarGroup>
                 </ToolbarToggleGroup>
                 <div>
                     <Switch

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -53,7 +53,7 @@ const Switch = styled(PFSwitch)`
  */
 export const handleChips = (item, comparator) => {
     if (item && comparator) {
-        const result = item.reduce((acc, i) => {
+        return item.reduce((acc, i) => {
             Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
 
             comparator.forEach(cmpItem => {
@@ -64,8 +64,6 @@ export const handleChips = (item, comparator) => {
 
             return acc;
         }, []);
-
-        return result;
     }
 
     return [];

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -1,4 +1,3 @@
-/*eslint-disable */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -54,17 +53,21 @@ const Switch = styled(PFSwitch)`
  */
 export const handleChips = (item, comparator) => {
     if (item === null || item === undefined || comparator === null || comparator === undefined) {
-        return new Array();
-    };
+        return [];
+    }
+
     const result = item.reduce((acc, i) => {
         Number.isInteger(parseInt(i)) ? (i = parseInt(i)) : i;
+
         comparator.forEach(cmpItem => {
             if (cmpItem.key === i) {
                 acc.push(cmpItem.value);
             }
         });
+
         return acc;
     }, []);
+
     return result;
 };
 
@@ -74,7 +77,8 @@ export const handleChips = (item, comparator) => {
 export const handleDateChips = (date, comparator) => {
     if (date === null || date === undefined || comparator === null || comparator === undefined) {
         return new Array();
-    };
+    }
+
     if (date && typeof date === 'string') {
         let val;
         comparator.forEach(i => {
@@ -87,6 +91,7 @@ export const handleDateChips = (date, comparator) => {
             return new Array(val);
         }
     }
+
     return new Array();
 };
 
@@ -188,13 +193,14 @@ const FilterableToolbar = ({
         ));
 
         let sortByMenuItems = [];
-        if ( sortables !== null ) {
+        if (sortables !== null) {
+
             sortByMenuItems = sortables.map(({ key, value }) => (
                 <SelectOption key={ key } value={ key }>
                     { value }
                 </SelectOption>
             ));
-        };
+        }
 
         const dateRangeMenuItems = dateRanges.map(({ key, value }) => (
             <SelectOption key={ key } value={ key }>
@@ -406,7 +412,7 @@ const FilterableToolbar = ({
                     <ToolbarGroup variant="filter-group">
                         { buildCategoryDropdown(toolbarCategories) }
                         { buildFilterDropdown() }
-                        { ( currentCategory === 'Date' && passedFilters.date === 'custom' ) && (
+                        { (currentCategory === 'Date' && passedFilters.date === 'custom') && (
                             <>
                               <InputGroup>
                                   <InputGroupText component="label" htmlFor="startDate">
@@ -435,7 +441,7 @@ const FilterableToolbar = ({
                                   />
                               </InputGroup>
                             </>
-                        )}
+                        ) }
                     </ToolbarGroup>
                 </ToolbarToggleGroup>
                 <div>

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -69,7 +69,6 @@ describe('Components/Toolbar/handleDateChips', () => {
         const comparator = [{ }, { }];
         const expected = [];
         const result = handleDateChips(date, comparator);
-        console.log('result', result);
         expect(result).toEqual([]);
     });
     it('should accept a valid date param and a null comparator and return an empty array, not an array of undefined', () => {
@@ -77,7 +76,6 @@ describe('Components/Toolbar/handleDateChips', () => {
         const comparator = null;
         const expected = [];
         const result = handleDateChips(date, comparator);
-        console.log('result', result);
         expect(result).toEqual([]);
     });
 

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -67,14 +67,12 @@ describe('Components/Toolbar/handleDateChips', () => {
     it('should accept a valid date param and a comparator of empty objects and return an empty array, not an array of undefined', () => {
         const date = 'id:asc';
         const comparator = [{ }, { }];
-        const expected = [];
         const result = handleDateChips(date, comparator);
         expect(result).toEqual([]);
     });
     it('should accept a valid date param and a null comparator and return an empty array, not an array of undefined', () => {
         const date = 'id:asc';
         const comparator = null;
-        const expected = [];
         const result = handleDateChips(date, comparator);
         expect(result).toEqual([]);
     });

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -1,4 +1,3 @@
-import { mount, shallow } from 'enzyme';
 import FilterableToolbar from './Toolbar';
 import { handleChips } from './Toolbar';
 import { handleDateChips } from './Toolbar';
@@ -37,26 +36,49 @@ describe('Components/Toolbar/handleChips', () => {
 });
 
 describe('Components/Toolbar/handleDateChips', () => {
+    it('should accept two undefineds and return an empty array', () => {
+        const date = undefined;
+        const comparator = undefined;
+        const expected = [];
+        const result = handleDateChips(date, comparator);
+        expect(result).toEqual(expected);
+    });
     it('should accept two nulls and return an empty array', () => {
         const date = null;
         const comparator = null;
         const expected = [];
         const result = handleDateChips(date, comparator);
-        expect(result).toEqual(expect.arrayContaining(expected));
+        expect(result).toEqual(expected);
     });
     it('should accept a null date and return an empty array', () => {
         const date = null;
         const comparator = [{ key: 'id:asc', value: 'ID ascending' }];
         const expected = [];
         const result = handleDateChips(date, comparator);
-        expect(result).toEqual(expect.arrayContaining(expected));
+        expect(result).toEqual(expected);
     });
     it('should accept a valid date param and return a non-empty array', () => {
         const date = 'id:asc';
         const comparator = [{ key: 'id:asc', value: 'ID ascending' }, { key: 'id:desc', value: 'ID descending' }];
         const expected = [ 'ID ascending' ];
         const result = handleDateChips(date, comparator);
-        expect(result).toEqual(expect.arrayContaining(expected));
+        expect(result).toEqual(expected);
+    });
+    it('should accept a valid date param and a comparator of empty objects and return an empty array, not an array of undefined', () => {
+        const date = 'id:asc';
+        const comparator = [{ }, { }];
+        const expected = [];
+        const result = handleDateChips(date, comparator);
+        console.log('result', result);
+        expect(result).toEqual([]);
+    });
+    it('should accept a valid date param and a null comparator and return an empty array, not an array of undefined', () => {
+        const date = 'id:asc';
+        const comparator = null;
+        const expected = [];
+        const result = handleDateChips(date, comparator);
+        console.log('result', result);
+        expect(result).toEqual([]);
     });
 
 });

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -12,7 +12,7 @@ describe('Components/Toolbar/handleChips', () => {
         const result = handleChips(statusParam, statusesParam);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
-    it('should accept two empy arrays and return an empty array', () => {
+    it('should accept two empty arrays and return an empty array', () => {
         const statusParam = [];
         const statusesParam = [];
         const expected = [];
@@ -36,28 +36,42 @@ describe('Components/Toolbar/handleChips', () => {
 });
 
 describe('Components/Toolbar/handleDateChips', () => {
-    it('should accept two nulls and return an empty list', () => {
+    it('should accept two nulls and return an empty array', () => {
         const date = null;
         const comparator = null;
         const expected = new Array();
         const result = handleDateChips(date, comparator);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
-    it('should accept an null date and return an empty list', () => {
+    it('should accept a null date and return an empty array', () => {
         const date = null;
         const comparator = [{key: 'id:asc', value: 'ID ascending'}];
         const expected = new Array();
         const result = handleDateChips(date, comparator);
-        console.log(result);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
-    it('should accept an valid date param and return a non-empty list', () => {
+    it('should accept a valid date param and return a non-empty array', () => {
         const date = 'id:asc';
         const comparator = [{key: 'id:asc', value: 'ID ascending'}, {key: 'id:desc', value: 'ID descending'}];
         const expected = ['ID ascending'];
         const result = handleDateChips(date, comparator);
-        console.log(result);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
 
+});
+
+describe('Components/Toolbar/FilterableToolbar', () => {
+    it('should shallow mount', () => {
+        let wrapper = shallow(
+            <FilterableToolbar
+                orgs={[]}
+                statuses={[]}
+                types={[]}
+                clusters={[]}
+                templates={[]}
+                sortables={[]}
+                dateRanges={[]}
+                passedFilters={{ status: null }}
+            />);
+    });
 });

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -1,5 +1,4 @@
-/*eslint-disable */
-import { mount,shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import FilterableToolbar from './Toolbar';
 import { handleChips } from './Toolbar';
 import { handleDateChips } from './Toolbar';
@@ -23,15 +22,15 @@ describe('Components/Toolbar/handleChips', () => {
     });
     it('should accept empty status and non-empty stateues and return an empty array', () => {
         const statusParam = [];
-        const statusesParam = [{key: 1, value: 'template_name_0'}];
+        const statusesParam = [{ key: 1, value: 'template_name_0' }];
         const expected = [];
         const result = handleChips(statusParam, statusesParam);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
     it('should trim the statuses down to the value of the key given by status', () => {
-        const statusParam = [1];
-        const statusesParam = [{key: 1, value: 'template_name_0'}, {key: 2, value: 'template_name_2'}];
-        const expected = ['template_name_0'];
+        const statusParam = [ 1 ];
+        const statusesParam = [{ key: 1, value: 'template_name_0' }, { key: 2, value: 'template_name_2' }];
+        const expected = [ 'template_name_0' ];
         const result = handleChips(statusParam, statusesParam);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
@@ -47,15 +46,15 @@ describe('Components/Toolbar/handleDateChips', () => {
     });
     it('should accept a null date and return an empty array', () => {
         const date = null;
-        const comparator = [{key: 'id:asc', value: 'ID ascending'}];
+        const comparator = [{ key: 'id:asc', value: 'ID ascending' }];
         const expected = new Array();
         const result = handleDateChips(date, comparator);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
     it('should accept a valid date param and return a non-empty array', () => {
         const date = 'id:asc';
-        const comparator = [{key: 'id:asc', value: 'ID ascending'}, {key: 'id:desc', value: 'ID descending'}];
-        const expected = ['ID ascending'];
+        const comparator = [{ key: 'id:asc', value: 'ID ascending' }, { key: 'id:desc', value: 'ID descending' }];
+        const expected = [ 'ID ascending' ];
         const result = handleDateChips(date, comparator);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
@@ -66,47 +65,47 @@ describe('Components/Toolbar/FilterableToolbar', () => {
     it('should shallow mount', () => {
         let wrapper = shallow(
             <FilterableToolbar
-                orgs={[]}
-                statuses={[]}
-                types={[]}
-                clusters={[]}
-                templates={[]}
-                sortables={[]}
-                dateRanges={[]}
-                passedFilters={{ status: null }}
+                orgs={ [] }
+                statuses={ [] }
+                types={ [] }
+                clusters={ [] }
+                templates={ [] }
+                sortables={ [] }
+                dateRanges={ [] }
+                passedFilters={ { status: null } }
             />);
         expect(wrapper).toBeTruthy();
     });
     it('should only have 1 button (Status) when the dropdown is not activated', () => {
-        let wrapper = mount( 
+        let wrapper = mount(
             <FilterableToolbar
-                orgs={[]}
-                statuses={[]}
-                types={[]}
-                clusters={[]}
-                templates={[]}
-                sortables={[]}
-                dateRanges={[]}
-                passedFilters={{ status: null, date: null }}
+                orgs={ [] }
+                statuses={ [] }
+                types={ [] }
+                clusters={ [] }
+                templates={ [] }
+                sortables={ [] }
+                dateRanges={ [] }
+                passedFilters={ { status: null, date: null } }
             />);
-        const buttons = wrapper.find({className: "pf-c-dropdown__toggle"});
+        const buttons = wrapper.find({ className: 'pf-c-dropdown__toggle' });
         expect(buttons.length).toBe(1);
         const buttonTexts = buttons.map((b) => {
             return b.text().trim();
         });
-        expect(buttonTexts).toEqual(expect.arrayContaining(['Status']));
+        expect(buttonTexts).toEqual(expect.arrayContaining([ 'Status' ]));
     });
     it('should have the correct number of categories', () => {
-        let wrapper = mount( 
+        let wrapper = mount(
             <FilterableToolbar
-                orgs={[]}
-                statuses={[]}
-                types={[]}
-                clusters={[]}
-                templates={[]}
-                sortables={[]}
-                dateRanges={[]}
-                passedFilters={{ status: null, date: null }}
+                orgs={ [] }
+                statuses={ [] }
+                types={ [] }
+                clusters={ [] }
+                templates={ [] }
+                sortables={ [] }
+                dateRanges={ [] }
+                passedFilters={ { status: null, date: null } }
             />);
 
         const categories = wrapper.find(ToolbarFilter).map((x) => x.props().categoryName);

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -40,14 +40,14 @@ describe('Components/Toolbar/handleDateChips', () => {
     it('should accept two nulls and return an empty array', () => {
         const date = null;
         const comparator = null;
-        const expected = new Array();
+        const expected = [];
         const result = handleDateChips(date, comparator);
         expect(result).toEqual(expect.arrayContaining(expected));
     });
     it('should accept a null date and return an empty array', () => {
         const date = null;
         const comparator = [{ key: 'id:asc', value: 'ID ascending' }];
-        const expected = new Array();
+        const expected = [];
         const result = handleDateChips(date, comparator);
         expect(result).toEqual(expect.arrayContaining(expected));
     });

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -3,6 +3,8 @@ import { mount,shallow } from 'enzyme';
 import FilterableToolbar from './Toolbar';
 import { handleChips } from './Toolbar';
 import { handleDateChips } from './Toolbar';
+import { toolbarCategories } from '../Utilities/constants';
+import { ToolbarFilter } from '@patternfly/react-core';
 
 describe('Components/Toolbar/handleChips', () => {
     it('should accept two nulls and return an empty array', () => {
@@ -73,5 +75,42 @@ describe('Components/Toolbar/FilterableToolbar', () => {
                 dateRanges={[]}
                 passedFilters={{ status: null }}
             />);
+        expect(wrapper).toBeTruthy();
     });
+    it('should only have 1 button (Status) when the dropdown is not activated', () => {
+        let wrapper = mount( 
+            <FilterableToolbar
+                orgs={[]}
+                statuses={[]}
+                types={[]}
+                clusters={[]}
+                templates={[]}
+                sortables={[]}
+                dateRanges={[]}
+                passedFilters={{ status: null, date: null }}
+            />);
+        const buttons = wrapper.find({className: "pf-c-dropdown__toggle"});
+        expect(buttons.length).toBe(1);
+        const buttonTexts = buttons.map((b) => {
+            return b.text().trim();
+        });
+        expect(buttonTexts).toEqual(expect.arrayContaining(['Status']));
+    });
+    it('should have the correct number of categories', () => {
+        let wrapper = mount( 
+            <FilterableToolbar
+                orgs={[]}
+                statuses={[]}
+                types={[]}
+                clusters={[]}
+                templates={[]}
+                sortables={[]}
+                dateRanges={[]}
+                passedFilters={{ status: null, date: null }}
+            />);
+
+        const categories = wrapper.find(ToolbarFilter).map((x) => x.props().categoryName);
+        expect(categories.length).toBe(toolbarCategories.length);
+    });
+
 });

--- a/src/Components/Toolbar.test.js
+++ b/src/Components/Toolbar.test.js
@@ -1,0 +1,63 @@
+/*eslint-disable */
+import { mount,shallow } from 'enzyme';
+import FilterableToolbar from './Toolbar';
+import { handleChips } from './Toolbar';
+import { handleDateChips } from './Toolbar';
+
+describe('Components/Toolbar/handleChips', () => {
+    it('should accept two nulls and return an empty array', () => {
+        const statusParam = null;
+        const statusesParam = null;
+        const expected = [];
+        const result = handleChips(statusParam, statusesParam);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+    it('should accept two empy arrays and return an empty array', () => {
+        const statusParam = [];
+        const statusesParam = [];
+        const expected = [];
+        const result = handleChips(statusParam, statusesParam);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+    it('should accept empty status and non-empty stateues and return an empty array', () => {
+        const statusParam = [];
+        const statusesParam = [{key: 1, value: 'template_name_0'}];
+        const expected = [];
+        const result = handleChips(statusParam, statusesParam);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+    it('should trim the statuses down to the value of the key given by status', () => {
+        const statusParam = [1];
+        const statusesParam = [{key: 1, value: 'template_name_0'}, {key: 2, value: 'template_name_2'}];
+        const expected = ['template_name_0'];
+        const result = handleChips(statusParam, statusesParam);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+});
+
+describe('Components/Toolbar/handleDateChips', () => {
+    it('should accept two nulls and return an empty list', () => {
+        const date = null;
+        const comparator = null;
+        const expected = new Array();
+        const result = handleDateChips(date, comparator);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+    it('should accept an null date and return an empty list', () => {
+        const date = null;
+        const comparator = [{key: 'id:asc', value: 'ID ascending'}];
+        const expected = new Array();
+        const result = handleDateChips(date, comparator);
+        console.log(result);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+    it('should accept an valid date param and return a non-empty list', () => {
+        const date = 'id:asc';
+        const comparator = [{key: 'id:asc', value: 'ID ascending'}, {key: 'id:desc', value: 'ID descending'}];
+        const expected = ['ID ascending'];
+        const result = handleDateChips(date, comparator);
+        console.log(result);
+        expect(result).toEqual(expect.arrayContaining(expected));
+    });
+
+});


### PR DESCRIPTION
do not render the date selectors if Date is not the current selection category

Fixes https://github.com/RedHatInsights/tower-analytics-frontend/issues/262

TODO:
- [X]  figure out why sortables is being sent as null instead of a mapable object
- [X] check the apis for the components that are taking in data from handleChips and handleDataChips to see if they actually allow arrays
- [X] figure out if `dateRanges.length > 0` was actually useful for something
- [X] add comments to Toolbar.js
- [X] write tests
- [X] fix linting