### PR TITLE
UXD Audit: Charts

### DIFF
--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -48,6 +48,14 @@ class Tooltip {
         .attr('height', 20)
         .attr('width', 20)
         .attr('fill', '#393f44');
+        this.boundingBox = this.toolTipBase
+        .append('rect')
+        .attr('x', 10)
+        .attr('y', -23)
+        .attr('rx', 2)
+        .attr('height', 68)
+        .attr('width', this.boxWidth)
+        .attr('fill', '#393f44');
         this.date = this.toolTipBase
         .append('text')
         .attr('x', 20)
@@ -133,15 +141,18 @@ class Tooltip {
           adjustedWidth = this.boxWidth;
       }
 
+      this.boundingBox.attr('width', adjustedWidth);
       this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
       if (flipped) {
           this.toolTipPoint.attr('transform', 'translate(-20, 0) rotate(45)');
+          this.boundingBox.attr('x', -adjustedWidth - 20);
           this.jobs.attr('x', -this.jobsWidth - 20 - 7);
           this.orgName.attr('x', -adjustedWidth - 7);
           this.clickMore.attr('x', -adjustedWidth - 7);
           this.date.attr('x', -adjustedWidth - 7);
       } else {
           this.toolTipPoint.attr('transform', 'translate(10, 0) rotate(45)');
+          this.boundingBox.attr('x', 10);
           this.orgName.attr('x', 20);
           this.clickMore.attr('x', 20);
           this.jobs.attr('x', adjustedWidth / 2);

--- a/src/Charts/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart.js
@@ -48,14 +48,6 @@ class Tooltip {
         .attr('height', 20)
         .attr('width', 20)
         .attr('fill', '#393f44');
-        this.boundingBox = this.toolTipBase
-        .append('rect')
-        .attr('x', 10)
-        .attr('y', -23)
-        .attr('rx', 2)
-        .attr('height', 68)
-        .attr('width', this.boxWidth)
-        .attr('fill', '#393f44');
         this.date = this.toolTipBase
         .append('text')
         .attr('x', 20)
@@ -141,18 +133,15 @@ class Tooltip {
           adjustedWidth = this.boxWidth;
       }
 
-      this.boundingBox.attr('width', adjustedWidth);
       this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
       if (flipped) {
           this.toolTipPoint.attr('transform', 'translate(-20, 0) rotate(45)');
-          this.boundingBox.attr('x', -adjustedWidth - 20);
           this.jobs.attr('x', -this.jobsWidth - 20 - 7);
           this.orgName.attr('x', -adjustedWidth - 7);
           this.clickMore.attr('x', -adjustedWidth - 7);
           this.date.attr('x', -adjustedWidth - 7);
       } else {
           this.toolTipPoint.attr('transform', 'translate(10, 0) rotate(45)');
-          this.boundingBox.attr('x', 10);
           this.orgName.attr('x', 20);
           this.clickMore.attr('x', 20);
           this.jobs.attr('x', adjustedWidth / 2);

--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -281,7 +281,7 @@ class TopTemplatesSavings extends Component {
         .selectAll('text')
         .style('text-anchor', 'start')
         .attr('dx', '0.75em')
-        .attr('dy', -x.bandwidth() / 1.45 - 5)
+        .attr('dy', -x.bandwidth() / 1.45 - 8)
         .attr('transform', 'rotate(-90)');
 
         svg.selectAll('.x-axis line').attr('stroke', 'transparent');

--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -33,14 +33,6 @@ class Tooltip {
         .attr('height', 20)
         .attr('width', 20)
         .attr('fill', '#393f44');
-        this.boundingBox = this.toolTipBase
-        .append('rect')
-        .attr('x', 10)
-        .attr('y', -23)
-        .attr('rx', 2)
-        .attr('height', 92)
-        .attr('width', this.boxWidth)
-        .attr('fill', '#393f44');
         this.name = this.toolTipBase
         .append('text')
         .attr('fill', 'white')
@@ -128,18 +120,15 @@ class Tooltip {
             adjustedWidth = this.boxWidth;
         }
 
-        this.boundingBox.attr('width', adjustedWidth);
         this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
         if (flipped) {
             this.toolTipPoint.attr('transform', 'translate(-20, 15) rotate(45)');
-            this.boundingBox.attr('x', -adjustedWidth - 20);
             this.name.attr('x', -(toolTipWidth - 7));
             this.savings.attr('x', -(toolTipWidth - 7));
             this.manualCost.attr('x', -(toolTipWidth - 7));
             this.automationCost.attr('x', -(toolTipWidth - 7));
         } else {
             this.toolTipPoint.attr('transform', 'translate(10, 15) rotate(45)');
-            this.boundingBox.attr('x', 10);
             this.name.attr('x', 20);
             this.savings.attr('x', 20);
             this.manualCost.attr('x', 20);

--- a/src/Charts/ROITopTemplates.js
+++ b/src/Charts/ROITopTemplates.js
@@ -33,6 +33,14 @@ class Tooltip {
         .attr('height', 20)
         .attr('width', 20)
         .attr('fill', '#393f44');
+        this.boundingBox = this.toolTipBase
+        .append('rect')
+        .attr('x', 10)
+        .attr('y', -23)
+        .attr('rx', 2)
+        .attr('height', 92)
+        .attr('width', this.boxWidth)
+        .attr('fill', '#393f44');
         this.name = this.toolTipBase
         .append('text')
         .attr('fill', 'white')
@@ -120,15 +128,18 @@ class Tooltip {
             adjustedWidth = this.boxWidth;
         }
 
+        this.boundingBox.attr('width', adjustedWidth);
         this.toolTipBase.attr('transform', 'translate(' + x + ',' + y + ')');
         if (flipped) {
             this.toolTipPoint.attr('transform', 'translate(-20, 15) rotate(45)');
+            this.boundingBox.attr('x', -adjustedWidth - 20);
             this.name.attr('x', -(toolTipWidth - 7));
             this.savings.attr('x', -(toolTipWidth - 7));
             this.manualCost.attr('x', -(toolTipWidth - 7));
             this.automationCost.attr('x', -(toolTipWidth - 7));
         } else {
             this.toolTipPoint.attr('transform', 'translate(10, 15) rotate(45)');
+            this.boundingBox.attr('x', 10);
             this.name.attr('x', 20);
             this.savings.attr('x', 20);
             this.manualCost.attr('x', 20);

--- a/src/Utilities/Legend.js
+++ b/src/Utilities/Legend.js
@@ -14,7 +14,7 @@ const Container = styled.div`
 
 const LegendDetail = styled.div`
   display: flex;
-  padding: 5px 10px;
+  padding: 7.5px 15px;
   align-items: center;
   justify-content: space-between;
 `;
@@ -44,7 +44,7 @@ const Title = styled.span`
 `;
 
 const SubTitle = styled.span`
-    font-size: 12px;
+    font-size: 14px;
     margin-left: 20px;
 `;
 

--- a/src/Utilities/Legend.js
+++ b/src/Utilities/Legend.js
@@ -44,7 +44,7 @@ const Title = styled.span`
 `;
 
 const SubTitle = styled.span`
-    font-size: 14px;
+    font-size: 15px;
     margin-left: 20px;
 `;
 
@@ -78,7 +78,7 @@ class Legend extends Component {
                                 <Title>{ name }</Title>
                             </Wrapper>
                             { count && (
-                                <SubTitle>{ count }</SubTitle>
+                                <SubTitle>{ count }%</SubTitle>
                             ) }
                             { selected && (
                                 <Switch

--- a/src/Utilities/Tooltip.js
+++ b/src/Utilities/Tooltip.js
@@ -33,20 +33,20 @@ class Tooltip {
         .attr('height', 110)
         .attr('width', this.boxWidth)
         .attr('fill', '#393f44');
-        this.circleGreen = this.toolTipBase
+        this.circleSuccess = this.toolTipBase
         .append('circle')
         .attr('cx', 26)
         .attr('cy', 0)
-        .attr('r', 7)
+        .attr('r', 8)
         .attr('stroke', 'white')
-        .attr('fill', this.colors(1));
-        this.circleRed = this.toolTipBase
+        .attr('fill', 'white');
+        this.circleFail = this.toolTipBase
         .append('circle')
         .attr('cx', 26)
         .attr('cy', 26)
-        .attr('r', 7)
+        .attr('r', 8)
         .attr('stroke', 'white')
-        .attr('fill', this.colors(0));
+        .attr('fill', 'white');
         this.successText = this.toolTipBase
         .append('text')
         .attr('x', 43)
@@ -61,14 +61,20 @@ class Tooltip {
         .attr('font-size', 12)
         .attr('fill', 'white')
         .text('Failed');
-        this.icon = this.toolTipBase
+        this.successIcon = this.toolTipBase
         .append('text')
-        .attr('fill', 'white')
-        .attr('stroke', 'white')
-        .attr('x', 24)
-        .attr('y', 30)
-        .attr('font-size', 12)
-        .text('!');
+        .attr('class', 'fas fa-sm')
+        .attr('fill', this.colors(1))
+        .attr('x', 19)
+        .attr('y', 5)
+        .text('\uf058');
+        this.failedIcon = this.toolTipBase
+        .append('text')
+        .attr('class', 'fas fa-sm')
+        .attr('fill', 'red')
+        .attr('x', 19)
+        .attr('y', 31.5)
+        .text('\uf06a');
         this.jobs = this.toolTipBase
         .append('text')
         .attr('fill', 'white')
@@ -174,9 +180,10 @@ class Tooltip {
         if (flipped) {
             this.toolTipPoint.attr('transform', 'translate(-20, 0) rotate(45)');
             this.boundingBox.attr('x', -adjustedWidth - 20);
-            this.circleGreen.attr('cx', -adjustedWidth);
-            this.circleRed.attr('cx', -adjustedWidth);
-            this.icon.attr('x', -adjustedWidth - 2);
+            this.circleSuccess.attr('cx', -adjustedWidth);
+            this.circleFail.attr('cx', -adjustedWidth);
+            this.failedIcon.attr('x', -adjustedWidth - 7);
+            this.successIcon.attr('x', -adjustedWidth - 7);
             this.successText.attr('x', -adjustedWidth + 17);
             this.failText.attr('x', -adjustedWidth + 17);
             this.successful.attr('x', -this.successTextWidth - 20 - 12);
@@ -187,9 +194,10 @@ class Tooltip {
         } else {
             this.toolTipPoint.attr('transform', 'translate(10, 0) rotate(45)');
             this.boundingBox.attr('x', 10);
-            this.circleGreen.attr('cx', 26);
-            this.circleRed.attr('cx', 26);
-            this.icon.attr('x', 24);
+            this.circleSuccess.attr('cx', 26);
+            this.circleFail.attr('cx', 26);
+            this.failedIcon.attr('x', 19);
+            this.successIcon.attr('x', 19);
             this.successText.attr('x', 43);
             this.failText.attr('x', 43);
             this.successful.attr('x', (adjustedWidth - this.successTextWidth));

--- a/src/Utilities/Tooltip.js
+++ b/src/Utilities/Tooltip.js
@@ -71,9 +71,9 @@ class Tooltip {
         this.failedIcon = this.toolTipBase
         .append('text')
         .attr('class', 'fas fa-sm')
-        .attr('fill', 'red')
-        .attr('x', 19)
-        .attr('y', 31.5)
+        .attr('fill', this.colors(0))
+        .attr('x', 20)
+        .attr('y', 31)
         .text('\uf06a');
         this.jobs = this.toolTipBase
         .append('text')


### PR DESCRIPTION
This PR handles a few Chart related UXD Audit changes.

### Issue #283 (Make chart legend numbers larger for legibility)

Before: 
![image](https://user-images.githubusercontent.com/32466511/94464812-f3aa3700-018c-11eb-9e47-1bdceb450631.png)

Verification:
<img width="280" alt="Screen Shot 2020-09-28 at 1 21 39 PM" src="https://user-images.githubusercontent.com/32466511/94466875-1be76500-0190-11eb-8570-0a1c0e502e85.png">


### Issue #284 (Fix spacing of x-axis labels):

Before:
<img width="120" alt="Screen Shot 2020-09-28 at 2 15 00 PM" src="https://user-images.githubusercontent.com/32466511/94470225-5d2e4380-0195-11eb-86a2-4d1c2e534a98.png">

Verification:
<img width="273" alt="Screen Shot 2020-09-28 at 2 13 34 PM" src="https://user-images.githubusercontent.com/32466511/94470243-64555180-0195-11eb-8352-a950b9cacfa4.png">


### Issue #273 (Update chart tooltips):

Before:
<img width="186" alt="Screen Shot 2020-09-28 at 6 47 19 PM" src="https://user-images.githubusercontent.com/32466511/94493693-40a50200-01bb-11eb-99cc-e03176852399.png">

Verification:
<img width="215" alt="Screen Shot 2020-09-28 at 6 54 45 PM" src="https://user-images.githubusercontent.com/32466511/94494094-4c44f880-01bc-11eb-9e2d-2ec508642280.png">




