### PR TITLE
Add height and hidden overflow on templates dropdown.

### DIFF
--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -371,6 +371,7 @@ const FilterableToolbar = ({
                         selections={ passedFilters.template }
                         isExpanded={ templateIsExpanded }
                         placeholderText="Filter by template"
+                        style={ { overflow: 'auto', height: 500 } }
                     >
                         { templateIdMenuItems }
                     </Select>

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -371,7 +371,10 @@ const FilterableToolbar = ({
                         selections={ passedFilters.template }
                         isExpanded={ templateIsExpanded }
                         placeholderText="Filter by template"
-                        style={ { overflow: 'auto', height: 500 } }
+                        style={ {
+                            maxHeight: 500,
+                            overflow: 'auto'
+                        } }
                     >
                         { templateIdMenuItems }
                     </Select>

--- a/src/Components/Toolbar.js
+++ b/src/Components/Toolbar.js
@@ -14,7 +14,7 @@ import {
     ToolbarToggleGroup,
     ToolbarItem,
     ToolbarGroup as PFToolbarGroup,
-    Select,
+    Select as PFSelect,
     SelectOption,
     Switch as PFSwitch,
     Tooltip,
@@ -45,6 +45,13 @@ const ToolbarContent = styled(PFToolbarContent)`
 const Switch = styled(PFSwitch)`
     &&& {
         margin: 0 15px;
+    }
+`;
+
+const Select = styled(PFSelect)`
+    .pf-c-select__menu {
+        max-height: 500px;
+        overflow: auto;
     }
 `;
 
@@ -319,10 +326,6 @@ const FilterableToolbar = ({
                         selections={ passedFilters.org }
                         isExpanded={ orgIsExpanded }
                         placeholderText="Filter by organization"
-                        style={ {
-                            maxHeight: 500,
-                            overflow: 'auto'
-                        } }
                     >
                         { organizationIdMenuItems }
                     </Select>
@@ -346,10 +349,6 @@ const FilterableToolbar = ({
                         selections={ passedFilters.cluster }
                         isExpanded={ clusterIsExpanded }
                         placeholderText="Filter by cluster"
-                        style={ {
-                            maxHeight: 500,
-                            overflow: 'auto'
-                        } }
                     >
                         { clusterIdMenuItems }
                     </Select>
@@ -371,10 +370,6 @@ const FilterableToolbar = ({
                         selections={ passedFilters.template }
                         isExpanded={ templateIsExpanded }
                         placeholderText="Filter by template"
-                        style={ {
-                            maxHeight: 500,
-                            overflow: 'auto'
-                        } }
                     >
                         { templateIdMenuItems }
                     </Select>
@@ -385,7 +380,7 @@ const FilterableToolbar = ({
                     chips={ handleDateChips(passedFilters.sortby, sortables) }
                     deleteChip={ onDelete }
                 >
-                    <Select
+                    <PFSelect
                         isOpen={ sortByIsExpanded }
                         aria-label="Sort by"
                         variant={ 'single' }
@@ -400,7 +395,7 @@ const FilterableToolbar = ({
                         placeholderText="Sort by attribute"
                     >
                         { sortByMenuItems }
-                    </Select>
+                    </PFSelect>
                 </ToolbarFilter>
             </React.Fragment>
         );


### PR DESCRIPTION
This PR handles a TODO item from issue #238:

5. Handle long dropdown menus by setting a max-height and auto-scroll.
before:
![Screen Shot 2020-08-17 at 4 05 37 PM](https://user-images.githubusercontent.com/32466511/90439586-c9505e80-e0a3-11ea-9a55-e1acd0864899.png)
after:
![](http://g.recordit.co/UpQL7dEo9J.gif)
