### PR TITLE
Adjust left margin of datalist headers.

### DIFF
--- a/src/Components/JobExplorerList.js
+++ b/src/Components/JobExplorerList.js
@@ -50,7 +50,7 @@ align-items: center;
 const mobileBreakpoint = 765;
 
 const buildHeader = labels => (
-    <DataListItemRow style={ { paddingLeft: '94px', fontWeight: '800' } }>
+    <DataListItemRow style={ { paddingLeft: '80px', fontWeight: '800' } }>
         { labels.map(label => (
             <DataListCell key={ label }>
                 { label }


### PR DESCRIPTION
Addresses column headers from #238

Before:
<img width="967" alt="Screen Shot 2020-10-06 at 11 21 45 AM" src="https://user-images.githubusercontent.com/2293210/95222098-27591280-07c6-11eb-8860-21c35d6abf78.png">

After:
<img width="978" alt="Screen Shot 2020-10-06 at 11 21 20 AM" src="https://user-images.githubusercontent.com/2293210/95222125-2b853000-07c6-11eb-8d07-dfa5320be5f3.png">
