### PR TITLE
Notifications Page UXD Audit Changes

### DIFF
--- a/src/Components/NotificationsList.js
+++ b/src/Components/NotificationsList.js
@@ -27,6 +27,9 @@ const NotificationDrawerListItem = styled(PFNotificationDrawerListItem)`
   border-bottom::nth-child(odd): 1px solid var(--pf-global--BorderColor--light-100
     );
   box-shadow: none;
+  &:focus {
+    outline: none;
+  }
 `;
 
 const NotificationDrawerList = styled(PFNotificationDrawerList)`

--- a/src/Components/NotificationsList.js
+++ b/src/Components/NotificationsList.js
@@ -1,76 +1,136 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import moment from 'moment';
+
 import {
-    Alert,
-    AlertGroup,
-    AlertVariant
+    NotificationDrawerList as PFNotificationDrawerList,
+    NotificationDrawerListItem as PFNotificationDrawerListItem,
+    NotificationDrawerListItemBody,
+    NotificationDrawerListItemHeader
 } from '@patternfly/react-core';
-import { ArrowIcon as PFArrowIcon } from '@patternfly/react-icons';
+
+import { ExternalLinkAltIcon as PFExternalLinkAltIcon } from '@patternfly/react-icons';
 import LoadingState from '../Components/LoadingState';
 import { capitalize } from '../Utilities/helpers';
+import { stringify } from 'query-string';
 
-const ArrowIcon = styled(PFArrowIcon)`
+const ExternalLinkAltIcon = styled(PFExternalLinkAltIcon)`
   margin-left: 7px;
+  color: var(--pf-global--Color--400);
+  font-size: 14px;
 `;
+
+const NotificationDrawerListItem = styled(PFNotificationDrawerListItem)`
+  border-top: 1px solid var(--pf-global--BorderColor--light-100
+    );
+  border-bottom::nth-child(odd): 1px solid var(--pf-global--BorderColor--light-100
+    );
+  box-shadow: none;
+`;
+
+const NotificationDrawerList = styled(PFNotificationDrawerList)`
+    &:last-child {
+      border-bottom: 1px solid var(--pf-global--BorderColor--light-100
+        );
+    }
+`;
+
+const stringifyDate = (date) => {
+    const oneHour = 60 * 60 * 1000;
+    const now = moment().utc();
+
+    if (now.isAfter(moment(date))) {
+        return `${now.diff(moment(date), 'days')} day(s) ago.`;
+    }
+
+    if (moment(date).isSame(now, 'day')) {
+        if (moment(date).valueOf() > oneHour) {
+            return  `${now.diff(moment(date), 'hours')} hour(s) ago.`;
+        }
+
+        return `${now.diff(moment(date), 'minutes')} minute(s) ago.`;
+    }
+};
 
 const AllNotificationTemplate = ({ notifications }) =>
     notifications.map(
         ({ date, message, label, notification_id: id, tower_url: url }) => {
             if (label === '' || label === 'notice') {
                 return (
-                    <Alert
-                        title={ capitalize(label) }
-                        variant={ AlertVariant.default }
-                        isInline
+                    <NotificationDrawerListItem
+                        variant="info"
                         key={ date + '-' + id }
-                        style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
                     >
-                        { message }{ ' ' }
-                        { url ? (
-                            <a target="_blank" rel="noopener noreferrer" href={ url }>
-                                <ArrowIcon />
-                            </a>
-                        ) : null }
-                    </Alert>
+                        <NotificationDrawerListItemHeader
+                            variant="info"
+                            title={
+                            <>
+                              { url ? (
+                                  <a target="_blank" rel="noopener noreferrer" href={ url }>
+                                      { capitalize(label) }
+                                      <ExternalLinkAltIcon />
+                                  </a>
+                              ) : capitalize(label) }
+                            </>
+                            }
+                        />
+                        <NotificationDrawerListItemBody>
+                            { message }{ ' ' }
+                        </NotificationDrawerListItemBody>
+                    </NotificationDrawerListItem>
                 );
             }
 
             if (label === 'error') {
                 return (
-                    <Alert
-                        title={ capitalize(label) }
-                        variant={ AlertVariant.danger }
-                        isInline
+                    <NotificationDrawerListItem
+                        variant="danger"
                         key={ date + '-' + id }
-                        style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
                     >
-                        { message }{ ' ' }
-                        { url ? (
-                            <a target="_blank" rel="noopener noreferrer" href={ url }>
-                                <ArrowIcon />
-                            </a>
-                        ) : null }
-                    </Alert>
+                        <NotificationDrawerListItemHeader
+                            variant="danger"
+                            title={
+                            <>
+                              { url ? (
+                                  <a target="_blank" rel="noopener noreferrer" href={ url }>
+                                      { capitalize(label) }
+                                      <ExternalLinkAltIcon />
+                                  </a>
+                              ) : capitalize(label) }
+                            </>
+                            }
+                        />
+                        <NotificationDrawerListItemBody timestamp={ stringifyDate(date) }>
+                            { message }{ ' ' }
+                        </NotificationDrawerListItemBody>
+                    </NotificationDrawerListItem>
                 );
             }
 
             if (label === 'warning') {
                 return (
-                    <Alert
-                        title={ capitalize(label) }
-                        variant={ AlertVariant.warning }
-                        isInline
+                    <NotificationDrawerListItem
+                        variant="warning"
                         key={ date + '-' + id }
-                        style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
                     >
-                        { message }{ ' ' }
-                        { url ? (
-                            <a target="_blank" rel="noopener noreferrer" href={ url }>
-                                <ArrowIcon />
-                            </a>
-                        ) : null }
-                    </Alert>
+                        <NotificationDrawerListItemHeader
+                            variant="warning"
+                            title={
+                            <>
+                              { url ? (
+                                  <a target="_blank" rel="noopener noreferrer" href={ url }>
+                                      { capitalize(label) }
+                                      <ExternalLinkAltIcon />
+                                  </a>
+                              ) : capitalize(label) }
+                            </>
+                            }
+                        />
+                        <NotificationDrawerListItemBody timestamp={ stringifyDate(date) }>
+                            { message }{ ' ' }
+                        </NotificationDrawerListItemBody>
+                    </NotificationDrawerListItem>
                 );
             }
         }
@@ -80,63 +140,89 @@ const ErrorNotificationTemplate = ({ notifications }) =>
     notifications
     .filter(notification => notification.label === 'error')
     .map(({ message, date, label, notification_id: id, tower_url: url }) => (
-        <Alert
-            title={ capitalize(label) }
-            variant={ AlertVariant.danger }
-            isInline
+        <NotificationDrawerListItem
+            variant="danger"
             key={ date + '-' + id }
-            style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
         >
-            { message }{ ' ' }
-            { url ? (
-                <a target="_blank" rel="noopener noreferrer" href={ url }>
-                    <ArrowIcon />
-                </a>
-            ) : null }
-        </Alert>
+            <NotificationDrawerListItemHeader
+                variant="danger"
+                title={
+                <>
+                  { url ? (
+                      <a target="_blank" rel="noopener noreferrer" href={ url }>
+                          { capitalize(label) }
+                          <ExternalLinkAltIcon />
+                      </a>
+                  ) : capitalize(label) }
+                </>
+                }
+            >
+            </NotificationDrawerListItemHeader>
+            <NotificationDrawerListItemBody timestamp={ stringify(date) }>
+                { message }{ ' ' }
+            </NotificationDrawerListItemBody>
+        </NotificationDrawerListItem>
     ));
 
 const NoticeNotificationTemplate = ({ notifications }) =>
     notifications
     .filter(notification => notification.label === 'notice')
     .map(({ message, date, label, notification_id: id, tower_url: url }) => (
-        <Alert
-            title={ capitalize(label) }
-            variant={ AlertVariant.default }
-            isInline
+        <NotificationDrawerListItem
+            variant="info"
             key={ date + '-' + id }
-            style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
         >
-            { message }{ ' ' }
-            { url ? (
-                <a target="_blank" rel="noopener noreferrer" href={ url }>
-                    <ArrowIcon />
-                </a>
-            ) : null }
-        </Alert>
+            <NotificationDrawerListItemHeader
+                variant="info"
+                title={
+                <>
+                  { url ? (
+                      <a target="_blank" rel="noopener noreferrer" href={ url }>
+                          { capitalize(label) }
+                          <ExternalLinkAltIcon />
+                      </a>
+                  ) : capitalize(label) }
+                </>
+                }
+            >
+            </NotificationDrawerListItemHeader>
+            <NotificationDrawerListItemBody>
+                { message }{ ' ' }
+            </NotificationDrawerListItemBody>
+        </NotificationDrawerListItem>
     ));
 
 const WarningNotificationTemplate = ({ notifications }) =>
     notifications
     .filter(notification => notification.label === 'warning')
     .map(({ message, date, label, notification_id: id, tower_url: url }) => (
-        <Alert
-            title={ capitalize(label) }
-            variant={ AlertVariant.warning }
-            isInline
+        <NotificationDrawerListItem
+            variant="warning"
             key={ date + '-' + id }
-            style={ { marginTop: 'var(--pf-c-alert-group__item--MarginTop)' } }
         >
-            { message }{ ' ' }
-            <a target="_blank" rel="noopener noreferrer" href={ url }>
-                <ArrowIcon />
-            </a>
-        </Alert>
+            <NotificationDrawerListItemHeader
+                variant="warning"
+                title={
+                <>
+                  { url ? (
+                      <a target="_blank" rel="noopener noreferrer" href={ url }>
+                          { capitalize(label) }
+                          <ExternalLinkAltIcon />
+                      </a>
+                  ) : capitalize(label) }
+                </>
+                }
+            >
+            </NotificationDrawerListItemHeader>
+            <NotificationDrawerListItemBody>
+                { message }{ ' ' }
+            </NotificationDrawerListItemBody>
+        </NotificationDrawerListItem>
     ));
 
 const NotificationsList = ({ filterBy, notifications }) => (
   <>
-    <AlertGroup>
+    <NotificationDrawerList>
         { notifications.length <= 0 && <LoadingState /> }
         { filterBy === '' && (
             <AllNotificationTemplate notifications={ notifications } />
@@ -150,7 +236,7 @@ const NotificationsList = ({ filterBy, notifications }) => (
         { filterBy === 'warning' && (
             <WarningNotificationTemplate notifications={ notifications } />
         ) }
-    </AlertGroup>
+    </NotificationDrawerList>
   </>
 );
 

--- a/src/Components/NotificationsList.test.js
+++ b/src/Components/NotificationsList.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { mount } from 'enzyme';
 import NotificationsList from './NotificationsList/';
 
@@ -68,7 +67,6 @@ describe('Components/NotificationsList', () => {
             />
         );
         const notificationTemplate = wrapper.find('AllNotificationTemplate');
-        console.log(wrapper.debug());
         const alertItem = notificationTemplate.find(notificationDrawerListItem);
         expect(alertItem.length).toEqual(notifications.length);
     });

--- a/src/Components/NotificationsList.test.js
+++ b/src/Components/NotificationsList.test.js
@@ -1,9 +1,10 @@
+/* eslint-disable no-console */
 import { mount } from 'enzyme';
 import NotificationsList from './NotificationsList/';
-import { Alert } from '@patternfly/react-core';
 
 describe('Components/NotificationsList', () => {
     /*eslint camelcase: ["error", {properties: "never"}]*/
+    const notificationDrawerListItem = '.pf-c-notification-drawer__list-item';
     const notifications = [
         {
             date: '2019-04-30T15:06:40.995',
@@ -67,7 +68,8 @@ describe('Components/NotificationsList', () => {
             />
         );
         const notificationTemplate = wrapper.find('AllNotificationTemplate');
-        const alertItem = notificationTemplate.find(Alert);
+        console.log(wrapper.debug());
+        const alertItem = notificationTemplate.find(notificationDrawerListItem);
         expect(alertItem.length).toEqual(notifications.length);
     });
     it('ErrorNotificationsTemplate should render only error type notifications', () => {
@@ -81,7 +83,7 @@ describe('Components/NotificationsList', () => {
             />
         );
         const notificationTemplate = wrapper.find('ErrorNotificationTemplate');
-        const alertItem = notificationTemplate.find(Alert);
+        const alertItem = notificationTemplate.find(notificationDrawerListItem);
         expect(alertItem.length).toEqual(
             notifications.filter(notification => notification.label === 'error')
             .length
@@ -98,7 +100,7 @@ describe('Components/NotificationsList', () => {
             />
         );
         const notificationTemplate = wrapper.find('WarningNotificationTemplate');
-        const alertItem = notificationTemplate.find(Alert);
+        const alertItem = notificationTemplate.find(notificationDrawerListItem);
         expect(alertItem.length).toEqual(
             notifications.filter(notification => notification.label === 'warning')
             .length
@@ -115,7 +117,7 @@ describe('Components/NotificationsList', () => {
             />
         );
         const notificationTemplate = wrapper.find('NoticeNotificationTemplate');
-        const alertItem = notificationTemplate.find(Alert);
+        const alertItem = notificationTemplate.find(notificationDrawerListItem);
         expect(alertItem.length).toEqual(
             notifications.filter(notification => notification.label === 'notice')
             .length

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -290,13 +290,13 @@ const Notifications = () => {
                       { !isLoading && notificationsData.length <= 0 && <NoData /> }
                       { !isLoading && notificationsData.length > 0 && (
                   <>
-                  <NotificationDrawer>
-                      <NotificationsList
-                          filterBy={ queryParams.severity || '' }
-                          options={ notificationOptions }
-                          notifications={ notificationsData }
-                      />
-                  </NotificationDrawer>
+                    <NotificationDrawer>
+                        <NotificationsList
+                            filterBy={ queryParams.severity || '' }
+                            options={ notificationOptions }
+                            notifications={ notificationsData }
+                        />
+                    </NotificationDrawer>
                     <Pagination
                         itemCount={ meta.count ? meta.count : 0 }
                         widgetId="pagination-options-menu-bottom"

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -20,9 +20,9 @@ import {
     CardTitle as PFCardTitle,
     FormSelect,
     FormSelectOption,
-    Badge,
     Pagination,
-    PaginationVariant
+    PaginationVariant,
+    NotificationDrawer
 } from '@patternfly/react-core';
 
 import NotificationsList from '../../Components/NotificationsList';
@@ -33,15 +33,6 @@ const CardTitle = styled(PFCardTitle)`
 
   @media screen and (max-width: 1035px) {
     display: block;
-  }
-`;
-
-const TitleWithBadge = styled.div`
-  display: flex;
-  align-items: center;
-
-  h2 {
-    margin-right: 10px;
   }
 `;
 
@@ -234,12 +225,6 @@ const Notifications = () => {
           <Main>
               <Card>
                   <CardTitle>
-                      <TitleWithBadge>
-                          <h2>
-                              <strong>Notifications</strong>
-                          </h2>
-                          <Badge isRead>{ meta.count ? meta.count : 0 }</Badge>
-                      </TitleWithBadge>
                       <DropdownGroup>
                           <FormSelect
                               name="selectedCluster"
@@ -283,17 +268,35 @@ const Notifications = () => {
                               ) }
                           </FormSelect>
                       </DropdownGroup>
+                      <Pagination
+                          isCompact
+                          itemCount={ meta.count ? meta.count : 0 }
+                          widgetId="pagination-options-menu-bottom"
+                          perPageOptions={ perPageOptions }
+                          perPage={ queryParams.limit }
+                          page={ currPage }
+                          dropDirection={ 'up' }
+                          onPerPageSelect={ (_event, perPage, page) => {
+                              handlePerPageSelect(perPage, page);
+                          } }
+                          onSetPage={ (_event, pageNumber) => {
+                              handleSetPage(pageNumber);
+                          } }
+                          style={ { marginTop: '20px' } }
+                      />
                   </CardTitle>
                   <CardBody>
                       { isLoading && <LoadingState /> }
                       { !isLoading && notificationsData.length <= 0 && <NoData /> }
                       { !isLoading && notificationsData.length > 0 && (
                   <>
-                    <NotificationsList
-                        filterBy={ queryParams.severity || '' }
-                        options={ notificationOptions }
-                        notifications={ notificationsData }
-                    />
+                  <NotificationDrawer>
+                      <NotificationsList
+                          filterBy={ queryParams.severity || '' }
+                          options={ notificationOptions }
+                          notifications={ notificationsData }
+                      />
+                  </NotificationDrawer>
                     <Pagination
                         itemCount={ meta.count ? meta.count : 0 }
                         widgetId="pagination-options-menu-bottom"


### PR DESCRIPTION
This PR handles changes to the Notifications page as noted in issue #282.

PR Feedback 11/2/2020:
- [x] Update FE tests so they pass
- [x] Absctract out <NotificationDrawerListItem> into separate function ( Captured in this ticket: https://github.com/RedHatInsights/tower-analytics-frontend/issues/335)
- [x] Update FE tests to handle UXD Audit changes

**Before:**
<img width="1790" alt="Screen Shot 2020-10-26 at 1 20 06 PM" src="https://user-images.githubusercontent.com/32466511/97205822-57c11a80-178e-11eb-88b9-622806c1aa2e.png">

**Verification:** 
![MfYqHVLLdC](https://user-images.githubusercontent.com/32466511/97205836-60195580-178e-11eb-9464-c5f232d00051.gif)