### PR TITLE
Fixed console error about nesting h1 into h1 elements

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -144,12 +144,6 @@ const WrapperRight = styled.div`
   flex-direction: column;
 `;
 
-const title = (
-    <Title headingLevel="h1">
-        Automation Calculator
-    </Title>
-);
-
 /* helper variables for further date ranges */
 const pastYear = moment().subtract(1, 'year');
 const pastYTD = moment().startOf('year');
@@ -393,7 +387,7 @@ const AutomationCalculator = ({ history }) => {
     return (
     <>
       <PageHeader style={ { flex: '0' } }>
-          <PageHeaderTitle title={ title } />
+          <PageHeaderTitle title={ 'Automation Calculator' } />
       </PageHeader>
       { preflightError && (
           <Main>

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -25,8 +25,7 @@ import {
     CardBody,
     CardTitle as PFCardTitle,
     FormSelect,
-    FormSelectOption,
-    Title
+    FormSelectOption
 } from '@patternfly/react-core';
 
 import { FilterIcon } from '@patternfly/react-icons';
@@ -51,11 +50,6 @@ const CardTitle = styled(PFCardTitle)`
     }
   }
 `;
-const title = (
-    <Title headingLevel="h1">
-        Clusters
-    </Title>
-);
 
 const timeFrameOptions = [
     { value: 'please choose', label: 'Select date range', disabled: true },
@@ -143,7 +137,7 @@ const Clusters = ({ history }) => {
     return (
         <React.Fragment>
             <PageHeader>
-                <PageHeaderTitle title={ title } />
+                <PageHeaderTitle title={ 'Clusters' } />
             </PageHeader>
             { preflightError && (
                 <Main>

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -29,8 +29,7 @@ import {
     CardBody,
     CardHeader as PFCardHeader,
     Pagination as PFPagination,
-    PaginationVariant,
-    Title
+    PaginationVariant
 } from '@patternfly/react-core';
 
 import JobExplorerList from '../../Components/JobExplorerList';
@@ -174,12 +173,6 @@ const JobExplorer = props => {
         return offsetVal;
     };
 
-    const title = (
-        <Title headingLevel="h1">
-          Job Explorer
-        </Title>
-    );
-
     const handleSetPage = page => {
         const nextOffset = returnOffsetVal(page);
         setOffset(nextOffset);
@@ -196,7 +189,7 @@ const JobExplorer = props => {
     return (
         <React.Fragment>
             <PageHeader>
-                <PageHeaderTitle title={ title } />
+                <PageHeaderTitle title={ 'Job Explorer' } />
             </PageHeader>
 
             { preflightError && (

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -22,8 +22,7 @@ import {
     FormSelectOption,
     Badge,
     Pagination,
-    PaginationVariant,
-    Title
+    PaginationVariant
 } from '@patternfly/react-core';
 
 import NotificationsList from '../../Components/NotificationsList';
@@ -68,12 +67,6 @@ const DropdownGroup = styled.div`
     }
   }
 `;
-
-const title = (
-    <Title headingLevel="h1">
-        Notifications
-    </Title>
-);
 
 const notificationOptions = [
     {
@@ -219,7 +212,7 @@ const Notifications = () => {
     return (
         <React.Fragment>
             <PageHeader>
-                <PageHeaderTitle title={ title } />
+                <PageHeaderTitle title={ 'Notifications' } />
             </PageHeader>
             { preflightError && (
                 <Main>

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -22,8 +22,7 @@ import {
     CardBody,
     CardTitle as PFCardTitle,
     FormSelect,
-    FormSelectOption,
-    Title
+    FormSelectOption
 } from '@patternfly/react-core';
 
 import { FilterIcon } from '@patternfly/react-icons';
@@ -65,12 +64,6 @@ const CardContainer = styled.div`
 const TopCard = styled(Card)`
   min-height: 500px;
 `;
-
-const title = (
-    <Title headingLevel="h1">
-        Organization Statistics
-    </Title>
-);
 
 const timeFrameOptions = [
     { value: 'please choose', label: 'Select Date Range', disabled: true },
@@ -184,7 +177,7 @@ const OrganizationStatistics = () => {
     return (
         <React.Fragment>
             <PageHeader>
-                <PageHeaderTitle title={ title } />
+                <PageHeaderTitle title={ 'Organization Statistics' } />
             </PageHeader>
             { preflightError && (
                 <Main>


### PR DESCRIPTION
I missed this error while reviewing #336. 

The page title already has a <Title h1> element in it so passing it again makes it double nesting.

**Before**
![Screenshot from 2020-11-04 13-04-53](https://user-images.githubusercontent.com/8531681/98110109-e45e8d80-1e9e-11eb-9860-246545a68d5c.png)

Note the error in the console.

**After**
![Screenshot from 2020-11-04 13-07-32](https://user-images.githubusercontent.com/8531681/98110139-ed4f5f00-1e9e-11eb-8e84-4d79cd18b541.png)
