### PR TITLE
Fixed redirect problem: Converting url keys for queryParam to camelCase

### DIFF
--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
 import { formatQueryStrings } from '../../Utilities/formatQueryStrings';
+import { keysToCamel } from '../../Utilities/helpers';
 
 import styled from 'styled-components';
 import LoadingState from '../../Components/LoadingState';
@@ -71,7 +72,10 @@ const initialOptionsParams = {
     attributes: jobExplorer.attributes
 };
 
-const JobExplorer = props => {
+const JobExplorer = ({
+    location: { search },
+    history
+}) => {
     const [ preflightError, setPreFlightError ] = useState(null);
     const [ apiError, setApiError ] = useState(null);
     const [ jobExplorerData, setJobExplorerData ] = useState([]);
@@ -87,10 +91,9 @@ const JobExplorer = props => {
     const [ quickDateRanges, setQuickDateRanges ] = useState([]);
 
     const { parse } = formatQueryStrings({});
-    const {
-        location: { search }
-    } = props;
-    let initialSearchParams = parse(search, { arrayFormat: 'bracket' });
+    let initialSearchParams = keysToCamel(
+        parse(search, { arrayFormat: 'bracket' })
+    );
     let combined = { ...initialQueryParams, ...initialSearchParams };
     const {
         queryParams,
@@ -107,7 +110,7 @@ const JobExplorer = props => {
         const { jobExplorer } = Paths;
         const { strings, stringify } = formatQueryStrings(urlMappedQueryParams);
         const search = stringify(strings);
-        props.history.push({
+        history.push({
             pathname: jobExplorer,
             search
         });

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -134,3 +134,40 @@ export function formatJobDetailsURL(baseURL, jobId) {
     const subDirectory2 = 'details';
     return `${baseURL}/#/${subDirectory1}/${jobId}/${subDirectory2}/`;
 }
+
+/**
+ * Converts the string from kebab-case or snake_case to camelCase
+ */
+export const toCamelCase = s =>
+    s.replace(/([-_][a-z])/ig, ($1) => {
+        return $1.toUpperCase()
+        .replace('-', '')
+        .replace('_', '');
+    });
+
+/**
+ * Converts all keys recursively in a object to camelCase
+ */
+export const keysToCamel = o => {
+    // Shadowing 'o'.
+    const isObject = o => {
+        return o === Object(o) && !Array.isArray(o) && typeof o !== 'function';
+    };
+
+    if (isObject(o)) {
+        const n = {};
+
+        Object.keys(o)
+        .forEach((k) => {
+            n[toCamelCase(k)] = keysToCamel(o[k]);
+        });
+
+        return n;
+    } else if (Array.isArray(o)) {
+        return o.map(el => {
+            return keysToCamel(el);
+        });
+    }
+
+    return o;
+};

--- a/src/Utilities/helpers.test.js
+++ b/src/Utilities/helpers.test.js
@@ -14,6 +14,8 @@ import { convertMinsToSeconds } from './helpers.js';
 import { convertSecondsToHours } from './helpers.js';
 import { convertWithCommas } from './helpers.js';
 import { formatJobType } from './helpers.js';
+import { toCamelCase } from './helpers.js';
+import { keysToCamel } from './helpers.js';
 
 describe('Utilities/helpers/isNumeric', () => {
     it('validates 0', () => {
@@ -315,5 +317,29 @@ describe('Utilities/helpers/formatJobType', () => {
     });
     it('returns "Workflow job" for !"job"', () => {
         expect(formatJobType("foo")).toBe('Workflow job');
+    });
+});
+
+describe('Utilities/helpers/toCamelCase', () => {
+    it('returns snake_case string as camelCase', () => {
+        expect(toCamelCase("snake_cased_string")).toBe('snakeCasedString');
+    });
+});
+
+describe('Utilities/helpers/keysToCamel', () => {
+    it('returns snake_case keys as camelCased keys in an object', () => {
+        /* eslint-disable */
+        const initial = {
+            snake_cased: { second_case: []},
+            snake_cased_two: [],
+            snake_case_three: 1
+        };
+        /* eslint-enable */
+        const expected = {
+            snakeCased: { secondCase: []},
+            snakeCasedTwo: [],
+            snakeCaseThree: 1
+        };
+        expect(keysToCamel(initial)).toStrictEqual(expected);
     });
 });


### PR DESCRIPTION
The `queryParam` is camelCase now so we need to convert the URL parsed params to camel case also.