### PR TITLE
Added useApi hook to simplify fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1538,9 +1538,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -3312,6 +3312,33 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz",
+      "integrity": "sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/testing-library__react-hooks": "^3.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -3443,6 +3470,31 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz",
+      "integrity": "sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -3460,6 +3512,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
+      "integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
+      "dev": true,
+      "requires": {
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -6764,6 +6825,12 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -6780,9 +6847,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.0.1.tgz",
-      "integrity": "sha512-3xtQZ0YM65soLgKQUgn2wg2IbWsM6A2yBg6L4RF31mZHr5LNKdO2/9sgiwxEVMKu2C2m6+IQ75zHP41kZP5rPg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.1.0.tgz",
+      "integrity": "sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -9592,7 +9659,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
@@ -9616,7 +9684,8 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
@@ -9640,19 +9709,22 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
@@ -9783,7 +9855,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
@@ -9823,7 +9896,8 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
@@ -9947,7 +10021,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
@@ -10057,7 +10132,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
@@ -10170,13 +10246,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@redhat-cloud-services/frontend-components-config": "2.1.8",
+    "@testing-library/react-hooks": "^3.7.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -154,7 +154,7 @@ const JobExplorer = ({
                                 }
                                 hasSettings
                             />
-                            { error && <ApiErrorState message={ error } /> }
+                            { error && <ApiErrorState message={ error.error } /> }
                             { isLoading && <LoadingState /> }
                             { isSuccess && data.length <= 0 && <NoResults /> }
                             { isSuccess && data.length > 0 && <JobExplorerList jobs={ data } /> }

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { parse, stringify } from 'query-string';
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
+import useApi from '../../Utilities/useApi';
 import { Paths } from '../../paths';
 
 import LoadingState from '../../Components/LoadingState';
@@ -45,17 +46,24 @@ const initialQueryParams = {
     attributes: jobExplorer.attributes
 };
 
+const optionsMapper = options => {
+    const { groupBy, attributes, ...rest } = options;
+    return rest;
+};
+
 const JobExplorer = ({
     location: { search },
     history
 }) => {
     const [ preflightError, setPreFlightError ] = useState(null);
-    const [ apiError, setApiError ] = useState(null);
-    const [ isLoading, setIsLoading ] = useState(true);
-    const [ jobExplorerData, setJobExplorerData ] = useState([]);
-    const [ meta, setMeta ] = useState({});
+    const [{
+        isLoading,
+        isSuccess,
+        error,
+        data: { meta = {}, items: data = []}
+    }, setData ] = useApi({ meta: {}, items: []});
     const [ currPage, setCurrPage ] = useState(1);
-    const [ explorerOptions, setExplorerOptions ] = useState({});
+    const [ options, setOptions ] = useApi({}, optionsMapper);
 
     let initialSearchParams = parse(search, { arrayFormat: 'bracket', parseBooleans: true });
     let combined = { ...initialQueryParams, ...initialSearchParams };
@@ -87,32 +95,9 @@ const JobExplorer = ({
     }, []);
 
     useEffect(() => {
-        setApiError(null);
-        setIsLoading(true);
-        let didCancel = false;
-        window.insights.chrome.auth.getUser()
-        .then(() => {
-            Promise.all([
-                readJobExplorer({ params: queryParams }),
-                readJobExplorerOptions({ params: queryParams })
-            ]).then(([
-                { items: jobExplorerData = [], meta = {}},
-                options
-            ]) => {
-                if (didCancel) { return; }
-
-                setJobExplorerData(jobExplorerData);
-                setMeta(meta);
-
-                setExplorerOptions(options);
-            })
-            .catch(e => setApiError(e.error))
-            .finally(() => {
-                updateURL();
-                setIsLoading(false);
-            });
-        });
-        return () => didCancel = true;
+        setData(readJobExplorer({ params: queryParams }),);
+        setOptions(readJobExplorerOptions({ params: queryParams }));
+        updateURL();
     }, [ queryParams ]);
 
     const returnOffsetVal = page => (page - 1) * queryParams.limit;
@@ -131,7 +116,7 @@ const JobExplorer = ({
     };
 
     return (
-        <>
+        <React.Fragment>
             <PageHeader>
                 <PageHeaderTitle title={ 'Job Explorer' } />
             </PageHeader>
@@ -147,7 +132,7 @@ const JobExplorer = ({
                     <Card>
                         <CardBody>
                             <FilterableToolbar
-                                categories={ explorerOptions }
+                                categories={ options.data }
                                 filters={ queryParams }
                                 setFilters={ setFromToolbar }
                                 pagination={
@@ -169,10 +154,10 @@ const JobExplorer = ({
                                 }
                                 hasSettings
                             />
-                            { apiError && <ApiErrorState message={ apiError } /> }
-                            { !apiError && isLoading && <LoadingState /> }
-                            { !apiError && !isLoading && jobExplorerData.length <= 0 && <NoResults /> }
-                            { !apiError && !isLoading && jobExplorerData.length > 0 && (<JobExplorerList jobs={ jobExplorerData } />) }
+                            { error && <ApiErrorState message={ error } /> }
+                            { isLoading && <LoadingState /> }
+                            { isSuccess && data.length <= 0 && <NoResults /> }
+                            { isSuccess && data.length > 0 && <JobExplorerList jobs={ data } /> }
                             <Pagination
                                 itemCount={ meta && meta.count ? meta.count : 0 }
                                 widgetId="pagination-options-menu-bottom"
@@ -192,7 +177,7 @@ const JobExplorer = ({
                     </Card>
                 </Main>
             ) }
-        </>
+        </React.Fragment>
     );
 };
 

--- a/src/Utilities/useApi.js
+++ b/src/Utilities/useApi.js
@@ -30,7 +30,7 @@ const dataFetchReducer = (state, action) => {
 };
 
 const useApi = (initialData, postprocess = d => d) => {
-    const [ url, setUrl ] = useState(null);
+    const [ request, setRequest ] = useState(null);
 
     const [ state, dispatch ] = useReducer(dataFetchReducer, {
         isLoading: false,
@@ -41,7 +41,7 @@ const useApi = (initialData, postprocess = d => d) => {
 
     useEffect(() => {
         // Prevent fetching nothing
-        if (!url) {
+        if (!request) {
             return;
         }
 
@@ -50,7 +50,7 @@ const useApi = (initialData, postprocess = d => d) => {
         dispatch({ type: 'FETCH_INIT' });
 
         // Fetching
-        window.insights.chrome.auth.getUser().then(() => url.then(data => {
+        window.insights.chrome.auth.getUser().then(() => request.then(data => {
             if (!didCancel) {
                 dispatch({
                     type: 'FETCH_SUCCESS',
@@ -64,9 +64,9 @@ const useApi = (initialData, postprocess = d => d) => {
         }));
 
         return () => { didCancel = true; };
-    }, [ url ]);
+    }, [ request ]);
 
-    return [ state, setUrl ];
+    return [ state, setRequest ];
 };
 
 export default useApi;

--- a/src/Utilities/useApi.js
+++ b/src/Utilities/useApi.js
@@ -1,0 +1,74 @@
+import { useState, useEffect, useReducer } from 'react';
+
+const dataFetchReducer = (state, action) => {
+    switch (action.type) {
+        case 'FETCH_INIT':
+            return {
+                ...state,
+                isLoading: true,
+                isSuccess: false,
+                error: null
+            };
+        case 'FETCH_SUCCESS':
+            return {
+                ...state,
+                isLoading: false,
+                isSuccess: true,
+                error: null,
+                data: action.payload
+            };
+        case 'FETCH_FAILURE':
+            return {
+                ...state,
+                isLoading: false,
+                isSuccess: false,
+                error: action.payload
+            };
+        default:
+            throw new Error();
+    }
+};
+
+const useApi = (initialData, postprocess = d => d) => {
+    const [ url, setUrl ] = useState(null);
+
+    const [ state, dispatch ] = useReducer(dataFetchReducer, {
+        isLoading: false,
+        isSuccess: false,
+        error: null,
+        data: initialData
+    });
+
+    useEffect(() => {
+        // Prevent fetching nothing
+        if (!url) {
+            return;
+        }
+
+        // Initialize
+        let didCancel = false;
+        dispatch({ type: 'FETCH_INIT' });
+
+        // Fetching
+        window.insights.chrome.auth.getUser().then(() => Promise.all(
+            Array.isArray(url) ? url : [ url ]
+        ).then(data => {
+            if (!didCancel) {
+                dispatch({
+                    type: 'FETCH_SUCCESS',
+                    payload: postprocess(Array.isArray(url) ? data : data[0])
+                });
+            }
+        }).catch(e => {
+            if (!didCancel) {
+                dispatch({ type: 'FETCH_FAILURE', payload: e.error });
+            }
+        }));
+
+        return () => { didCancel = true; };
+    }, [ url ]);
+
+    return [ state, setUrl ];
+};
+
+export default useApi;

--- a/src/Utilities/useApi.js
+++ b/src/Utilities/useApi.js
@@ -50,13 +50,11 @@ const useApi = (initialData, postprocess = d => d) => {
         dispatch({ type: 'FETCH_INIT' });
 
         // Fetching
-        window.insights.chrome.auth.getUser().then(() => Promise.all(
-            Array.isArray(url) ? url : [ url ]
-        ).then(data => {
+        window.insights.chrome.auth.getUser().then(() => url.then(data => {
             if (!didCancel) {
                 dispatch({
                     type: 'FETCH_SUCCESS',
-                    payload: postprocess(Array.isArray(url) ? data : data[0])
+                    payload: postprocess(data)
                 });
             }
         }).catch(e => {

--- a/src/Utilities/useApi.js
+++ b/src/Utilities/useApi.js
@@ -59,7 +59,7 @@ const useApi = (initialData, postprocess = d => d) => {
             }
         }).catch(e => {
             if (!didCancel) {
-                dispatch({ type: 'FETCH_FAILURE', payload: e.error });
+                dispatch({ type: 'FETCH_FAILURE', payload: e });
             }
         }));
 

--- a/src/Utilities/useApi.test.js
+++ b/src/Utilities/useApi.test.js
@@ -71,7 +71,10 @@ describe('Utilities/useApi', () => {
 
         expect(data).toEqual({
             data: {},
-            error: 'Error',
+            error: {
+                error: 'Error',
+                status: 401
+            },
             isLoading: false,
             isSuccess: false
         });

--- a/src/Utilities/useApi.test.js
+++ b/src/Utilities/useApi.test.js
@@ -1,0 +1,114 @@
+import fetchMock from 'fetch-mock-jest';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
+import useApi from './useApi';
+
+const dummyUrl = 'https://www.test.com';
+
+const success = {
+    url: dummyUrl,
+    response: { msg: 'Success' }
+};
+
+const error = {
+    url: dummyUrl,
+    response: { throws: { status: 401, error: 'Error' }, status: 401 }
+};
+
+const fetchHandle = (url) => {
+    return fetch(url).then(response => response.json());
+};
+
+const mountHook = async (url, init) => {
+    const hookReturn = renderHook(() => useApi(init));
+
+    if (url !== null) {
+        act(() => {
+            hookReturn.result.current[1](url);
+        });
+        await hookReturn.waitForNextUpdate();
+    }
+
+    return hookReturn;
+};
+
+describe('Utilities/useApi', () => {
+    afterEach(() => {
+        fetchMock.restore();
+    });
+
+    it('should fetch null data', async () => {
+        const { result } = await mountHook(null, null);
+        const [ data ] = result.current;
+
+        expect(data).toEqual({
+            data: null,
+            error: null,
+            isLoading: false,
+            isSuccess: false
+        });
+    });
+
+    it('should fetch initial data', async () => {
+        fetchMock.get({ ...success });
+
+        const { result } = await mountHook(fetchHandle(dummyUrl), {});
+        const [ data ] = result.current;
+
+        expect(data).toEqual({
+            data: { msg: 'Success' },
+            error: null,
+            isLoading: false,
+            isSuccess: true
+        });
+    });
+
+    it('should fetch initial data with error', async () => {
+        fetchMock.get({ ...error });
+
+        const { result } = await mountHook(fetchHandle(dummyUrl), {});
+        const [ data ] = result.current;
+
+        expect(data).toEqual({
+            data: {},
+            error: 'Error',
+            isLoading: false,
+            isSuccess: false
+        });
+    });
+
+    it('should fetch on url change', async () => {
+        fetchMock.get({ ...success });
+
+        let { result, waitFor, waitForNextUpdate } = await mountHook(null, {});
+        // Expect initial state
+        expect(result.current[0]).toEqual({
+            data: {},
+            error: null,
+            isLoading: false,
+            isSuccess: false
+        });
+
+        // Fire a url change.
+        act(() => {
+            result.current[1](fetchHandle(dummyUrl));
+        });
+        await waitFor(() => result.current[0].isLoading === true);
+        // Expect loading state
+        expect(result.current[0]).toEqual({
+            data: {},
+            error: null,
+            isLoading: true,
+            isSuccess: false
+        });
+
+        await waitForNextUpdate();
+        // Expect success state
+        expect(result.current[0]).toEqual({
+            data: { msg: 'Success' },
+            error: null,
+            isLoading: false,
+            isSuccess: true
+        });
+    });
+});


### PR DESCRIPTION
@kialam It was a long time ago that we speak about this, but I had to made fetching research, and while at it I come up with this solution. (Now I understand why there were `ignore` at API fetching)

I think this hook could simplify fetching API. I can fetch one endpoint or multiple (`Promise.all`). It accepts a postprocessing function, allowing it to remap or modify data from API. It is also preventing memory leaks when the component is unmounted before API is fetched.

Returns and object with the following keys: 
* (bool) isLoading
* (string) errror - null if no error
* (bool) isSuccess - loaded without error --> this variable replaces the `!isLoading && !error`, making the code more readable.
* (object) data - the loaded data from the API

**Note**: Needed to update `JobExplorerList` component to use camelCase instead of snake_case, the `useApi` hook automatically converts the fetched data to it.

**New dev package**: https://react-hooks-testing-library.com/ for testing hooks (async hooks too ^^) with ease.

cc @benthomasson 