### PR TITLE
Push to all the betas from devel

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -2,12 +2,14 @@
 set -e
 set -x
 
-# If current dev branch is devel, push to build repo ci-beta
+# If current dev branch is devel, push to build repo ci-beta, qa-beta, and prod-beta
 if [ "${TRAVIS_BRANCH}" = "devel" ]; then
     .travis/release.sh "ci-beta"
+    .travis/release.sh "qa-beta"
+    .travis/release.sh "prod-beta"
 fi
 
 # If current dev branch is deployment branch, push to build repo
-if [[ "${TRAVIS_BRANCH}" = "ci-stable"  || "${TRAVIS_BRANCH}" = "qa-beta" || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-beta" ]]; then
+if [[ "${TRAVIS_BRANCH}" = "ci-stable"  || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-stable" || "${TRAVIS_BRANCH}" = "qaprodauth-beta" ]]; then
     .travis/release.sh "${TRAVIS_BRANCH}"
 fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/RedHatInsights/tower-analytics-frontend.svg?branch=master)](https://travis-ci.org/RedHatInsights/tower-analytics-frontend)
+[![Build Status](https://travis-ci.org/RedHatInsights/tower-analytics-frontend.svg?branch=devel)](https://travis-ci.org/RedHatInsights/tower-analytics-frontend)
 
 # Automation Analytics Front End
 
@@ -29,14 +29,14 @@ Automation Analytics provides data analytics for Ansible Tower that provides vis
 
 ### How it works
 
-- any push to the `{REPO}` `master` branch will deploy to a `{REPO}-build` `ci-beta` branch
+- any push to the `{REPO}` `devel` branch will deploy to a `{REPO}-build` `ci-beta` branch
 - any push to the `{REPO}` `ci-stable` branch will deploy to a `{REPO}-build` `ci-stable` branch
 - any push to the `{REPO}` `qa-beta` branch will deploy to a `{REPO}-build` `qa-beta` branch
 - any push to the `{REPO}` `qa-stable` branch will deploy to a `{REPO}-build` `qa-stable` branch
 - any push to the `{REPO}` `prod-beta` branch will deploy to a `{REPO}-build` `prod-beta` branch
 - any push to the `{REPO}` `prod-stable` branch will deploy to a `{REPO}-build` `prod-stable` branch
-- Pull requests (based on master) will not be pushed to `{REPO}-build` `master` branch
-  - If the PR is accepted and merged, master will be rebuilt and will deploy to `{REPO}-build` `ci-beta` branch
+- Pull requests (based on devel) will not be pushed to `{REPO}-build` `devel` branch
+  - If the PR is accepted and merged, devel will be rebuilt and will deploy to `{REPO}-build` `ci-beta` branch
 
 ## Running locally
 Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH


### PR DESCRIPTION
This change will push to all beta environments from devel.     This supports a faster beta feedback cycle but makes production-beta more unstable.   Users can always go to the non-beta production site if they want a stable version.


Please discuss pushing to all betas at the same time from devel.   Point out any problems like the left nav needing matching PRs.


