### PR TITLE
Tests: Updated the App tests to use the global insights object

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -12,8 +12,11 @@ global.React = React;
 // For page API
 global.insights = {
     chrome: {
+        on() {},
+        init() {},
+        identifyApp() {},
         auth: {
-            getUser: () => new Promise((resolve) => resolve(''))
+            getUser: () => new Promise((resolve) => resolve('bob'))
         },
         appNavClick: jest.fn()
     }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,36 +1,14 @@
-
-import { mount, shallow } from 'enzyme';
 import App from './App.js';
 import { Router } from 'react-router-dom';
-
-import configureStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
-
+import { mountPage } from './Containers/tests/helpers';
 import packageJson from '../package.json';
 
 describe('App', () => {
-    it('App loads', () => {
+    it('should have function', () => {
         expect(App).toBeTruthy();
     });
-    it('should render successfully', () => {
-        shallow(<App />);
-    });
+
     it('should return a div with a version attribute', () => {
-
-        // the insights object
-        const mockInsights = {
-            chrome: {
-                on() {},
-                init() {},
-                identifyApp() {},
-                auth: {
-                    getUser: () => {
-                        return 'bob';
-                    }
-                }
-            }
-        };
-
         const history = {
             listen() {
                 return { unlisten() {} };
@@ -46,16 +24,13 @@ describe('App', () => {
             }
         };
 
-        const mockStore = configureStore();
-        const store = mockStore({});
-        global.insights = mockInsights;
-        let wrapper = mount(
-            <Provider store={ store } >
-                <Router history={ history }>
-                    <App />
-                </Router>
-            </Provider>
+        const Component = () => (
+            <Router history={ history }>
+                <App />
+            </Router>
         );
+
+        const wrapper = mountPage(Component);
 
         let componentVersion = wrapper.find('#automation-analytics-application').props().version;
         expect(componentVersion).toBe(packageJson.version);


### PR DESCRIPTION
Removed the `App.test` mock of `insights`. We have it globaly set up. Let this test to use it as well. 