### PR TITLE
Disable camel case check

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -36,7 +36,7 @@ rules:
     - 2
     - after: true
   comma-style: 2
-  camelcase: 2
+  camelcase: off
   curly:
     - error
     - all


### PR DESCRIPTION
Since we have a convention of using snake case to match the attributes from the API turn off camel case checking.