### PR TITLE
Cypress testing: Changed env variable for baseURL

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,10 +2,12 @@
     "chromeWebSecurity": false,
     "waitForAnimations": true,
     "videoCompression": 0,
+    "viewportHeight": 2000,
+    "viewportWidth": 1600,
+    "baseUrl": "https://prod.foo.redhat.com:8443",
     "env": {
         "appid":"#automation-analytics-application",
-        "CLOUD_BASE_URL": "https://prod.foo.redhat.com:8443",
-        "CLOUD_USERNAME": "bob",
-        "CLOUD_PASSWORD": "redhat1234"
+        "USERNAME": "bob",
+        "PASSWORD": "redhat1234"
     }
 }

--- a/cypress/integration/AutomationCalculator.spec.js
+++ b/cypress/integration/AutomationCalculator.spec.js
@@ -1,61 +1,34 @@
-/* global cy, Cypress */
-const appid = Cypress.env('appid');
-const waitDuration = 1000;
-
-async function fuzzCalculatorPage() {
-
-    // try all time groupings ...
-    let timeGroups = [ 'Past month', 'Past quarter', 'Past year to date', 'Past year' ];
-    timeGroups.forEach((tg) => {
-        cy.get(appid).find('select[name="roiTimeFrame"]').eq(0).select(tg).wait(waitDuration);
-        cy.wait(waitDuration);
-    });
-
-    // hover over the first 3 bars to check for tooltips ...
-    for (let i = 0; i < 3; i++) {
-        cy.get(appid).find('g > rect').eq(i).trigger('mouseover', { force: true });
-        cy.wait(waitDuration);
-    }
-
-    // increment the manual and automated costs ...
-    cy.get(appid).find('#manual-cost').type('100');
-    cy.get(appid).find('#automation-cost').type('0');
-    cy.wait(waitDuration);
-
-    // template toggles have no unique IDs or elements yet that allow easy automated testing ...
-
-}
-
-beforeEach(() => {
-    // open the cloud landing page ...
-    cy.viewport(1600, 2000);
-    cy.getBaseUrl().then(url => cy.visit(url));
-
-    // sso login ...
-    cy.get('[data-ouia-component-id="1"]').click();
-    cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
-    cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
-});
+/* global cy, before */
+import {
+    appid,
+    calculatorUrl
+} from './constants';
 
 describe('Automation Caluclator page smoketests', () => {
-    it('can interact with the automation calculator page without breaking the UI', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-        cy.wait(waitDuration);
+    before(() => {
+        // open the cloud landing page ...
+        cy.visit('/');
 
-        cy.get('li[ouiaid="automation-analytics"] > section > ul > li > a').eq(4).each((href, hid) => {
-            cy.log('href', hid, href[0].pathname);
+        // sso login ...
+        cy.get('[data-ouia-component-id="1"]').click();
+        cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
+        cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
+        cy.visit(calculatorUrl);
+    });
 
-            cy.getBaseUrl().then(url => cy.visit(url + href[0].pathname));
-            cy.wait(waitDuration);
-            cy.clearFeatureDialogs();
+    it('can change manual and automated cost', () => {
+        cy.get('#manual-cost').type('1');
+        cy.get('#automation-cost').type('1');
 
-            const screenshotFilename = 'notifications.png';
-            cy.screenshot(screenshotFilename);
+        cy.get('#manual-cost').should('have.value', '501');
+        cy.get('#automation-cost').should('have.value', '201');
 
-            fuzzCalculatorPage();
-        });
+        // Maybe check the total cost after the chagne --> fixtures needed
+    });
 
+    it('can hover over the first 3 bars to show tooltip', () => {
+        for (let i = 0; i < 3; i++) {
+            cy.get(appid).find('g > rect').eq(i).trigger('mouseover', { force: true });
+        }
     });
 });

--- a/cypress/integration/Dashboard.spec.js
+++ b/cypress/integration/Dashboard.spec.js
@@ -4,17 +4,14 @@ import {
 } from './constants';
 
 const appid = Cypress.env('appid');
-const waitDuration = 1000;
 
 async function fuzzClustersPage() {
 
     // open each top template modal and save a screenshot ...
     for (let i = 0; i <= 4; i++) {
         cy.get(appid).find('a').eq(i).click({ waitForAnimations: true }).then(() => {
-            cy.wait(waitDuration);
             cy.screenshot('top-template-modal-' + i + '.png', { capture: 'fullPage' });
-            cy.get('button[aria-label="Close"]').click({ waitForAnimations: true }).wait(waitDuration);
-            cy.wait(waitDuration);
+            cy.get('button[aria-label="Close"]').click({ waitForAnimations: true });
         });
     }
 
@@ -27,7 +24,6 @@ async function fuzzClustersPage() {
 
         // click it and wait for the jobexplorer page to load ...
         cy.get(appid).find('rect').eq(barid).click({ waitForAnimations: true });
-        cy.wait(waitDuration * 2);
         cy.screenshot('clusters-bar-' + barid + '-jobexplorer-details.png', { capture: 'fullPage' });
 
         // go back to the clusters page ...

--- a/cypress/integration/Dashboard.spec.js
+++ b/cypress/integration/Dashboard.spec.js
@@ -1,4 +1,8 @@
-/* global cy, Cypress */
+/* global cy, Cypress, before */
+import {
+    dashboardUrl
+} from './constants';
+
 const appid = Cypress.env('appid');
 const waitDuration = 1000;
 
@@ -27,40 +31,24 @@ async function fuzzClustersPage() {
         cy.screenshot('clusters-bar-' + barid + '-jobexplorer-details.png', { capture: 'fullPage' });
 
         // go back to the clusters page ...
-        cy.getBaseUrl().then(url => {
-            cy.get('a[href="' + url + '/ansible/automation-analytics/clusters"]').first().click();
-            cy.wait(waitDuration);
-        });
+        cy.visit(dashboardUrl);
     }
 
 }
 
-beforeEach(() => {
-    // open the cloud landing page ...
-    cy.viewport(1600, 2000);
-    cy.getBaseUrl().then(url => cy.visit(url));
-
-    // sso login ...
-    cy.get('[data-ouia-component-id="1"]').click();
-    cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
-    cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
-});
-
 describe('Dashboard page smoketests', () => {
+    before(() => {
+        // open the cloud landing page ...
+        cy.visit('/');
+
+        // sso login ...
+        cy.get('[data-ouia-component-id="1"]').click();
+        cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
+        cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
+        cy.visit(dashboardUrl);
+    });
+
     it('can interact with the clusters page without breaking the UI', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-        cy.wait(waitDuration);
-
-        cy.get('li[ouiaid="automation-analytics"] > section > ul > li > a').first().each((href, hid) => {
-            cy.log('href', hid, href[0].pathname);
-
-            cy.getBaseUrl().then(url => cy.visit(url + href[0].pathname));
-            cy.wait(waitDuration);
-            cy.clearFeatureDialogs();
-
-            fuzzClustersPage();
-        });
+        fuzzClustersPage();
     });
 });

--- a/cypress/integration/Global.spec.js
+++ b/cypress/integration/Global.spec.js
@@ -1,58 +1,36 @@
-/* global cy */
-/*
- * Automation Analytics Smoketest.
- *
- * local usage: npm run integration
- * CI usage: npm run integration_headless
- *
- * Specify the baseurl and credentials before starting:
- *  export CYPRESS_CLOUD_BASE_URL="https://cloud.redhat.com"
- *  export CYPRESS_CLOUD_USERNAME="<your-username>"
- *  export CYPRESS_CLOUD_PASSWORD="<your-password>"
- *
- */
-const waitDuration = 1000;
-
-beforeEach(() => {
-    // open the cloud landing page ...
-    cy.viewport(1600, 2000);
-    cy.getBaseUrl().then(url => cy.visit(url));
-
-    // sso login ...
-    cy.get('[data-ouia-component-id="1"]').click();
-    cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
-    cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
-});
+/* global cy, before */
+import {
+    calculatorUrl,
+    jobExplorerUrl,
+    dashboardUrl,
+    notificationsUrl,
+    orgsUrl
+} from './constants';
 
 describe('automation analytics smoketests', () => {
+    before(() => {
+        // open the cloud landing page ...
+        cy.visit('/');
+
+        // sso login ...
+        cy.get('[data-ouia-component-id="1"]').click();
+        cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
+        cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
+    });
 
     it('has all the AA navigation items', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-        cy.wait(waitDuration);
-
+        cy.visit('/ansible/automation-analytics');
         const navbar = cy.get('li[ouiaid="automation-analytics"]');
         const navlis = navbar.find('li');
         navlis.should('have.length', 5);
     });
 
     it('can open each page without breaking the UI', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-        cy.wait(waitDuration);
-
-        cy.get('li[ouiaid="automation-analytics"] > section > ul > li > a').each((href, hid) => {
-            cy.log('href', hid, href[0].pathname);
-
-            cy.getBaseUrl().then(url => cy.visit(url + href[0].pathname));
-            cy.wait(waitDuration);
-            cy.clearFeatureDialogs();
-
-            const screenshotFilename = hid.toString() + '.png';
-            cy.screenshot(screenshotFilename);
-
-        });
+        cy.visit('/ansible/automation-analytics');
+        cy.visit(calculatorUrl);
+        cy.visit(jobExplorerUrl);
+        cy.visit(dashboardUrl);
+        cy.visit(notificationsUrl);
+        cy.visit(orgsUrl);
     });
 });

--- a/cypress/integration/Notifications.spec.js
+++ b/cypress/integration/Notifications.spec.js
@@ -4,7 +4,6 @@ import {
 } from './constants';
 
 const appid = Cypress.env('appid');
-const waitDuration = 1000;
 
 const getUniqueRandomNumbers = (upperBound, total, excluded) => {
     let randomIDS = [];
@@ -26,19 +25,18 @@ async function fuzzNotificationsPage() {
     selectedIDs.forEach((xid) => {
         cy.get(appid).find('select[name="selectedCluster"]').eq(0).then(($select) => {
             $select.find('option').eq(xid).each((ix, opt) => {
-                cy.get(appid).find('select[name="selectedCluster"]').eq(0).select(opt.innerHTML).wait(waitDuration);
+                cy.get(appid).find('select[name="selectedCluster"]').eq(0).select(opt.innerHTML);
             });
         });
     });
 
     // go back to all clusters ...
-    cy.get(appid).find('select[name="selectedCluster"]').eq(0).select('All Clusters').wait(waitDuration);
+    cy.get(appid).find('select[name="selectedCluster"]').eq(0).select('All Clusters');
 
     // try all message type filters ...
     let levels = [ 'View Critical', 'View Warning', 'View Notice', 'View All' ];
     levels.forEach((level) => {
-        cy.get(appid).find('select[name="selectedNotification"]').eq(0).select(level).wait(waitDuration);
-        cy.wait(waitDuration);
+        cy.get(appid).find('select[name="selectedNotification"]').eq(0).select(level);
     });
 
 }

--- a/cypress/integration/Notifications.spec.js
+++ b/cypress/integration/Notifications.spec.js
@@ -1,4 +1,8 @@
-/* global cy, Cypress */
+/* global cy, Cypress, before */
+import {
+    notificationsUrl
+} from './constants';
+
 const appid = Cypress.env('appid');
 const waitDuration = 1000;
 
@@ -39,33 +43,19 @@ async function fuzzNotificationsPage() {
 
 }
 
-beforeEach(() => {
-    // open the cloud landing page ...
-    cy.viewport(1600, 2000);
-    cy.getBaseUrl().then(url => cy.visit(url));
-
-    // sso login ...
-    cy.get('[data-ouia-component-id="1"]').click();
-    cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
-    cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
-});
-
 describe('Notification page smoketests', () => {
+    before(() => {
+        // open the cloud landing page ...
+        cy.visit('/');
+
+        // sso login ...
+        cy.get('[data-ouia-component-id="1"]').click();
+        cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
+        cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
+        cy.visit(notificationsUrl);
+    });
+
     it('can interact with the notifications page without breaking the UI', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-        cy.wait(waitDuration);
-
-        cy.get('li[ouiaid="automation-analytics"] > section > ul > li > a').eq(3).each((href, hid) => {
-            cy.log('href', hid, href[0].pathname);
-
-            cy.getBaseUrl().then(url => cy.visit(url + href[0].pathname));
-            cy.wait(waitDuration);
-            cy.clearFeatureDialogs();
-
-            fuzzNotificationsPage();
-        });
-
+        fuzzNotificationsPage();
     });
 });

--- a/cypress/integration/OrganizationStatistics.spec.js
+++ b/cypress/integration/OrganizationStatistics.spec.js
@@ -4,7 +4,6 @@ import {
 } from './constants';
 
 const appid = Cypress.env('appid');
-const waitDuration = 1000;
 
 const getUniqueRandomNumbers = (upperBound, total, excluded) => {
     let randomIDS = [];
@@ -28,13 +27,11 @@ async function fuzzOrgStatsPage() {
 
         // click on the rectangle ...
         cy.get(appid).find('rect').eq(xid).click({ force: true });
-        cy.wait(waitDuration);
 
         // go back to the stats page ...
         cy.getBaseUrl().then(url => {
             const statslink = cy.get('a[href="' + url + '/ansible/automation-analytics/organization-statistics"]');
             statslink.click();
-            cy.wait(waitDuration);
         });
     });
 
@@ -43,36 +40,29 @@ async function fuzzOrgStatsPage() {
         //toggle.click().wait(waitDuration);
         //toggle.click().wait(waitDuration);
         cy.get(appid).find('span[class="pf-c-switch__toggle"]').eq(ix).click();
-        cy.wait(waitDuration);
         cy.get(appid).find('span[class="pf-c-switch__toggle"]').eq(ix).click();
-        cy.wait(waitDuration);
-
     });
 
     // flip through each org grouping ...
     let orgGroups = [ 'All Orgs', 'Bottom 5 Orgs', 'Top 5 Orgs' ];
     orgGroups.forEach((group) => {
-        cy.get(appid).find('select[name="sortOrder"]').eq(0).select(group).wait(waitDuration);
-        cy.wait(waitDuration);
+        cy.get(appid).find('select[name="sortOrder"]').eq(0).select(group);
     });
 
     // flip through each time grouping ...
     let timeGroups = [ 'Past Week', 'Past 2 Weeks', 'Past Month' ];
     timeGroups.forEach((group) => {
-        cy.get(appid).find('select[name="timeframe"]').eq(0).select(group).wait(waitDuration);
-        cy.wait(waitDuration);
+        cy.get(appid).find('select[name="timeframe"]').eq(0).select(group);
     });
 
     // hover over each donut1 pie slice ...
     cy.get(appid).find('#d3-donut-1-chart-root > svg > g > path').each((slice, ix) => {
         cy.get(appid).find('#d3-donut-1-chart-root > svg > g > path').eq(ix).trigger('mouseover', { force: true });
-        cy.wait(waitDuration);
     });
 
     // hover over each donut2 pie slice ...
     cy.get(appid).find('#d3-donut-2-chart-root > svg > g > path').each((slice, ix) => {
         cy.get(appid).find('#d3-donut-2-chart-root > svg > g > path').eq(ix).trigger('mouseover', { force: true });
-        cy.wait(waitDuration);
     });
 
 }

--- a/cypress/integration/OrganizationStatistics.spec.js
+++ b/cypress/integration/OrganizationStatistics.spec.js
@@ -1,4 +1,8 @@
-/* global cy, Cypress */
+/* global cy, Cypress, before */
+import {
+    orgsUrl
+} from './constants';
+
 const appid = Cypress.env('appid');
 const waitDuration = 1000;
 
@@ -73,30 +77,19 @@ async function fuzzOrgStatsPage() {
 
 }
 
-beforeEach(() => {
-    // open the cloud landing page ...
-    cy.viewport(1600, 2000);
-    cy.getBaseUrl().then(url => cy.visit(url));
-
-    // sso login ...
-    cy.get('[data-ouia-component-id="1"]').click();
-    cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
-    cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
-});
-
 describe('Organization statistics page smoketests', () => {
+    before(() => {
+        // open the cloud landing page ...
+        cy.visit('/');
+
+        // sso login ...
+        cy.get('[data-ouia-component-id="1"]').click();
+        cy.getUsername().then(uname => cy.get('#username').type(`${uname}{enter}`));
+        cy.getPassword().then(password => cy.get('#password').type(`${password}{enter}`));
+        cy.visit(orgsUrl);
+    });
+
     it('can interact with the org stats page without breaking the UI', () => {
-        cy.getBaseUrl().then(url => cy.visit(url));
-        const aalink = cy.get('a[href="/ansible/automation-analytics"]').first();
-        aalink.click();
-
-        cy.get('li[ouiaid="automation-analytics"] > section > ul > li > a').eq(1).each((href, hid) => {
-            cy.log('href', hid, href[0].pathname);
-
-            cy.getBaseUrl().then(url => cy.visit(url + href[0].pathname));
-            cy.clearFeatureDialogs();
-
-            fuzzOrgStatsPage();
-        });
+        fuzzOrgStatsPage();
     });
 });

--- a/cypress/integration/constants.js
+++ b/cypress/integration/constants.js
@@ -1,0 +1,7 @@
+/* global Cypress */
+export const appid = Cypress.env('appid');
+export const calculatorUrl = '/ansible/automation-analytics/automation-calculator';
+export const jobExplorerUrl = '/ansible/automation-analytics/job-explorer';
+export const dashboardUrl = '/ansible/automation-analytics/clusters';
+export const notificationsUrl = '/ansible/automation-analytics/notifications';
+export const orgsUrl = '/ansible/automation-analytics/organization-statistics';

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,15 +26,15 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('getBaseUrl', () =>
-    Cypress.env('CLOUD_BASE_URL')
+    Cypress.env('baseUrl')
 );
 
 Cypress.Commands.add('getUsername', () =>
-    Cypress.env('CLOUD_USERNAME')
+    Cypress.env('USERNAME')
 );
 
 Cypress.Commands.add('getPassword', () =>
-    Cypress.env('CLOUD_PASSWORD')
+    Cypress.env('PASSWORD')
 );
 
 /*


### PR DESCRIPTION
For these changes we need to change the pipeline here: https://github.com/RedHatInsights/analytics-pipeline

## Env variable renames
Renamed:
* `CLOUD_PASSWORD --> PASSWORD` 
* `CLOUD_USERNAME --> USERNAME` 
* `CLOUD_BASE_URL --> BASE_URL`
 
Also, the base URL is now set in the `cypress.json` making running server checks available.  The `baseURL` is a standard convention in cypress and it is best practice to have it set up. Allows using visit, without specifying the base URL part all the time.

So instead of: `cy.visit('https://localhost:8000/index')` we can use just `cy.visit('/index')`.

## Additional global settings:
Added `viewport` to the config file. This sets the default viewport for all tests. If it is needed it can be overwritten with `cy.viewport(x, y)` from withing the tests.

## Removed waits:
In cypress, waits are [anti-pattern](https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-Waiting). If needed we can increase timeouts for various events in the config:
https://docs.cypress.io/guides/references/configuration.html#Timeouts 