### PR TITLE
'View All' Bugfix on Notifications page

### DIFF
--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -28,12 +28,13 @@ export const useQueryParams = initial => {
                 return { ...state, limit: parseInt(value.limit) };
             /* v1 api reducers */
             case 'SET_OFFSET':
-            case 'SET_SEVERITY': {
-                const { severity: ignored, ...rest } = state;
-                if (value.severity === '') { return rest; }
-            }
+            case 'SET_SEVERITY':
+                if (value.severity === '') {
+                    const { severity: ignored, ...rest } = state;
+                    return rest;
+                }
 
-            // eslint-disable-next-line no-fallthrough
+                return { ...state, ...value };
             case 'SET_ATTRIBUTES':
             case 'SET_JOB_TYPE':
             case 'SET_STATUS':

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -27,13 +27,6 @@ export const useQueryParams = initial => {
                 return { ...state, limit: parseInt(value.limit) };
             /* v1 api reducers */
             case 'SET_OFFSET':
-            case 'SET_SEVERITY':
-                if (value.severity === '') {
-                    const { severity: ignored, ...rest } = state;
-                    return rest;
-                }
-
-                return { ...state, ...value };
             case 'SET_ATTRIBUTES':
             case 'SET_JOB_TYPE':
             case 'SET_STATUS':
@@ -53,6 +46,13 @@ export const useQueryParams = initial => {
                 return newState;
             }
 
+            case 'SET_SEVERITY':
+                if (value.severity === '') {
+                    const { severity: ignored, ...rest } = state;
+                    return rest;
+                }
+
+                return { ...state, ...value };
             case 'SET_START_DATE':
             case 'SET_END_DATE': {
                 let newValues = {};

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useReducer } from 'react';
 import moment from 'moment';
 
@@ -27,7 +28,12 @@ export const useQueryParams = initial => {
                 return { ...state, limit: parseInt(value.limit) };
             /* v1 api reducers */
             case 'SET_OFFSET':
-            case 'SET_SEVERITY':
+            case 'SET_SEVERITY': {
+                const { severity: ignored, ...rest } = state;
+                if (value.severity === '') { return rest; }
+            }
+
+            // eslint-disable-next-line no-fallthrough
             case 'SET_ATTRIBUTES':
             case 'SET_JOB_TYPE':
             case 'SET_STATUS':
@@ -94,7 +100,9 @@ export const useQueryParams = initial => {
         dispatch,
         setLimit: limit => dispatch({ type: 'SET_LIMIT', value: { limit }}),
         setOffset: offset => dispatch({ type: 'SET_OFFSET', value: { offset }}),
-        setSeverity: severity => dispatch({ type: 'SET_SEVERITY', value: { severity }}),
+        setSeverity: (severity) => {
+            dispatch({ type: 'SET_SEVERITY', value: { severity }});
+        },
         setFromToolbar: (varName, value = null) => {
             if (!varName) {
                 dispatch({ type: 'RESET_FILTER' });

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useReducer } from 'react';
 import moment from 'moment';
 
@@ -101,9 +100,7 @@ export const useQueryParams = initial => {
         dispatch,
         setLimit: limit => dispatch({ type: 'SET_LIMIT', value: { limit }}),
         setOffset: offset => dispatch({ type: 'SET_OFFSET', value: { offset }}),
-        setSeverity: (severity) => {
-            dispatch({ type: 'SET_SEVERITY', value: { severity }});
-        },
+        setSeverity: severity => dispatch({ type: 'SET_SEVERITY', value: { severity }}),
         setFromToolbar: (varName, value = null) => {
             if (!varName) {
                 dispatch({ type: 'RESET_FILTER' });


### PR DESCRIPTION
### Verification
This PR addresses a bug in prod on the Notifications page that causes an empty query string to be sent to the Notifications endpoint on the selection of the 'View All' filter. 

**Before:**
![DMG1fsE3SY](https://user-images.githubusercontent.com/32466511/105775018-18909a00-5f34-11eb-95c8-9cc77dd0ddf0.gif)


**After:**
![GFE0niCKt2](https://user-images.githubusercontent.com/32466511/105774988-057dca00-5f34-11eb-90de-493142b86653.gif)


Jira Issue: https://issues.redhat.com/browse/AA-238