### PR TITLE
Added switches back to the top templates on the roi page

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -60,8 +60,11 @@ const mapApi = ({ items = []}) =>
         delta: 0,
         avgRunTime: 3600,
         manualCost: 0,
-        automatedCost: 0
+        automatedCost: 0,
+        enabled: true
     }));
+
+const filterDisabled = data => data.filter(({ enabled }) => enabled);
 
 const updateDeltaCost = (data, costAutomation, costManual) =>
     data.map(el => {
@@ -118,6 +121,14 @@ const AutomationCalculator = ({ history }) => {
         setDataInApi(updatedData);
     };
 
+    const setEnabled = id => value => {
+        setDataInApi(api.data.map(el =>
+            el.id === id
+                ? { ...el, enabled: value }
+                : el
+        ));
+    };
+
     useEffect(() => {
         setPreflight(preflightRequest());
         setOptions(readROIOptions({ params: queryParams }));
@@ -163,7 +174,7 @@ const AutomationCalculator = ({ history }) => {
                                 <TopTemplatesSavings
                                     margin={{ top: 20, right: 20, bottom: 20, left: 70 }}
                                     id="d3-roi-chart-root"
-                                    data={api.data}
+                                    data={filterDisabled(api.data)}
                                 />
                                 <p style={{ textAlign: 'center' }}>Templates</p>
                             </React.Fragment>
@@ -180,7 +191,7 @@ const AutomationCalculator = ({ history }) => {
     const renderRight = () => (
         <WrapperRight>
             <Main style={{ paddingBottom: '0', paddingLeft: '0' }}>
-                <TotalSavings totalSavings={computeTotalSavings(api.data)} />
+                <TotalSavings totalSavings={computeTotalSavings(filterDisabled(api.data))} />
             </Main>
             <Main
                 style={{
@@ -201,6 +212,7 @@ const AutomationCalculator = ({ history }) => {
                     data={api.data}
                     setDataRunTime={setDataRunTime}
                     setUnfilteredData={api.data}
+                    setEnabled={setEnabled}
                 />
             </Main>
         </WrapperRight>

--- a/src/Containers/AutomationCalculator/TopTemplates.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.js
@@ -12,7 +12,11 @@ import {
     Tooltip,
     Popover
 } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import {
+    InfoCircleIcon,
+    ToggleOnIcon,
+    ToggleOffIcon
+} from '@patternfly/react-icons';
 
 import {
     convertSecondsToMins,
@@ -101,46 +105,49 @@ QuestionIconTooltip.propTypes = {
 const TopTemplates = ({
     data = [],
     setDataRunTime = () => {},
+    setEnabled = () => {},
     redirectToJobExplorer = () => {}
 }) => (
     <Card style={{ overflow: 'auto', flex: '1 1 0' }} className="top-templates">
         <CardBody>
             <p>Enter the time it takes to run the following templates manually.</p>
-            {data.map(data => (
-                <div key={data.id}>
+            {data.map(item => (
+                <div key={item.id}>
                     <Tooltip content={'List of jobs for this template for past 30 days'}>
                         <Button
                             style={{ padding: '15px 0 10px' }}
                             component="a"
-                            onClick={() => redirectToJobExplorer(data.id)}
+                            onClick={() => redirectToJobExplorer(item.id)}
                             variant="link"
                         >
-                            {data.name}
+                            {item.name}
                         </Button>
                     </Tooltip>
                     <TemplateDetail>
-                        <InputAndText key={data.id}>
+                        <InputAndText key={item.id}>
                             <InputGroup>
                                 <TextInput
-                                    id={data.id}
+                                    id={item.id}
                                     type="number"
                                     aria-label="time run manually"
-                                    value={convertSecondsToMins(data.avgRunTime)}
+                                    value={convertSecondsToMins(item.avgRunTime)}
                                     onChange={minutes =>
-                                        setDataRunTime(convertMinsToSeconds(minutes), data.id)
+                                        setDataRunTime(convertMinsToSeconds(minutes), item.id)
                                     }
                                 />
                                 <InputGroupText>min</InputGroupText>
                             </InputGroup>
                         </InputAndText>
                         <TemplateDetailSubTitle>
-              x {data.successful_hosts_total} host runs
+                            x {item.successful_hosts_total} host runs
                         </TemplateDetailSubTitle>
                         <IconGroup>
-                            <QuestionIconTooltip data={data} />
+                            <QuestionIconTooltip data={item} />
+                            { !item.enabled && <ToggleOffIcon onClick={ () => setEnabled(item.id)(true) } /> }
+                            { item.enabled && <ToggleOnIcon onClick={ () => setEnabled(item.id)(false) } /> }
                         </IconGroup>
                     </TemplateDetail>
-                    <p style={{ color: '#486B00' }}>${data.delta.toFixed(2)}</p>
+                    <p style={{ color: '#486B00' }}>${item.delta.toFixed(2)}</p>
                 </div>
             ))}
         </CardBody>
@@ -152,7 +159,8 @@ TopTemplates.propTypes = {
     setDataRunTime: PropTypes.func,
     redirectToJobExplorer: PropTypes.func,
     deselectedIds: PropTypes.array,
-    setDeselectedIds: PropTypes.func
+    setDeselectedIds: PropTypes.func,
+    setEnabled: PropTypes.func
 };
 
 export default TopTemplates;

--- a/src/Containers/AutomationCalculator/TopTemplates.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.js
@@ -76,20 +76,24 @@ const InputAndText = styled.div`
   flex: 1;
 `;
 
-export const QuestionIconTooltip = ({ data }) => (
+export const QuestionIconTooltip = ({
+    successfulElapsedTotal,
+    totalOrgCount,
+    totalClusterCount
+}) => (
     <Popover
         aria-label="template detail popover"
         position="left"
         bodyContent={
             <TooltipWrapper>
                 <p>
-                    <b>Success elapsed sum</b>: {data.successful_elapsed_total.toFixed(2)}
+                    <b>Success elapsed sum</b>: {successfulElapsedTotal.toFixed(2)}
                 </p>
                 <p>
-                    <b>Number of associated organizations</b>: {data.total_org_count}
+                    <b>Number of associated organizations</b>: {totalOrgCount}
                 </p>
                 <p>
-                    <b>Number of associated clusters</b>: {data.total_cluster_count}
+                    <b>Number of associated clusters</b>: {totalClusterCount}
                 </p>
             </TooltipWrapper>
         }
@@ -99,7 +103,9 @@ export const QuestionIconTooltip = ({ data }) => (
 );
 
 QuestionIconTooltip.propTypes = {
-    data: PropTypes.object
+    successfulElapsedTotal: PropTypes.number,
+    totalOrgCount: PropTypes.number,
+    totalClusterCount: PropTypes.number
 };
 
 const TopTemplates = ({
@@ -111,43 +117,57 @@ const TopTemplates = ({
     <Card style={{ overflow: 'auto', flex: '1 1 0' }} className="top-templates">
         <CardBody>
             <p>Enter the time it takes to run the following templates manually.</p>
-            {data.map(item => (
-                <div key={item.id}>
+            {data.map(({
+                id,
+                name,
+                avgRunTime,
+                enabled,
+                delta,
+                successful_hosts_total,
+                successful_elapsed_total,
+                total_org_count,
+                total_cluster_count
+            }) => (
+                <div key={id}>
                     <Tooltip content={'List of jobs for this template for past 30 days'}>
                         <Button
                             style={{ padding: '15px 0 10px' }}
                             component="a"
-                            onClick={() => redirectToJobExplorer(item.id)}
+                            onClick={() => redirectToJobExplorer(id)}
                             variant="link"
                         >
-                            {item.name}
+                            {name}
                         </Button>
                     </Tooltip>
                     <TemplateDetail>
-                        <InputAndText key={item.id}>
+                        <InputAndText key={id}>
                             <InputGroup>
                                 <TextInput
-                                    id={item.id}
+                                    id={id}
                                     type="number"
                                     aria-label="time run manually"
-                                    value={convertSecondsToMins(item.avgRunTime)}
+                                    value={convertSecondsToMins(avgRunTime)}
                                     onChange={minutes =>
-                                        setDataRunTime(convertMinsToSeconds(minutes), item.id)
+                                        setDataRunTime(convertMinsToSeconds(minutes), id)
                                     }
                                 />
                                 <InputGroupText>min</InputGroupText>
                             </InputGroup>
                         </InputAndText>
                         <TemplateDetailSubTitle>
-                            x {item.successful_hosts_total} host runs
+                            x {successful_hosts_total} host runs
                         </TemplateDetailSubTitle>
                         <IconGroup>
-                            <QuestionIconTooltip data={item} />
-                            { !item.enabled && <ToggleOffIcon onClick={ () => setEnabled(item.id)(true) } /> }
-                            { item.enabled && <ToggleOnIcon onClick={ () => setEnabled(item.id)(false) } /> }
+                            <QuestionIconTooltip
+                                successfulElapsedTotal={successful_elapsed_total}
+                                totalOrgCount={total_org_count}
+                                totalClusterCount={total_cluster_count}
+                            />
+                            { !enabled && <ToggleOffIcon onClick={ () => setEnabled(id)(true) } /> }
+                            { enabled && <ToggleOnIcon onClick={ () => setEnabled(id)(false) } /> }
                         </IconGroup>
                     </TemplateDetail>
-                    <p style={{ color: '#486B00' }}>${item.delta.toFixed(2)}</p>
+                    <p style={{ color: '#486B00' }}>${delta.toFixed(2)}</p>
                 </div>
             ))}
         </CardBody>


### PR DESCRIPTION
![Screenshot from 2021-02-11 15-48-21](https://user-images.githubusercontent.com/8531681/107652176-979a0800-6c80-11eb-8790-0a62e87b2b85.png)



The switches are not icons as they used to be. Will ot be fine with a normal switch component or should we find the original switch icons?