### PR TITLE
Fixed clear filter button on job explorer

### DIFF
--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -65,14 +65,13 @@ const JobExplorer = ({ location: { search }, history }) => {
     const [ currPage, setCurrPage ] = useState(1);
     const [ options, setOptions ] = useApi({}, optionsMapper);
 
-    let initialSearchParams = parse(search, {
-        arrayFormat: 'bracket',
-        parseBooleans: true
-    });
-    let combined = { ...initialQueryParams, ...initialSearchParams };
-    const { queryParams, setLimit, setOffset, setFromToolbar } = useQueryParams(
-        combined
-    );
+    const {
+        queryParams,
+        setLimit,
+        setOffset,
+        setFromToolbar,
+        dispatch
+    } = useQueryParams(initialQueryParams);
 
     const updateURL = () => {
         const { jobExplorer } = Paths;
@@ -93,6 +92,16 @@ const JobExplorer = ({ location: { search }, history }) => {
                 })
             // Loading is set false when the data also loaded
         );
+
+        const initialSearchParams = parse(search, {
+            arrayFormat: 'bracket',
+            parseBooleans: true
+        });
+
+        dispatch({ type: 'REINITIALIZE', value: {
+            ...initialQueryParams,
+            ...initialSearchParams
+        }});
     }, []);
 
     useEffect(() => {

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -63,6 +63,8 @@ export const useQueryParams = initial => {
                 return { ...state, ...newValues };
             }
 
+            case 'REINITIALIZE':
+                return { ...value };
             case 'RESET_FILTER':
                 return {
                     ...state,


### PR DESCRIPTION
It was cause by the fact that the initial query param was updated at 
every rerender from the search. Therefore the clear all button reseted 
the state to the CURRENT state.