### PR TITLE
AA-352 Improve Sort UX in Automation Calculator

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -213,6 +213,7 @@ const AutomationCalculator = ({ history }) => {
                     setDataRunTime={setDataRunTime}
                     setUnfilteredData={api.data}
                     setEnabled={setEnabled}
+                    sortBy={queryParams.sort_by}
                 />
             </Main>
         </WrapperRight>

--- a/src/Containers/AutomationCalculator/TopTemplates.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.js
@@ -20,7 +20,8 @@ import {
 
 import {
     convertSecondsToMins,
-    convertMinsToSeconds
+    convertMinsToSeconds,
+    capitalize
 } from '../../Utilities/helpers';
 
 const TemplateDetail = styled.div`
@@ -76,36 +77,28 @@ const InputAndText = styled.div`
   flex: 1;
 `;
 
-export const QuestionIconTooltip = ({
-    successfulElapsedTotal,
-    totalOrgCount,
-    totalClusterCount
-}) => (
-    <Popover
-        aria-label="template detail popover"
-        position="left"
-        bodyContent={
-            <TooltipWrapper>
-                <p>
-                    <b>Success elapsed sum</b>: {successfulElapsedTotal.toFixed(2)}
-                </p>
-                <p>
-                    <b>Number of associated organizations</b>: {totalOrgCount}
-                </p>
-                <p>
-                    <b>Number of associated clusters</b>: {totalClusterCount}
-                </p>
-            </TooltipWrapper>
-        }
-    >
-        <InfoCircleIcon />
-    </Popover>
-);
+export const QuestionIconTooltip = ({ details }) => {
+    return (
+        <Popover
+            aria-label="template detail popover"
+            position="left"
+            bodyContent={
+                <TooltipWrapper>
+                    {Object.keys(details).map((k, i) => (
+                        <p key={i}>
+                            <b>{capitalize(k.split('_').join(' '))}</b>: {details[k]}
+                        </p>
+                    ))}
+                </TooltipWrapper>
+            }
+        >
+            <InfoCircleIcon />
+        </Popover>
+    );
+};
 
 QuestionIconTooltip.propTypes = {
-    successfulElapsedTotal: PropTypes.number,
-    totalOrgCount: PropTypes.number,
-    totalClusterCount: PropTypes.number
+    details: PropTypes.object
 };
 
 const TopTemplates = ({
@@ -117,57 +110,45 @@ const TopTemplates = ({
     <Card style={{ overflow: 'auto', flex: '1 1 0' }} className="top-templates">
         <CardBody>
             <p>Enter the time it takes to run the following templates manually.</p>
-            {data.map(({
-                id,
-                name,
-                avgRunTime,
-                enabled,
-                delta,
-                successful_hosts_total,
-                successful_elapsed_total,
-                total_org_count,
-                total_cluster_count
-            }) => (
-                <div key={id}>
+            {data.map(d => (
+                <div key={d.id}>
                     <Tooltip content={'List of jobs for this template for past 30 days'}>
                         <Button
                             style={{ padding: '15px 0 10px' }}
                             component="a"
-                            onClick={() => redirectToJobExplorer(id)}
+                            onClick={() => redirectToJobExplorer(d.id)}
                             variant="link"
                         >
-                            {name}
+                            {d.name}
                         </Button>
                     </Tooltip>
                     <TemplateDetail>
-                        <InputAndText key={id}>
+                        <InputAndText key={d.id}>
                             <InputGroup>
                                 <TextInput
-                                    id={id}
+                                    id={d.id}
                                     type="number"
                                     aria-label="time run manually"
-                                    value={convertSecondsToMins(avgRunTime)}
+                                    value={convertSecondsToMins(d.avgRunTime)}
                                     onChange={minutes =>
-                                        setDataRunTime(convertMinsToSeconds(minutes), id)
+                                        setDataRunTime(convertMinsToSeconds(minutes), d.id)
                                     }
                                 />
                                 <InputGroupText>min</InputGroupText>
                             </InputGroup>
                         </InputAndText>
                         <TemplateDetailSubTitle>
-                            x {successful_hosts_total} host runs
+                            x {d.successful_hosts_total} host runs
                         </TemplateDetailSubTitle>
                         <IconGroup>
                             <QuestionIconTooltip
-                                successfulElapsedTotal={successful_elapsed_total}
-                                totalOrgCount={total_org_count}
-                                totalClusterCount={total_cluster_count}
+                                details={d}
                             />
-                            { !enabled && <ToggleOffIcon onClick={ () => setEnabled(id)(true) } /> }
-                            { enabled && <ToggleOnIcon onClick={ () => setEnabled(id)(false) } /> }
+                            { !d.enabled && <ToggleOffIcon onClick={ () => setEnabled(d.id)(true) } /> }
+                            { d.enabled && <ToggleOnIcon onClick={ () => setEnabled(d.id)(false) } /> }
                         </IconGroup>
                     </TemplateDetail>
-                    <p style={{ color: '#486B00' }}>${delta.toFixed(2)}</p>
+                    <p style={{ color: '#486B00' }}>${d.delta.toFixed(2)}</p>
                 </div>
             ))}
         </CardBody>

--- a/src/Containers/AutomationCalculator/TopTemplates.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.js
@@ -25,13 +25,9 @@ import {
 } from '../../Utilities/helpers';
 
 const TemplateDetail = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  div,
   em {
-    padding-right: 5px;
+    display: block;
+    padding: 5px 0;
   }
 
   @media (max-width: 1490px) {
@@ -77,6 +73,19 @@ const InputAndText = styled.div`
   flex: 1;
 `;
 
+export const showSortAttr = (details, s) => {
+    const trimmed = s.split(':')[0];
+    const sortAttribute = Object.keys(details).map(k =>
+        k === trimmed ? `${details[k]}` : null
+    );
+
+    return (
+        <TemplateDetailSubTitle>
+            {capitalize(trimmed.split('_').join(' '))}: {sortAttribute}
+        </TemplateDetailSubTitle>
+    );
+};
+
 export const QuestionIconTooltip = ({ details }) => {
     return (
         <Popover
@@ -103,6 +112,7 @@ QuestionIconTooltip.propTypes = {
 
 const TopTemplates = ({
     data = [],
+    sortBy = null,
     setDataRunTime = () => {},
     setEnabled = () => {},
     redirectToJobExplorer = () => {}
@@ -140,6 +150,7 @@ const TopTemplates = ({
                         <TemplateDetailSubTitle>
                             x {d.successful_hosts_total} host runs
                         </TemplateDetailSubTitle>
+                        {showSortAttr(d, sortBy)}
                         <IconGroup>
                             <QuestionIconTooltip
                                 details={d}
@@ -161,7 +172,8 @@ TopTemplates.propTypes = {
     redirectToJobExplorer: PropTypes.func,
     deselectedIds: PropTypes.array,
     setDeselectedIds: PropTypes.func,
-    setEnabled: PropTypes.func
+    setEnabled: PropTypes.func,
+    sortBy: PropTypes.string
 };
 
 export default TopTemplates;

--- a/src/Containers/AutomationCalculator/TopTemplates.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.js
@@ -73,8 +73,8 @@ const InputAndText = styled.div`
   flex: 1;
 `;
 
-export const showSortAttr = (details, s) => {
-    const trimmed = s.split(':')[0];
+const showSortAttr = (details, sortBy) => {
+    const trimmed = sortBy.split(':')[0];
     const sortAttribute = Object.keys(details).map(k =>
         k === trimmed ? `${details[k]}` : null
     );
@@ -86,25 +86,23 @@ export const showSortAttr = (details, s) => {
     );
 };
 
-export const QuestionIconTooltip = ({ details }) => {
-    return (
-        <Popover
-            aria-label="template detail popover"
-            position="left"
-            bodyContent={
-                <TooltipWrapper>
-                    {Object.keys(details).map((k, i) => (
-                        <p key={i}>
-                            <b>{capitalize(k.split('_').join(' '))}</b>: {details[k]}
-                        </p>
-                    ))}
-                </TooltipWrapper>
-            }
-        >
-            <InfoCircleIcon />
-        </Popover>
-    );
-};
+const QuestionIconTooltip = ({ details }) => (
+    <Popover
+        aria-label="template detail popover"
+        position="left"
+        bodyContent={
+            <TooltipWrapper>
+                {Object.keys(details).map((k, i) => (
+                    <p key={i}>
+                        <b>{capitalize(k.split('_').join(' '))}</b>: {details[k]}
+                    </p>
+                ))}
+            </TooltipWrapper>
+        }
+    >
+        <InfoCircleIcon />
+    </Popover>
+);
 
 QuestionIconTooltip.propTypes = {
     details: PropTypes.object
@@ -112,7 +110,7 @@ QuestionIconTooltip.propTypes = {
 
 const TopTemplates = ({
     data = [],
-    sortBy = null,
+    sortBy = '',
     setDataRunTime = () => {},
     setEnabled = () => {},
     redirectToJobExplorer = () => {}

--- a/src/Containers/AutomationCalculator/TopTemplates.test.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.test.js
@@ -49,13 +49,13 @@ describe('Containers/AutomationCalculator/TopTemplates', () => {
     });
 
     it('should render with dummy data', () => {
-        const wrapper = mount(<TopTemplates data={dummyData} />);
+        const wrapper = mount(<TopTemplates data={dummyData} sortBy={'foo'} />);
         expect(wrapper.find('input')).toHaveLength(3);
     });
 
     it('should call redirect on link click', () => {
         const wrapper = mount(
-            <TopTemplates data={dummyData} redirectToJobExplorer={fn} />
+            <TopTemplates data={dummyData} redirectToJobExplorer={fn} sortBy={'foo'} />
         );
         wrapper
         .find('a')
@@ -66,7 +66,7 @@ describe('Containers/AutomationCalculator/TopTemplates', () => {
 
     it('should call setDataRunTime with the correct value on input change', () => {
         const wrapper = mount(
-            <TopTemplates data={dummyData} setDataRunTime={fn} />
+            <TopTemplates data={dummyData} setDataRunTime={fn} sortBy={'foo'} />
         );
 
         // First field

--- a/src/Containers/AutomationCalculator/TopTemplates.test.js
+++ b/src/Containers/AutomationCalculator/TopTemplates.test.js
@@ -49,13 +49,13 @@ describe('Containers/AutomationCalculator/TopTemplates', () => {
     });
 
     it('should render with dummy data', () => {
-        const wrapper = mount(<TopTemplates data={dummyData} sortBy={'foo'} />);
+        const wrapper = mount(<TopTemplates data={dummyData} sortBy={'foo:asc'} />);
         expect(wrapper.find('input')).toHaveLength(3);
     });
 
     it('should call redirect on link click', () => {
         const wrapper = mount(
-            <TopTemplates data={dummyData} redirectToJobExplorer={fn} sortBy={'foo'} />
+            <TopTemplates data={dummyData} redirectToJobExplorer={fn} sortBy={'foo:desc'} />
         );
         wrapper
         .find('a')


### PR DESCRIPTION
Spoke with @trahman73 on this and the fix is to:

1. Dynamiclaly show in the UI on the right side Templates list column the sort by details:
![sortBy_ROI_templates_list](https://user-images.githubusercontent.com/2293210/108010463-ec1beb00-6fd2-11eb-83a9-82e2d9ac840b.gif)

2. Include all the sort by attributes/values returned by the API in the popover like so:
<img width="1405" alt="Screen Shot 2021-02-15 at 8 17 10 PM" src="https://user-images.githubusercontent.com/2293210/108007255-81b37c80-6fcb-11eb-90aa-eee28553bd09.png">
