### PR TITLE
utilize centralized authenticated fetch api helper

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -38,14 +38,18 @@ function handleResponse(response) {
     });
 }
 
+function authenticatedFetch(endpoint, options) {
+    return window.insights.chrome.auth.getUser().then(() => fetch(endpoint, options));
+}
+
 export const preflightRequest = () => {
-    return fetch(preflightEndpoint).then(handleResponse);
+    return authenticatedFetch(preflightEndpoint).then(handleResponse);
 };
 
 /* Section: Orgs page */
 export const readOrgOptions = ({ params = {}}) => {
     let url = new URL(orgOptionsEndpoint, getAbsoluteUrl());
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -66,7 +70,7 @@ export const readHostAcrossOrg = ({ params = {}}) => {
         sort_by: combined.sort_by
     });
 
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(combined)
     }).then(handleResponse);
@@ -87,7 +91,7 @@ export const readJobsByDateAndOrg = ({ params = {}}) => {
         sort_by: combined.sort_by
     });
 
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(combined)
     }).then(handleResponse);
@@ -108,7 +112,7 @@ export const readJobRunsByOrg = ({ params = {}}) => {
         sort_by: combined.sort_by
     });
 
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(combined)
     }).then(handleResponse);
@@ -130,7 +134,7 @@ export const readJobEventsByOrg = ({ params = {}}) => {
         sort_by: combined.sort_by
     });
 
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(combined)
     }).then(handleResponse);
@@ -139,20 +143,20 @@ export const readJobEventsByOrg = ({ params = {}}) => {
 
 // used in Notifications.js
 export const readClusters = () => {
-    return fetch(clustersEndpoint).then(handleResponse);
+    return authenticatedFetch(clustersEndpoint).then(handleResponse);
 };
 
 export const readNotifications = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(notificationsEndPoint, formattedUrl);
     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
-    return fetch(url).then(handleResponse);
+    return authenticatedFetch(url).then(handleResponse);
 };
 
 export const readJobExplorerOptions = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerOptionsEndpoint, formattedUrl);
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -161,7 +165,7 @@ export const readJobExplorerOptions = ({ params = {}}) => {
 export const readClustersOptions = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(clustersOptionsEndpoint, formattedUrl);
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -178,7 +182,7 @@ export const readJobExplorer = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerEndpoint, formattedUrl);
     url.search = qs;
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -195,7 +199,7 @@ export const readEventExplorer = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(eventExplorerEndpoint, formattedUrl);
     url.search = qs;
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -204,7 +208,7 @@ export const readEventExplorer = ({ params = {}}) => {
 export const readClustersBarChart = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(jobExplorerEndpoint, formattedUrl);
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -214,7 +218,7 @@ export const readROI = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(ROIEndpoint, formattedUrl);
     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);
@@ -223,7 +227,7 @@ export const readROI = ({ params = {}}) => {
 export const readROIOptions = ({ params = {}}) => {
     const formattedUrl = getAbsoluteUrl();
     let url = new URL(ROITemplatesOptionsEndpoint, formattedUrl);
-    return fetch(url, {
+    return authenticatedFetch(url, {
         method: 'POST',
         body: JSON.stringify(params)
     }).then(handleResponse);

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -148,7 +148,6 @@ const Clusters = () => {
 
     useEffect(() => {
         async function initializeWithPreflight() {
-            await window.insights.chrome.auth.getUser();
             await preflightRequest().catch(error => {
                 setPreFlightError({ preflightError: error });
             });

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -85,13 +85,9 @@ const JobExplorer = ({ location: { search }, history }) => {
     useEffect(() => {
         insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
 
-        window.insights.chrome.auth.getUser().then(
-            () =>
-                preflightRequest().catch(error => {
-                    setPreFlightError({ preflightError: error });
-                })
-            // Loading is set false when the data also loaded
-        );
+        preflightRequest().catch(error => {
+            setPreFlightError({ preflightError: error });
+        });
 
         const initialSearchParams = parse(search, {
             arrayFormat: 'bracket',

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -130,9 +130,8 @@ const Notifications = () => {
             return readNotifications({ params: queryParams });
         };
 
-        const update = async () => {
+        const update = () => {
             setIsLoading(true);
-            await window.insights.chrome.auth.getUser();
             getData().then(({ notifications: notificationsData = [], meta }) => {
                 setNotificationsData(notificationsData);
                 setMeta(meta);
@@ -157,7 +156,6 @@ const Notifications = () => {
 
         async function initializeWithPreflight() {
             setIsLoading(true);
-            await window.insights.chrome.auth.getUser();
             await preflightRequest().catch(error => {
                 setPreFlightError({ preflightError: error });
             });

--- a/src/Utilities/useApi.js
+++ b/src/Utilities/useApi.js
@@ -55,22 +55,18 @@ const useApi = (initialData, postprocess = d => d) => {
         dispatch({ type: 'FETCH_INIT' });
 
         // Fetching
-        window.insights.chrome.auth.getUser().then(() =>
-            request
-            .then(data => {
-                if (!didCancel) {
-                    dispatch({
-                        type: 'FETCH_SUCCESS',
-                        payload: postprocess(data)
-                    });
-                }
-            })
-            .catch(e => {
-                if (!didCancel) {
-                    dispatch({ type: 'FETCH_FAILURE', payload: e });
-                }
-            })
-        );
+        request.then(data => {
+            if (!didCancel) {
+                dispatch({
+                    type: 'FETCH_SUCCESS',
+                    payload: postprocess(data)
+                });
+            }
+        }).catch(e => {
+            if (!didCancel) {
+                dispatch({ type: 'FETCH_FAILURE', payload: e });
+            }
+        });
 
         return () => {
             didCancel = true;


### PR DESCRIPTION
this fixes https://issues.redhat.com/browse/AA-353

For whatever reason, the useApi hook did not seem to be successfully gating requests until they were finished logging in.  I also found a number of places (that I guess have not been converted to this useApi hook yet).  So here is an attempt at a simple and consistent solution for gating api requests to make sure they are logged in first.

This pr does two things:
- removes `window.insights.chrome.auth.getUser()` across the app
- wraps fetch calls in api.js (which seemed to be the centralized place that stores alll api requests) in a simple wrapper which calls `window.insights.chrome.auth.getUser()`, waits for a response, and then returns fetch