### PR TITLE
Fix AA-429 pie chart values

### DIFF
--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -168,7 +168,6 @@ const OrganizationStatistics = ({ history }) => {
         ...queryParams,
         group_by: 'org',
         include_others: true,
-        granularity: 'daily',
         attributes: [ 'host_task_count' ],
         sort_by: `host_task_count:desc`
     };

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -157,7 +157,7 @@ const OrganizationStatistics = ({ history }) => {
     const [ preflight, setPreflight ] = useApi(null);
     const [ activeTabKey, setActiveTabKey ] = useState(0);
     const [ orgs, setOrgs ] = useApi([], orgsChartMapper(chartMapper[activeTabKey].attr));
-    const [ jobs, setJobs ] = useApi([], pieChartMapper('host_count'));
+    const [ jobs, setJobs ] = useApi([], pieChartMapper('total_count'));
     const [ tasks, setTasks ] = useApi([], pieChartMapper('host_task_count'));
     const [ options, setOptions ] = useApi({}, optionsMapper);
     const { queryParams, setFromToolbar } = useQueryParams(

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -166,33 +166,33 @@ const OrganizationStatistics = ({ history }) => {
 
     const jobEventsByOrgParams = {
         ...queryParams,
+        attributes: [ 'host_task_count' ],
         group_by: 'org',
         include_others: true,
-        attributes: [ 'host_task_count' ],
         sort_by: `host_task_count:desc`
     };
 
     const jobRunsByOrgParams = {
         ...queryParams,
+        attributes: [ 'total_count' ],
         group_by: 'org',
         include_others: true,
-        attributes: [ 'total_count' ],
         sort_by: `total_count:desc`
     };
 
     const jobsByDateAndOrgParams = {
         ...queryParams,
         attributes: [ 'total_count' ],
-        group_by_time: true,
         group_by: 'org',
+        group_by_time: true,
         sort_by: `total_count:desc`
     };
 
     const hostAcrossOrgParams = {
         ...queryParams,
         attributes: [ 'total_unique_host_count' ],
-        group_by_time: true,
         group_by: 'org',
+        group_by_time: true,
         sort_by: `host_task_count:desc`
     };
 

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -177,7 +177,7 @@ const OrganizationStatistics = ({ history }) => {
         ...queryParams,
         group_by: 'org',
         include_others: true,
-        attributes: [ 'host_count' ],
+        attributes: [ 'total_count' ],
         sort_by: `total_count:desc`
     };
 


### PR DESCRIPTION
There's a lot of noise in this PR as I re-ordered the list of params for each of the charts so they're ordered alphabetically for ease of readability, but the main fix for this bug is to [change out the `attribute` param in `jobRunsByOrgParams ` from `host_count` to `total_count`](https://github.com/RedHatInsights/tower-analytics-frontend/commit/9d269f3fec018eb31f0148aaca73da7959b90c40). 