### PR TITLE
scripted tmux config for fully local ui dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 .PHONY: all build fully_local_dev_start
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+
+REL_BACKEND_PATH ?= ../tower-analytics-backend
+REL_PROXY_PATH ?= ../insights-proxy
+REL_PROXY_CONFIG_PATH ?= ../tower-analytics-frontend/config/fast-api.spandx.config.js bash scripts/run.sh
+REL_CRC_CONFIG_PATH ?= ../cloud-services-config
 
 
 all: build
@@ -12,12 +18,12 @@ build:
 fully_local_dev_start:
 	tmux new-session -d -s aa "exec npm run test_dev"
 	tmux select-window -t aa:0
-	tmux split-window -h -p 20 "cd ../tower-analytics-backend && exec make ui"
+	tmux split-window -h -p 20 "cd ${REL_BACKEND_PATH} && exec make ui"
 	tmux select-window -t aa:0
 	tmux split-window -v -p 70 "exec npm start"
 	tmux select-pane -U
-	tmux split-window -v "cd ../insights-proxy && SPANDX_CONFIG=../tower-analytics-frontend/config/fast-api.spandx.config.js exec scripts/run.sh"
-	tmux split-window -v "cd ../cloud-services-config && exec npx http-server -p 8889"
+	tmux split-window -v "cd ${REL_PROXY_PATH} && SPANDX_CONFIG=${REL_PROXY_CONFIG_PATH}"
+	tmux split-window -v "cd ${REL_CRC_CONFIG_PATH} && exec npx http-server -p 8889"
 	tmux select-pane -U
 	tmux select-pane -U
 	tmux resize-pane -U 5

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,21 @@ build:
 	docker build -t tower-analytics-frontend:${BRANCH} .
 
 fully_local_dev_start:
-	tmux new-session -d -s aa 'exec npm start'
+	tmux new-session -d -s aa "exec npm run test_dev"
 	tmux select-window -t aa:0
-	tmux split-window -v "cd ../tower-analytics-backend && exec make ui"
-	tmux split-window -v "cd ../cloud-services-config && exec npx http-server -p 8889"
+	tmux split-window -h -p 20 "cd ../tower-analytics-backend && exec make ui"
+	tmux select-window -t aa:0
+	tmux split-window -v -p 70 "exec npm start"
+	tmux select-pane -U
 	tmux split-window -v "cd ../insights-proxy && SPANDX_CONFIG=../tower-analytics-frontend/config/fast-api.spandx.config.js exec scripts/run.sh"
-	tmux split-window -h "exec npm run test_dev"
+	tmux split-window -v "cd ../cloud-services-config && exec npx http-server -p 8889"
+	tmux select-pane -U
+	tmux select-pane -U
+	tmux resize-pane -U 5
+	tmux select-pane -D
+	tmux resize-pane -U 5
+	tmux select-pane -D
+	tmux resize-pane -U 5
+	tmux select-pane -L
+	tmux set mouse on
 	tmux attach -t aa

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build
+.PHONY: all build fully_local_dev_start
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
@@ -9,3 +9,11 @@ all: build
 build:
 	docker build -t tower-analytics-frontend:${BRANCH} .
 
+fully_local_dev_start:
+	tmux new-session -d -s aa 'exec npm start'
+	tmux select-window -t aa:0
+	tmux split-window -v "cd ../tower-analytics-backend && exec make ui"
+	tmux split-window -v "cd ../cloud-services-config && exec npx http-server -p 8889"
+	tmux split-window -v "cd ../insights-proxy && SPANDX_CONFIG=../tower-analytics-frontend/config/fast-api.spandx.config.js exec scripts/run.sh"
+	tmux split-window -h "exec npm run test_dev"
+	tmux attach -t aa

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build fully_local_dev_start
+.PHONY: all build fully_local_dev_install_mac fully_local_dev_start
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -15,10 +15,11 @@ all: build
 build:
 	docker build -t tower-analytics-frontend:${BRANCH} .
 
+fully_local_dev_install_mac:
+	brew install tmux
+
 fully_local_dev_start:
-	tmux new-session -d -s aa "exec npm run test_dev"
-	tmux select-window -t aa:0
-	tmux split-window -h -p 20 "cd ${REL_BACKEND_PATH} && exec make ui"
+	tmux new-session -d -s aa "cd ${REL_BACKEND_PATH} && exec make ui"
 	tmux select-window -t aa:0
 	tmux split-window -v -p 70 "exec npm start"
 	tmux select-pane -U
@@ -31,6 +32,6 @@ fully_local_dev_start:
 	tmux resize-pane -U 5
 	tmux select-pane -D
 	tmux resize-pane -U 5
-	tmux select-pane -L
+	tmux select-pane -D
 	tmux set mouse on
 	tmux attach -t aa


### PR DESCRIPTION
After discussing my thoughts around documenting the fully local setup with @benthomasson, he had the idea that trying to automate it may help make this stuff more impervious to being out of date.  So here's my very rudimentary attempt at doing that.  It definitely needs beefing up before it is useful and ready to merge, I think.

Basically, it is a new phony make target which starts and attaches to a tmux session which contains all the main pieces for a fully local UI dev setup:
- cloud-services-config for custom side nav
- frontend running webpack dev (i.e. always updating the bundle as changes are made to the frontend src)
- backend ran using headless (i.e. no ui cotainer) make ui target
- insights-proxy running using the fast-api config to connect all these pieces.

Iteration 1 looks like this:
<img width="1680" alt="Screen Shot 2021-03-18 at 4 34 03 PM" src="https://user-images.githubusercontent.com/1342624/111695719-c66c4680-8809-11eb-9bf4-3317584005a9.png">

---

**Some things to note and that need iterating below:**

sometimes (about 50% of the time for me) the kafka container fails.  this is recognizable through the backend log output consistently saying that it is trying to connect to kafka indefinitely.  luckily, this has an easy fix, either restarting on the cli in another terminal shell, or starting the container in the docker UI:

![Screen Shot 2021-03-18 at 4 54 38 PM](https://user-images.githubusercontent.com/1342624/111696770-13045180-880b-11eb-9d5f-3b0ee6bbc202.png)


Luckily, you don't need to bounce anything else...once kafka is started back up everything magically connects and works.  Because of this, I don't think this runner needs to implement anything fancy like retry logic.  maybe it could print out something somewhere that if this happens that you might need to restart it.

---

ports are current non configurable.

---

this is just for **running** the processes needed.  all bootstrapping commands (npm install on frontend, various make build/pull/data/etc. commands on backend) need to be done before this target will work.  maybe there's some sort of local build and clean targets that should be written to handle all of that mangement?