### PR TITLE
Clusters modal: change sort order to descending instead of ascending

### DIFF
--- a/src/Components/ModalContents.js
+++ b/src/Components/ModalContents.js
@@ -191,7 +191,7 @@ const ModalContents = ({
         ],
         group_by_time: false,
         limit: 5,
-        sort_by: 'created:asc',
+        sort_by: 'created:desc',
         quick_date_range: qp.quick_date_range
             ? qp.quick_date_range
             : 'last_30_days',


### PR DESCRIPTION
This will allow is to correctly display the last 5 jobs.

Issue filed [here](https://issues.redhat.com/browse/AA-152?focusedCommentId=16003811&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16003811).
