### PR TITLE
update chart axis ticks:

### DIFF
--- a/src/Charts/GroupedBarChart/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart/GroupedBarChart.js
@@ -48,7 +48,7 @@ const GroupedBarChart = ({
     const draw = () => {
         // Clear our chart container element first
         d3.selectAll('#' + props.id + ' > *').remove();
-        let { data: unformattedData, timeFrame } = props;
+        let { data: unformattedData } = props;
         const data = unformattedData.reduce((formatted, { date, items }) => {
             const selectedOrgs = items.filter(({ id }) => selectedIds.includes(id));
             return formatted.concat({ date, selectedOrgs });
@@ -64,11 +64,12 @@ const GroupedBarChart = ({
         const x1 = d3.scaleBand();
         const y = d3.scaleLinear().range([ height, 0 ]);
         // format our X Axis ticks
-        const maxTicks = Math.round(data.length / (timeFrame / 2));
+        const maxTicksOneMonth = Math.round(data.length / (data.length / 2));
+        const maxTicksTwoMonths = Math.round(data.length / (data.length / 4));
         let ticks = data.map(d => d.date);
-        if (timeFrame === 31) {
+        if (data.length > 14) {
             ticks = data
-            .map((d, i) => (i % maxTicks === 0 ? d.date : undefined))
+            .map((d, i) => (i % (data.length > 31 ? maxTicksTwoMonths : maxTicksOneMonth) === 0 ? d.date : undefined))
             .filter(item => item);
         }
 
@@ -238,7 +239,6 @@ GroupedBarChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
-    timeFrame: PropTypes.number,
     colorFunc: PropTypes.func,
     yLabel: PropTypes.string,
     onClick: PropTypes.func,

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -303,7 +303,6 @@ PieChart.propTypes = {
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,
-    timeFrame: PropTypes.number,
     colorFunc: PropTypes.func
 };
 

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -251,7 +251,6 @@ const OrganizationStatistics = ({ history }) => {
                                         id="d3-grouped-bar-chart-root"
                                         data={ orgs.data }
                                         history={ history }
-                                        timeFrame={ orgs.data .length }
                                         colorFunc={ colorFunc }
                                         yLabel={ chartMapper[activeTabKey].label }
                                         onClick={ chartMapper[activeTabKey].onClick(toJobExplorer, queryParams) }
@@ -276,7 +275,6 @@ const OrganizationStatistics = ({ history }) => {
                                             margin={{ top: 20, right: 20, bottom: 0, left: 20 }}
                                             id="d3-donut-1-chart-root"
                                             data={jobs.data}
-                                            timeFrame={jobs.data.length}
                                             colorFunc={colorFunc}
                                         />
                                     )}
@@ -297,7 +295,6 @@ const OrganizationStatistics = ({ history }) => {
                                             margin={{ top: 20, right: 20, bottom: 0, left: 20 }}
                                             id="d3-donut-2-chart-root"
                                             data={tasks.data}
-                                            timeFrame={tasks.data.length}
                                             colorFunc={colorFunc}
                                         />
                                     )}


### PR DESCRIPTION
This updates the number of labeled ticks on the x axis of the org stats chart.  For grouped bar I go to every 2 for month view, and every 4 for 2 month view.

![Screen Shot 2021-04-07 at 2 06 24 PM](https://user-images.githubusercontent.com/1342624/113914904-148ebd00-97ac-11eb-8547-29b997e161fd.png)

I also removed timeFrame data prop to clean things up for consistency across all the different charts (unused in pie charts, and we were just finding the length of the data on line/bar).