### PR TITLE
Updated orgs page legend from the api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           build: npm run build
           start: |
             npm run start
-            npm run proxy
+            npm run proxy:ci
           spec: cypress/integration/**/*spec.js
           wait-on: 'https://localhost:8002/'
         env:

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "webpack-cli": "^3.2.3"
   },
   "scripts": {
-    "proxy": "SPANDX_CONFIG=./config/spandx.config.js bash ./insights-proxy/scripts/run.sh",
+    "proxy:ci": "SPANDX_CONFIG=./config/spandx.config.js bash ./insights-proxy/scripts/run.sh",
     "proxy:local": "SPANDX_CONFIG=./config/spandx.config.js bash ../insights-proxy/scripts/run.sh",
     "build": "webpack --config config/prod.webpack.config.js",
     "test": "jest --verbose",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "scripts": {
     "proxy": "SPANDX_CONFIG=./config/spandx.config.js bash ./insights-proxy/scripts/run.sh",
+    "proxy:local": "SPANDX_CONFIG=./config/spandx.config.js bash ../insights-proxy/scripts/run.sh",
     "build": "webpack --config config/prod.webpack.config.js",
     "test": "jest --verbose",
     "test_dev": "jest --coverage=false --watch",

--- a/src/Charts/GroupedBarChart/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart/GroupedBarChart.js
@@ -21,19 +21,18 @@ const formatDate = date => {
 const GroupedBarChart = ({
     onClick = null,
     TooltipClass,
+    legend,
     ...props
 }) => {
-    const orgsList = props.data[0].items;
-    const colors = orgsList.map(org => {
-        const name = org.id === -1 ? 'Others' : org.name;
+    const colors = legend.map(({ id, name }) => {
         return {
             name,
-            value: props.colorFunc(name),
-            id: org.id
+            value: props.colorFunc(id),
+            id
         };
     });
     const [ selectedIds, setSelectedIds ] = useState(
-        orgsList.map(({ id }) => id).slice(0, 8)
+        legend.map(({ id }) => id).slice(0, 8)
     );
     let timeout = null;
 
@@ -99,12 +98,11 @@ const GroupedBarChart = ({
         );
 
         const dates = data.map(d => d.date);
-        const selectedOrgNames = data[0].selectedOrgs.map(d => d.name);
         const tooltip = new TooltipClass({
             svg: '#' + props.id
         });
         x0.domain(dates);
-        x1.domain(selectedOrgNames).range([ 0, x0.bandwidth() ]); // unsorted
+        x1.domain(selectedIds).range([ 0, x0.bandwidth() ]);
         y.domain([
             0,
             d3.max(data, date => d3.max(date.selectedOrgs, d => d.value * 1.15)) || 8
@@ -171,10 +169,10 @@ const GroupedBarChart = ({
         .append('rect')
         .attr('width', x1.bandwidth())
         .attr('x', function(d) {
-            return x1(d.name);
+            return x1(d.id);
         }) // unsorted
         .style('fill', function(d) {
-            return color(d.name);
+            return color(d.id);
         })
         .attr('y', function(d) {
             return y(d.value);
@@ -184,12 +182,12 @@ const GroupedBarChart = ({
         })
         .on('mouseover', function(d) {
             d3.select(this).style('cursor', onClick ? 'pointer' : 'default');
-            d3.select(this).style('fill', d3.rgb(color(d.name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(color(d.id)).darker(1));
             tooltip.handleMouseOver();
         })
         .on('mousemove', tooltip.handleMouseOver)
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.name));
+            d3.select(this).style('fill', color(d.id));
             tooltip.handleMouseOut();
         })
         .on('click', onClick);
@@ -236,6 +234,7 @@ const GroupedBarChart = ({
 GroupedBarChart.propTypes = {
     id: PropTypes.string,
     data: PropTypes.array,
+    legend: PropTypes.array,
     margin: PropTypes.object,
     getHeight: PropTypes.func,
     getWidth: PropTypes.func,

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -171,13 +171,12 @@ const PieChart = ({
     getWidth,
     getHeight
 }) => {
-    const colors = data.map(org => {
-        const name = org.id === -1 ? 'Others' : org.name;
+    const colors = data.map(({ id, name, count }) => {
         return {
-            id: org.id,
+            id,
             name,
-            value: color(name),
-            count: Math.round(org.count)
+            value: color(id),
+            count: Math.round(count)
         };
     }).sort((a, b) => (a.count > b.count) ? 1 : ((b.count > a.count) ? -1 : 0));
 
@@ -242,16 +241,16 @@ const PieChart = ({
         .enter()
         .append('path')
         .attr('d', arc)
-        .attr('fill', d => color(d.data.name));
+        .attr('fill', d => color(d.data.id));
 
         svg
         .selectAll('path')
         .on('mouseover', function(d) {
-            d3.select(this).style('fill', d3.rgb(color(d.data.name)).darker(1));
+            d3.select(this).style('fill', d3.rgb(color(d.data.id)).darker(1));
             donutTooltip.handleMouseOver(d);
         })
         .on('mouseout', function(d) {
-            d3.select(this).style('fill', color(d.data.name));
+            d3.select(this).style('fill', color(d.data.id));
             donutTooltip.handleMouseOut();
         })
         .on('mousemove', donutTooltip.handleMouseOver);

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -88,22 +88,24 @@ const optionsMapper = options => {
     return { ...rest };
 };
 
-const orgsChartMapper = attrName => ({ dates: data = []}) =>
-    data.map(({ date, items }) => ({
+const orgsChartMapper = attrName => ({ dates: data = [], meta }) => ({
+    data: data.map(({ date, items }) => ({
         date,
         items: items.map(({ id, [attrName]: value, name }) => ({
             id,
             date,
             value,
-            name: id === -1 ? 'Others' : (name || 'No organization')
+            name: name || 'No organization'
         }))
-    }));
+    })),
+    legend: meta.legend
+});
 
 const pieChartMapper = attrName => ({ items = []}) =>
     items.map(({ id, [attrName]: count, name }) => ({
         id,
         count,
-        name: id === -1 ? 'Others' : name || 'No organization'
+        name: name || 'No organization'
     }));
 
 const redirectToJobExplorer = (toJobExplorer, queryParams) => ({ date, id }) => {
@@ -244,12 +246,13 @@ const OrganizationStatistics = ({ history }) => {
                             <CardBody>
                                 {orgs.isLoading && <LoadingState />}
                                 {orgs.error && <ApiErrorState message={orgs.error.error} />}
-                                {orgs.isSuccess && orgs.data.length <= 0 && <NoData />}
-                                {orgs.isSuccess && orgs.data.length > 0 && (
+                                {orgs.isSuccess && orgs.data?.data.length <= 0 && <NoData />}
+                                {orgs.isSuccess && orgs.data?.data.length > 0 && (
                                     <GroupedBarChart
                                         margin={{ top: 20, right: 20, bottom: 50, left: 50 }}
                                         id="d3-grouped-bar-chart-root"
-                                        data={ orgs.data }
+                                        data={ orgs.data.data }
+                                        legend={ orgs.data.legend }
                                         history={ history }
                                         colorFunc={ colorFunc }
                                         yLabel={ chartMapper[activeTabKey].label }

--- a/src/Utilities/Legend.js
+++ b/src/Utilities/Legend.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Switch as PFSwitch } from '@patternfly/react-core';
+import { Switch } from '@patternfly/react-core';
 
 import styled from 'styled-components';
 
@@ -45,15 +45,9 @@ const Title = styled.span`
 
 const SubTitle = styled.span`
   font-size: 15px;
-  margin-left: 20px;
-`;
-
-const Switch = styled(PFSwitch)`
-  margin-left: 20px;
-
-  svg {
-    display: none;
-  }
+  margin-left: auto;
+  margin-right: 0;
+  padding-right: 10px;
 `;
 
 const Legend = ({
@@ -62,8 +56,6 @@ const Legend = ({
     height,
     onToggle
 }) => {
-    const handleChange = (_isChecked, { target: { value }}) => { onToggle(parseFloat(value)); };
-
     return (
         <Container height={ height }>
             { data.map(
@@ -73,13 +65,13 @@ const Legend = ({
                             <Color color={ value } />
                             <Title>{ name }</Title>
                         </Wrapper>
-                        { count && (
-                            <SubTitle>{ count }</SubTitle>
-                        ) }
+                        {count && (
+                            <SubTitle>{count}</SubTitle>
+                        )}
                         { selected && (
                             <Switch
                                 isChecked={ selected.some(selection => selection === id) }
-                                onChange={ handleChange }
+                                onChange={ () => onToggle(id) }
                                 aria-label={ name }
                                 value={ id }
                                 key={ index }


### PR DESCRIPTION
The API now provides a legend field in the meta, where the `Others` has the correct number before it. This PR making use of this extra information, displaying the correct number of others in the legend.

**Additionally:**
- The `name` prop could not be used for colors coding, since the `X Other` string could be different in the charts, so the `id` is used instead
- The grouped bar chart groups used the `name` as the domain for ordering, but since the `name` is now different in the series (since in every series there can be a different amount of `Others`) the `id` is used for specifying the subdomain bandwidth.

**CSS Update:**
Played around with the CSS in the legend to make the count align nicely and consistently to the right. 

**Before**:
![Screenshot from 2021-04-10 11-33-12](https://user-images.githubusercontent.com/8531681/114265342-8f481a00-99f0-11eb-9aea-672950b1d589.png)

**After**:
![Screenshot from 2021-04-10 11-30-54](https://user-images.githubusercontent.com/8531681/114265321-7475a580-99f0-11eb-98e9-467129a9db61.png)
