### PR TITLE
First cut of changes to display RBAC error message and stop loading of other elements on the screen when user does not have access to the screen.

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -28,6 +28,11 @@ function handleResponse(response) {
                 status: response.status,
                 message: json
             });
+        } else if (response.status === 403) {
+            return Promise.reject({
+                status: response.status,
+                error: 'RBAC access denied'
+            });
         } else {
             return Promise.reject(json);
         }

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
     Main,
+    NotAuthorized,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
 import { Card, CardBody } from '@patternfly/react-core';
+import { notAuthorizedParams } from '../../Utilities/constants';
 
 // Imports from custom components
 import LoadingState from '../../Components/LoadingState';
@@ -218,6 +220,10 @@ const AutomationCalculator = ({ history }) => {
             </Main>
         </WrapperRight>
     );
+    console.log('options', preflight);
+    if (preflight?.error?.status === 403) {
+        return <NotAuthorized { ...notAuthorizedParams } />;
+    }
 
     return (
         <React.Fragment>

--- a/src/Containers/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.test.js
@@ -3,7 +3,8 @@ import {
     history,
     mountPage,
     preflight200,
-    preflight400
+    preflight400,
+    preflight403
 } from '../../Utilities/tests/helpers';
 import fetchMock from 'fetch-mock-jest';
 import AutomationCalculator from './AutomationCalculator';
@@ -99,6 +100,16 @@ describe('Containers/AutomationCalculator', () => {
         wrapper.update();
 
         expect(wrapper.text()).toEqual(expect.stringContaining('Not authorized'));
+    });
+
+    it('should render RBAC Access error', async () => {
+        fetchMock.get({ ...preflight403 });
+        await act(async () => {
+            wrapper = mountPage(AutomationCalculator);
+        });
+        wrapper.update();
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('RBAC Access Denied'));
     });
 
     it('should render api error', async () => {

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -16,9 +16,11 @@ import useApi from '../../Utilities/useApi';
 
 import {
     Main,
+    NotAuthorized,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
+import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
     Card,
@@ -168,6 +170,10 @@ const Clusters = () => {
 
         fetchEndpoints();
     }, [ queryParams ]);
+
+    if (preflightError?.preflightError?.status === 403) {
+        return <NotAuthorized { ...notAuthorizedParams } />;
+    }
 
     return (
         <React.Fragment>

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -10,6 +10,7 @@ import LoadingState from '../../Components/LoadingState';
 import EmptyState from '../../Components/EmptyState';
 import NoResults from '../../Components/NoResults';
 import ApiErrorState from '../../Components/ApiErrorState';
+
 import {
     preflightRequest,
     readJobExplorer,
@@ -19,9 +20,11 @@ import { jobExplorer } from '../../Utilities/constants';
 
 import {
     Main,
+    NotAuthorized,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
+import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
     Card,
@@ -120,6 +123,10 @@ const JobExplorer = ({ location: { search }, history }) => {
         setOffset(nextOffset);
         setCurrPage(page);
     };
+
+    if (preflightError?.preflightError?.status === 403) {
+        return <NotAuthorized { ...notAuthorizedParams } />;
+    }
 
     return (
         <React.Fragment>

--- a/src/Containers/JobExplorer/JobExplorer.test.js
+++ b/src/Containers/JobExplorer/JobExplorer.test.js
@@ -3,7 +3,8 @@ import { stringify } from 'query-string';
 import {
     mountPage,
     preflight200,
-    preflight400
+    preflight400,
+    preflight403
 } from '../../Utilities/tests/helpers';
 import fetchMock from 'fetch-mock-jest';
 import JobExplorer from './JobExplorer';
@@ -90,6 +91,16 @@ describe('Containers/JobExplorer', () => {
         wrapper.update();
 
         expect(wrapper.text()).toEqual(expect.stringContaining('Not authorized'));
+    });
+
+    it('should render RBAC Access error', async () => {
+        fetchMock.get({ ...preflight403 });
+        await act(async () => {
+            wrapper = mountPage(JobExplorer);
+        });
+        wrapper.update();
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('RBAC Access Denied'));
     });
 
     it('should render api error', async () => {

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -10,9 +10,11 @@ import { preflightRequest, readClusters, readNotifications } from '../../Api';
 
 import {
     Main,
+    NotAuthorized,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
+import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
     Card,
@@ -197,6 +199,10 @@ const Notifications = () => {
         setOffset(nextOffset);
         setCurrPage(page);
     };
+
+    if (preflightError?.preflightError?.status === 403) {
+        return <NotAuthorized { ...notAuthorizedParams } />;
+    }
 
     return (
         <React.Fragment>

--- a/src/Containers/Notifications/Notifications.test.js
+++ b/src/Containers/Notifications/Notifications.test.js
@@ -3,7 +3,8 @@ import { parse } from 'query-string';
 import {
     mountPage,
     preflight200,
-    preflight400
+    preflight400,
+    preflight403
 } from '../../Utilities/tests/helpers';
 import fetchMock from 'fetch-mock-jest';
 import Notifications from './Notifications.js';
@@ -90,6 +91,16 @@ describe('Containers/Notifications', () => {
         expect(wrapper.text()).toEqual(expect.stringContaining('Not authorized'));
     });
 
+    it('should render RBAC Access error', async () => {
+        fetchMock.get({ ...preflight403, overwriteRoutes: true });
+        await act(async () => {
+            wrapper = mountPage(Notifications);
+        });
+        wrapper.update();
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('RBAC Access Denied'));
+    });
+
     xit('should render api error', async () => {
         fetchMock.get({
             url: notificationsUrl,
@@ -102,7 +113,9 @@ describe('Containers/Notifications', () => {
         });
         wrapper.update();
 
-        expect(wrapper.text()).toEqual(expect.stringContaining('General Error'));
+        expect(wrapper.text()).toEqual(expect.stringContaining('RBAC Access Denied'));
+        // RBAC access denied displayed
+        expect(wrapper.find('a')).toHaveLength(1);
     });
 
     it('should render with empty response', async () => {

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -21,9 +21,11 @@ import {
 
 import {
     Main,
+    NotAuthorized,
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
+import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
     Card,
@@ -219,6 +221,10 @@ const OrganizationStatistics = ({ history }) => {
         setJobs(readJobExplorer({ params: jobRunsByOrgParams }));
         setTasks(readJobExplorer({ params: jobEventsByOrgParams }));
     }, [ queryParams ]);
+
+    if (preflight?.error?.status === 403) {
+        return <NotAuthorized { ...notAuthorizedParams } />;
+    }
 
     return (
         <React.Fragment>

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
@@ -3,7 +3,8 @@ import { act } from 'react-dom/test-utils';
 import {
     mountPage,
     preflight200,
-    preflight400
+    preflight400,
+    preflight403
 } from '../../Utilities/tests/helpers';
 import fetchMock from 'fetch-mock-jest';
 import OrganizationStatistics from './OrganizationStatistics';
@@ -156,8 +157,17 @@ describe('Containers/OrganizationStatistics', () => {
             wrapper = mountPage(OrganizationStatistics);
         });
         wrapper.update();
-
         expect(wrapper.text()).toEqual(expect.stringContaining('Not authorized'));
+    });
+
+    it('should render RBAC Access error', async () => {
+        fetchMock.get({ ...preflight403, overwriteRoutes: true });
+        await act(async () => {
+            wrapper = mountPage(OrganizationStatistics);
+        });
+        wrapper.update();
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('RBAC Access Denied'));
     });
 
     it('should render api error', async () => {
@@ -171,7 +181,6 @@ describe('Containers/OrganizationStatistics', () => {
             wrapper = mountPage(OrganizationStatistics);
         });
         wrapper.update();
-
         expect(wrapper.text()).toEqual(expect.stringContaining('General Error'));
     });
 
@@ -182,7 +191,6 @@ describe('Containers/OrganizationStatistics', () => {
             wrapper = mountPage(OrganizationStatistics);
         });
         wrapper.update();
-
         expect(wrapper.text()).toEqual(expect.stringContaining('No Data'));
     });
 

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -76,3 +76,8 @@ export const clusters = {
         only_root_workflows_and_standalone_jobs: false
     }
 };
+
+export const notAuthorizedParams = {
+    title: 'RBAC Access Denied',
+    description: 'User does not have privileges to perform this action. Contact your organization adminstrator(s) for more information.'
+};

--- a/src/Utilities/tests/helpers.js
+++ b/src/Utilities/tests/helpers.js
@@ -30,3 +30,8 @@ export const preflight400 = {
     url: '/api/tower-analytics/v0/authorized/',
     response: { throws: { status: 401 }, status: 401 }
 };
+
+export const preflight403 = {
+    url: '/api/tower-analytics/v0/authorized/',
+    response: { throws: { status: 403 }, status: 403 }
+};


### PR DESCRIPTION
Added `AlertMessage` component that uses patternfly Alert component, this component can be used/enhanced further to be used as common component to display other notifications to user on screen.

https://issues.redhat.com/browse/AA-322

@benthomasson pls review first cut, hopefully i am on right track.

before
User without RBAC acces to Automation Calculator screen
![Screen Shot 2021-04-13 at 10 42 40 PM](https://user-images.githubusercontent.com/3450808/114646690-b8df9a80-9ca9-11eb-87f3-f5998f7b59cb.png)

User with RBAC acces to Automation Calculator screen
![Screen Shot 2021-04-13 at 10 43 14 PM](https://user-images.githubusercontent.com/3450808/114646735-ceed5b00-9ca9-11eb-8bea-5d8c0f7aeb96.png)

after
User without RBAC acces to Automation Calculator screen
![Screen Shot 2021-04-14 at 4 26 14 PM](https://user-images.githubusercontent.com/3450808/114774436-2e954600-9d3e-11eb-9108-538ec282c1c7.png)

User with RBAC acces to Automation Calculator screen
![Screen Shot 2021-04-13 at 10 41 42 PM](https://user-images.githubusercontent.com/3450808/114646777-e0cefe00-9ca9-11eb-92bc-d9b2ddc1f9a1.png)
