### PR TITLE
savings planner add flow

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -10,6 +10,7 @@ const hostExplorerEndpoint = '/api/tower-analytics/v1/host_explorer/';
 const eventExplorerEndpoint = '/api/tower-analytics/v1/event_explorer/';
 const ROIEndpoint = '/api/tower-analytics/v1/roi_templates/';
 const plansEndpoint = '/api/tower-analytics/v1/plans/';
+const planEndpoint = '/api/tower-analytics/v1/plan/';
 
 /* page options endpoints */
 const jobExplorerOptionsEndpoint =
@@ -128,6 +129,14 @@ export const readPlans = ({ params = {} }) => {
   const qs = stringify(paginationParams);
   let url = new URL(plansEndpoint, window.location.origin);
   url.search = qs;
+  return authenticatedFetch(url, {
+    method: 'POST',
+    body: JSON.stringify(params),
+  }).then(handleResponse);
+};
+
+export const createPlan = ({ params = {} }) => {
+  let url = new URL(planEndpoint, window.location.origin);
   return authenticatedFetch(url, {
     method: 'POST',
     body: JSON.stringify(params),

--- a/src/Components/Popover.js
+++ b/src/Components/Popover.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { node, string } from 'prop-types';
+import { Popover as PFPopover } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import styled from 'styled-components';
+
+const PopoverButton = styled.button`
+  padding: var(--pf-global--spacer--xs);
+  margin: -(var(--pf-global--spacer--xs));
+  font-size: var(--pf-global--FontSize--sm);
+`;
+
+function Popover({ ariaLabel, content, header, id, maxWidth, ...rest }) {
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <PFPopover
+      bodyContent={content}
+      headerContent={header}
+      hideOnOutsideClick
+      id={id}
+      maxWidth={maxWidth}
+      {...rest}
+    >
+      <PopoverButton
+        aria-label={ariaLabel ?? 'More information'}
+        aria-haspopup="true"
+        className="pf-c-form__group-label-help"
+        onClick={(e) => e.preventDefault()}
+        type="button"
+      >
+        <HelpIcon noVerticalAlign />
+      </PopoverButton>
+    </PFPopover>
+  );
+}
+
+Popover.propTypes = {
+  ariaLabel: string,
+  content: node,
+  header: node,
+  id: string,
+  maxWidth: string,
+};
+Popover.defaultProps = {
+  ariaLabel: null,
+  content: null,
+  header: null,
+  id: '',
+  maxWidth: '',
+};
+
+export default Popover;

--- a/src/Components/Toolbar/Toolbar.js
+++ b/src/Components/Toolbar/Toolbar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Toolbar,
   ToolbarContent,
+  ToolbarGroup,
   Button,
   ToolbarItem,
 } from '@patternfly/react-core';
@@ -20,6 +21,7 @@ const FilterableToolbar = ({
   setFilters,
   pagination = null,
   hasSettings = false,
+  additionalControls = [],
 }) => {
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const { quick_date_range, sort_options, ...restCategories } = categories;
@@ -78,6 +80,13 @@ const FilterableToolbar = ({
               </Button>
             </ToolbarItem>
           )}
+          {additionalControls.length > 0 && (
+            <ToolbarGroup>
+              {additionalControls.map((control) => (
+                <ToolbarItem key={control.key}>{control}</ToolbarItem>
+              ))}
+            </ToolbarGroup>
+          )}
           {pagination && (
             <ToolbarItem
               variant="pagination"
@@ -106,6 +115,7 @@ FilterableToolbar.propTypes = {
   setFilters: PropTypes.func.isRequired,
   pagination: PropTypes.object,
   hasSettings: PropTypes.bool,
+  additionalControls: PropTypes.array,
 };
 
 export default FilterableToolbar;

--- a/src/Containers/SavingsPlanner/Add/index.js
+++ b/src/Containers/SavingsPlanner/Add/index.js
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+
+import { Card, CardBody } from '@patternfly/react-core';
+
+import Main from '@redhat-cloud-services/frontend-components/Main';
+import {
+  PageHeader,
+  PageHeaderTitle,
+} from '@redhat-cloud-services/frontend-components/PageHeader';
+
+import Breadcrumbs from '../../../Components/Breadcrumbs';
+
+import useApi from '../../../Utilities/useApi';
+
+import { readPlanOptions } from '../../../Api';
+
+import Form from '../Shared/Form';
+
+const Add = () => {
+  const [options, setOptions] = useApi({});
+
+  useEffect(() => {
+    setOptions(readPlanOptions());
+  }, []);
+
+  const title = 'Create new plan';
+
+  return (
+    <>
+      <PageHeader>
+        <Breadcrumbs
+          items={[{ title: 'Savings Planner', navigate: '/savings-planner' }]}
+        />
+        <PageHeaderTitle title={title} />
+      </PageHeader>
+      <Main>
+        <Card>
+          <CardBody>
+            {options.isSuccess && <Form title={title} options={options} />}
+          </CardBody>
+        </Card>
+      </Main>
+    </>
+  );
+};
+
+export default Add;

--- a/src/Containers/SavingsPlanner/SavingsPlanner.js
+++ b/src/Containers/SavingsPlanner/SavingsPlanner.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { preflightRequest, readPlanOptions, readPlans } from '../../Api';
 import FilterableToolbar from '../../Components/Toolbar/';
@@ -17,12 +18,17 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-
 import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 
-import { Gallery, PaginationVariant } from '@patternfly/react-core';
+import { Button, Gallery, PaginationVariant } from '@patternfly/react-core';
+
+// TODO: update to fining this out from API RBAC
+const canAddPlan = true;
 
 const SavingsPlanner = () => {
+  const history = useHistory();
+  const { pathname } = useLocation();
+
   const { queryParams, setFromPagination, setFromToolbar } = useQueryParams(
     savingsPlanner.defaultParams
   );
@@ -67,6 +73,24 @@ const SavingsPlanner = () => {
           categories={combinedOptions}
           filters={queryParams}
           setFilters={setFromToolbar}
+          additionalControls={[
+            ...(canAddPlan
+              ? [
+                  <Button
+                    key="add-plan-button"
+                    variant="primary"
+                    aria-label="Add plan"
+                    onClick={() => {
+                      history.push({
+                        pathname: `${pathname}/add`,
+                      });
+                    }}
+                  >
+                    Add plan
+                  </Button>,
+                ]
+              : []),
+          ]}
           pagination={
             <Pagination
               count={meta?.total_count}

--- a/src/Containers/SavingsPlanner/Shared/Details.js
+++ b/src/Containers/SavingsPlanner/Shared/Details.js
@@ -12,21 +12,10 @@ import {
 
 import Popover from '../../../Components/Popover';
 
-const Details = ({
-  options,
-  name,
-  setName,
-  category,
-  setCategory,
-  description,
-  setDescription,
-  manualTime,
-  setManualTime,
-  hosts,
-  setHosts,
-  frequencyPeriod,
-  setFrequencyPeriod,
-}) => {
+const Details = ({ options, formData, setField }) => {
+  const { name, category, description, manual_time, hosts, frequency_period } =
+    formData;
+
   const [categoryIsOpen, setCategoryIsOpen] = useState(false);
   const [manualTimeIsOpen, setManualTimeIsOpen] = useState(false);
   const [frequencyPeriodIsOpen, setFrequencyPeriodIsOpen] = useState(false);
@@ -47,7 +36,7 @@ const Details = ({
               id="name-field"
               name="name"
               value={name}
-              onChange={(newName) => setName(newName)}
+              onChange={(newName) => setField('name', newName)}
             />
           </FormGroup>
           <FormGroup
@@ -62,7 +51,7 @@ const Details = ({
               aria-label={'Plan category selector'}
               onToggle={() => setCategoryIsOpen(!categoryIsOpen)}
               onSelect={(_event, selection) => {
-                setCategory(selection);
+                setField('category', selection);
                 setCategoryIsOpen(false);
               }}
               selections={category}
@@ -81,7 +70,9 @@ const Details = ({
               id="description-field"
               name="description"
               value={description}
-              onChange={(newDescription) => setDescription(newDescription)}
+              onChange={(newDescription) =>
+                setField('description', newDescription)
+              }
             />
           </FormGroup>
           <FormGroup
@@ -99,10 +90,10 @@ const Details = ({
               aria-label={'Plan time selector'}
               onToggle={() => setManualTimeIsOpen(!manualTimeIsOpen)}
               onSelect={(_event, selection) => {
-                setManualTime(selection);
+                setField('manual_time', selection);
                 setManualTimeIsOpen(false);
               }}
-              selections={manualTime}
+              selections={manual_time}
             >
               {(options.data?.manual_time || []).map(({ key, value }) => (
                 <SelectOption key={key} value={key}>
@@ -121,7 +112,7 @@ const Details = ({
               id="hosts-field"
               name="hosts"
               value={hosts}
-              onChange={(newHosts) => setHosts(newHosts)}
+              onChange={(newHosts) => setField('hosts', newHosts)}
             />
           </FormGroup>
           <FormGroup
@@ -141,10 +132,10 @@ const Details = ({
                 setFrequencyPeriodIsOpen(!frequencyPeriodIsOpen);
               }}
               onSelect={(_event, selection) => {
-                setFrequencyPeriod(selection);
+                setField('frequency_period', selection);
                 setFrequencyPeriodIsOpen(false);
               }}
-              selections={frequencyPeriod}
+              selections={frequency_period}
             >
               {(options.data?.frequency_period || []).map(({ key, value }) => (
                 <SelectOption key={key} value={key}>
@@ -161,18 +152,8 @@ const Details = ({
 
 Details.propTypes = {
   options: PropTypes.object.isRequired,
-  name: PropTypes.string.isRequired,
-  setName: PropTypes.func.isRequired,
-  category: PropTypes.string.isRequired,
-  setCategory: PropTypes.func.isRequired,
-  description: PropTypes.string.isRequired,
-  setDescription: PropTypes.func.isRequired,
-  manualTime: PropTypes.number.isRequired,
-  setManualTime: PropTypes.func.isRequired,
-  hosts: PropTypes.number.isRequired,
-  setHosts: PropTypes.func.isRequired,
-  frequencyPeriod: PropTypes.string.isRequired,
-  setFrequencyPeriod: PropTypes.func.isRequired,
+  formData: PropTypes.object.isRequired,
+  setField: PropTypes.func.isRequired,
 };
 
 export default Details;

--- a/src/Containers/SavingsPlanner/Shared/Details.js
+++ b/src/Containers/SavingsPlanner/Shared/Details.js
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Form,
+  FormGroup,
+  Grid,
+  Select,
+  SelectOption,
+  TextInput,
+} from '@patternfly/react-core';
+
+import Popover from '../../../Components/Popover';
+
+const Details = ({
+  options,
+  name,
+  setName,
+  category,
+  setCategory,
+  description,
+  setDescription,
+  manualTime,
+  setManualTime,
+  hosts,
+  setHosts,
+  frequencyPeriod,
+  setFrequencyPeriod,
+}) => {
+  const [categoryIsOpen, setCategoryIsOpen] = useState(false);
+  const [manualTimeIsOpen, setManualTimeIsOpen] = useState(false);
+  const [frequencyPeriodIsOpen, setFrequencyPeriodIsOpen] = useState(false);
+
+  return (
+    <Form>
+      {options?.data && (
+        <Grid hasGutter md={6}>
+          <FormGroup
+            label="What do you want to automate?"
+            isRequired
+            fieldId="name-field"
+          >
+            <TextInput
+              isRequired
+              placeholder="Example: Provision NGINX server"
+              type="text"
+              id="name-field"
+              name="name"
+              value={name}
+              onChange={(newName) => setName(newName)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="What type of task is it?"
+            isRequired
+            fieldId="category-field"
+          >
+            <Select
+              id="category-field"
+              isOpen={categoryIsOpen}
+              variant={'single'}
+              aria-label={'Plan category selector'}
+              onToggle={() => setCategoryIsOpen(!categoryIsOpen)}
+              onSelect={(_event, selection) => {
+                setCategory(selection);
+                setCategoryIsOpen(false);
+              }}
+              selections={category}
+            >
+              {(options.data?.category || []).map(({ key, value }) => (
+                <SelectOption key={key} value={key}>
+                  {value}
+                </SelectOption>
+              ))}
+            </Select>
+          </FormGroup>
+          <FormGroup label="Description" fieldId="description-field">
+            <TextInput
+              type="text"
+              placeholder="Place description here"
+              id="description-field"
+              name="description"
+              value={description}
+              onChange={(newDescription) => setDescription(newDescription)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="How long does it take to do this manually?"
+            fieldId="manual-time-field"
+            labelIcon={
+              <Popover content="Select the option closest to the average amount of time the thing you are trying to automate takes each time it is done." />
+            }
+          >
+            <Select
+              id="manual-time-field"
+              isOpen={manualTimeIsOpen}
+              variant={'single'}
+              placeholderText="Select amount"
+              aria-label={'Plan time selector'}
+              onToggle={() => setManualTimeIsOpen(!manualTimeIsOpen)}
+              onSelect={(_event, selection) => {
+                setManualTime(selection);
+                setManualTimeIsOpen(false);
+              }}
+              selections={manualTime}
+            >
+              {(options.data?.manual_time || []).map(({ key, value }) => (
+                <SelectOption key={key} value={key}>
+                  {value}
+                </SelectOption>
+              ))}
+            </Select>
+          </FormGroup>
+          <FormGroup
+            label="How many hosts do you plan to run this on?"
+            fieldId="hosts-field"
+          >
+            <TextInput
+              type="number"
+              placeholder="Enter number of hosts"
+              id="hosts-field"
+              name="hosts"
+              value={hosts}
+              onChange={(newHosts) => setHosts(newHosts)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="How often do you do this?"
+            fieldId="frequency-period-field"
+            labelIcon={
+              <Popover content="Select the option closest to the average number of times the thing you are trying to automate is done manually." />
+            }
+          >
+            <Select
+              id="frequency-period-field"
+              isOpen={frequencyPeriodIsOpen}
+              variant={'single'}
+              placeholderText="Select frequency period"
+              aria-label={'Plan frequency period selector'}
+              onToggle={() => {
+                setFrequencyPeriodIsOpen(!frequencyPeriodIsOpen);
+              }}
+              onSelect={(_event, selection) => {
+                setFrequencyPeriod(selection);
+                setFrequencyPeriodIsOpen(false);
+              }}
+              selections={frequencyPeriod}
+            >
+              {(options.data?.frequency_period || []).map(({ key, value }) => (
+                <SelectOption key={key} value={key}>
+                  {value}
+                </SelectOption>
+              ))}
+            </Select>
+          </FormGroup>
+        </Grid>
+      )}
+    </Form>
+  );
+};
+
+Details.propTypes = {
+  options: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  setName: PropTypes.func.isRequired,
+  category: PropTypes.string.isRequired,
+  setCategory: PropTypes.func.isRequired,
+  description: PropTypes.string.isRequired,
+  setDescription: PropTypes.func.isRequired,
+  manualTime: PropTypes.number.isRequired,
+  setManualTime: PropTypes.func.isRequired,
+  hosts: PropTypes.number.isRequired,
+  setHosts: PropTypes.func.isRequired,
+  frequencyPeriod: PropTypes.string.isRequired,
+  setFrequencyPeriod: PropTypes.func.isRequired,
+};
+
+export default Details;

--- a/src/Containers/SavingsPlanner/Shared/Form.js
+++ b/src/Containers/SavingsPlanner/Shared/Form.js
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useHistory, useLocation, Redirect } from 'react-router-dom';
+
+import { Wizard } from '@patternfly/react-core';
+
+import { Paths } from '../../../paths';
+
+import useApi from '../../../Utilities/useApi';
+
+import { createPlan } from '../../../Api';
+
+import Details from './Details';
+import Tasks from './Tasks';
+import Templates from './Templates';
+
+const Form = ({ title, options }) => {
+  const history = useHistory();
+  const { hash } = useLocation();
+
+  const [startStep, setStartStep] = useState(null);
+
+  useEffect(() => {
+    if (hash) {
+      setStartStep(steps.find((step) => `#${step.id}` === hash).step_number);
+    } else {
+      history.replace({
+        hash: 'details',
+      });
+      setStartStep(1);
+    }
+  }, []);
+
+  const [{ isSuccess }, setData] = useApi({ meta: {}, items: [] });
+
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('system');
+  const [description, setDescription] = useState('');
+  const [manualTime, setManualTime] = useState(240);
+  const [hosts, setHosts] = useState(1);
+  const [frequencyPeriod, setFrequencyPeriod] = useState('weekly');
+  const [tasks, setTasks] = useState([]);
+  const [templateId, setTemplateId] = useState(-2);
+
+  const onStepChange = (newStep) => {
+    history.replace({
+      hash: newStep.id,
+    });
+  };
+
+  const onSave = () => {
+    setData(
+      createPlan({
+        params: {
+          name,
+          category,
+          description,
+          manual_time: manualTime,
+          hosts,
+          frequency_period: frequencyPeriod,
+          tasks: tasks.map((task, index) => ({
+            task,
+            task_order: index + 1,
+          })),
+          template_id: templateId,
+          hourly_rate: 50,
+          frequency_per_period: 1,
+        },
+      })
+    );
+  };
+
+  const steps = [
+    {
+      step_number: 1,
+      id: 'details',
+      name: 'Details',
+      component: (
+        <Details
+          options={options}
+          name={name}
+          setName={setName}
+          category={category}
+          setCategory={setCategory}
+          description={description}
+          setDescription={setDescription}
+          manualTime={manualTime}
+          setManualTime={setManualTime}
+          hosts={hosts}
+          setHosts={setHosts}
+          frequencyPeriod={frequencyPeriod}
+          setFrequencyPeriod={setFrequencyPeriod}
+        />
+      ),
+    },
+    {
+      step_number: 2,
+      id: 'tasks',
+      name: 'Tasks',
+      component: <Tasks tasks={tasks} setTasks={setTasks} />,
+    },
+    {
+      step_number: 3,
+      id: 'link_template',
+      name: 'Link template',
+      component: (
+        <Templates
+          templates={options?.data?.template_id}
+          templateId={templateId}
+          setTemplateId={setTemplateId}
+        />
+      ),
+      nextButtonText: 'Save',
+    },
+  ];
+
+  return (
+    <>
+      {isSuccess && <Redirect to={Paths.savingsPlanner} />}
+      <Wizard
+        navAriaLabel={`${title} steps`}
+        mainAriaLabel={`${title} content`}
+        steps={steps}
+        onGoToStep={onStepChange}
+        onNext={onStepChange}
+        onBack={onStepChange}
+        onSave={onSave}
+        startAtStep={startStep}
+        height="calc(100vh - 285px)"
+      />
+    </>
+  );
+};
+
+Form.propTypes = {
+  title: PropTypes.string.isRequired,
+  options: PropTypes.object.isRequired,
+};
+
+export default Form;

--- a/src/Containers/SavingsPlanner/Shared/Tasks.js
+++ b/src/Containers/SavingsPlanner/Shared/Tasks.js
@@ -41,7 +41,11 @@ const TaskRow = styled(DataListItemRow)`
   align-items: center;
 `;
 
-const Tasks = ({ tasks, setTasks }) => {
+const Tasks = ({ tasks, setField }) => {
+  const setTasks = (val) => {
+    setField('tasks', val);
+  };
+
   const [taskToAdd, setTaskToAdd] = useState('');
 
   const [liveText, setLiveText] = useState('');
@@ -174,7 +178,7 @@ const Tasks = ({ tasks, setTasks }) => {
 
 Tasks.propTypes = {
   tasks: PropTypes.array.isRequired,
-  setTasks: PropTypes.func.isRequired,
+  setField: PropTypes.func.isRequired,
 };
 
 export default Tasks;

--- a/src/Containers/SavingsPlanner/Shared/Tasks.js
+++ b/src/Containers/SavingsPlanner/Shared/Tasks.js
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import {
+  Button,
+  DataList,
+  DataListAction,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListControl,
+  DataListDragButton,
+  DataListItemCells,
+  Form,
+  FormGroup,
+  Grid,
+  InputGroup,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { PlusIcon, TimesIcon } from '@patternfly/react-icons';
+
+const TaskSection = styled.div`
+  margin-top: 20px;
+`;
+
+const TaskTitle = styled(Title)`
+  margin-bottom: 10px;
+`;
+
+const TaskDeleteButton = styled(Button)`
+  padding: 0 16px;
+`;
+
+const DeleteTaskActionSection = styled(DataListAction)`
+  padding: 6px 0;
+`;
+
+const TaskRow = styled(DataListItemRow)`
+  align-items: center;
+`;
+
+const Tasks = ({ tasks, setTasks }) => {
+  const [taskToAdd, setTaskToAdd] = useState('');
+
+  const [liveText, setLiveText] = useState('');
+  const [id, setId] = useState('');
+
+  const onDragStart = (newId) => {
+    setId(newId);
+    setLiveText(`Dragging started for task ${newId}.`);
+  };
+
+  const onDragMove = (oldIndex, newIndex) => {
+    setLiveText(
+      `Dragging task ${id}.  Task ${oldIndex} is now task ${newIndex}.`
+    );
+  };
+
+  const onDragCancel = () => {
+    setLiveText('Dragging cancelled. Tasks list order is unchanged.');
+  };
+
+  const onDragFinish = (newItemOrder) => {
+    setLiveText('Dragging finsihed');
+    setTasks([...newItemOrder]);
+  };
+
+  const appendTask = () => {
+    setTasks([...tasks, taskToAdd]);
+    setTaskToAdd('');
+  };
+
+  const handleTextKeyDown = (e) => {
+    if (e.key && e.key === 'Enter') {
+      e.preventDefault();
+      appendTask();
+    }
+  };
+
+  const removeTask = (task) => {
+    setTasks(tasks.filter((t) => t !== task));
+  };
+
+  return (
+    <>
+      <Form>
+        <Grid hasGutter md={6}>
+          <FormGroup
+            label="What tasks do you need to accomplish this plan?"
+            fieldId="task-field"
+          >
+            <InputGroup>
+              <TextInput
+                placeholder="Enter a description of the task"
+                type="text"
+                id="task-field"
+                name="task"
+                value={taskToAdd}
+                onChange={(newTaskName) => setTaskToAdd(newTaskName)}
+                onKeyDown={handleTextKeyDown}
+              />
+              <Button
+                onClick={appendTask}
+                variant="control"
+                aria-label="Add task"
+              >
+                <PlusIcon />
+              </Button>
+            </InputGroup>
+          </FormGroup>
+        </Grid>
+      </Form>
+      {tasks.length > 0 && (
+        <TaskSection>
+          <TaskTitle headingLevel="h4" size="xl">
+            Tasks
+          </TaskTitle>
+          <DataList
+            aria-label="Draggable list to reorder and remove tasks."
+            isCompact
+            onDragFinish={onDragFinish}
+            onDragStart={onDragStart}
+            onDragMove={onDragMove}
+            onDragCancel={onDragCancel}
+            itemOrder={tasks}
+          >
+            {tasks.map((task, index) => (
+              <DataListItem
+                aria-labelledby={`cell-${index + 1}`}
+                id={task}
+                key={index + 1}
+              >
+                <TaskRow>
+                  <DataListControl>
+                    <DataListDragButton
+                      aria-label="Reorder"
+                      aria-labelledby={`cell-${index + 1}`}
+                      aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                      aria-pressed="false"
+                    />
+                  </DataListControl>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={index + 1}>
+                        <span id={`cell-${index + 1}`}>{`${
+                          index + 1
+                        }. ${task}`}</span>
+                      </DataListCell>,
+                    ]}
+                  />
+                  <DeleteTaskActionSection aria-label="Actions">
+                    <TaskDeleteButton
+                      onClick={() => removeTask(task)}
+                      variant="plain"
+                      aria-label="Delete"
+                    >
+                      <TimesIcon />
+                    </TaskDeleteButton>
+                  </DeleteTaskActionSection>
+                </TaskRow>
+              </DataListItem>
+            ))}
+          </DataList>
+        </TaskSection>
+      )}
+      <div className="pf-screen-reader" aria-live="assertive">
+        {liveText}
+      </div>
+    </>
+  );
+};
+
+Tasks.propTypes = {
+  tasks: PropTypes.array.isRequired,
+  setTasks: PropTypes.func.isRequired,
+};
+
+export default Tasks;

--- a/src/Containers/SavingsPlanner/Shared/Templates.js
+++ b/src/Containers/SavingsPlanner/Shared/Templates.js
@@ -18,7 +18,7 @@ const TemplateRow = styled(DataListItemRow)`
   align-items: center;
 `;
 
-const Templates = ({ templates = [], templateId, setTemplateId }) => {
+const Templates = ({ templates = [], template_id, setField }) => {
   return (
     <Form>
       <>
@@ -32,9 +32,9 @@ const Templates = ({ templates = [], templateId, setTemplateId }) => {
                 <TemplateRow>
                   <DataListControl>
                     <Radio
-                      isChecked={templateId === key}
+                      isChecked={template_id === key}
                       name={`radio-${key}`}
-                      onChange={() => setTemplateId(key)}
+                      onChange={() => setField('template_id', key)}
                       aria-label={`Radio selector for template ${key}.`}
                       id={`radio-${key}`}
                       value={key}
@@ -59,8 +59,8 @@ const Templates = ({ templates = [], templateId, setTemplateId }) => {
 
 Templates.propTypes = {
   templates: PropTypes.array,
-  templateId: PropTypes.number.isRequired,
-  setTemplateId: PropTypes.func.isRequired,
+  template_id: PropTypes.number.isRequired,
+  setField: PropTypes.func.isRequired,
 };
 
 Templates.defaultProps = {

--- a/src/Containers/SavingsPlanner/Shared/Templates.js
+++ b/src/Containers/SavingsPlanner/Shared/Templates.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import {
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListControl,
+  DataListItemCells,
+  Form,
+  FormGroup,
+  Radio,
+} from '@patternfly/react-core';
+
+const TemplateRow = styled(DataListItemRow)`
+  align-items: center;
+`;
+
+const Templates = ({ templates = [], templateId, setTemplateId }) => {
+  return (
+    <Form>
+      <>
+        <FormGroup
+          label="Link a template to this plan."
+          fieldId="template-link-field"
+        >
+          <DataList aria-label="draggable data list example" isCompact>
+            {templates.map(({ key, value }) => (
+              <DataListItem aria-labelledby={`cell-${key}`} id={key} key={key}>
+                <TemplateRow>
+                  <DataListControl>
+                    <Radio
+                      isChecked={templateId === key}
+                      name={`radio-${key}`}
+                      onChange={() => setTemplateId(key)}
+                      aria-label={`Radio selector for template ${key}.`}
+                      id={`radio-${key}`}
+                      value={key}
+                    />
+                  </DataListControl>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={key}>
+                        <span id={`cell-${key}`}>{value}</span>
+                      </DataListCell>,
+                    ]}
+                  />
+                </TemplateRow>
+              </DataListItem>
+            ))}
+          </DataList>
+        </FormGroup>
+      </>
+    </Form>
+  );
+};
+
+Templates.propTypes = {
+  templates: PropTypes.array,
+  templateId: PropTypes.number.isRequired,
+  setTemplateId: PropTypes.func.isRequired,
+};
+
+Templates.defaultProps = {
+  templates: [],
+};
+
+export default Templates;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -36,6 +36,13 @@ const JobExplorer = asyncComponent(() =>
   )
 );
 
+const SavingsPlanAdd = asyncComponent(() =>
+  import(
+    /* webpackChunkName: "automation_analytics" */
+    './Containers/SavingsPlanner/Add/index'
+  )
+);
+
 const SavingsPlanner = asyncComponent(() =>
   import(
     /* webpackChunkName: "automation_analytics" */
@@ -91,6 +98,11 @@ export const Routes = () => {
         path={Paths.jobExplorer}
         component={JobExplorer}
         rootClass="jobExplorer"
+      />
+      <InsightsRoute
+        path={Paths.savingsPlanAdd}
+        component={SavingsPlanAdd}
+        rootClass="SavingsPlanAdd"
       />
       <InsightsRoute
         path={Paths.savingsPlan}

--- a/src/Utilities/useForm.js
+++ b/src/Utilities/useForm.js
@@ -1,0 +1,25 @@
+import { useReducer } from 'react';
+
+const useForm = (initial) => {
+  const formReducer = (state, { type, value }) => {
+    switch (type) {
+      /* v1 api reducers */
+      case 'SET_FIELD':
+        return { ...state, ...value };
+      default:
+        throw new Error();
+    }
+  };
+
+  const [formData, dispatch] = useReducer(formReducer, {
+    ...initial,
+  });
+
+  return {
+    formData,
+    setField: (field, value) =>
+      dispatch({ type: 'SET_FIELD', value: { [field]: value } }),
+  };
+};
+
+export default useForm;

--- a/src/paths.js
+++ b/src/paths.js
@@ -6,4 +6,5 @@ export const Paths = {
   jobExplorer: '/job-explorer',
   savingsPlanner: '/savings-planner',
   savingsPlan: '/savings-planner/:id',
+  savingsPlanAdd: '/savings-planner/add',
 };


### PR DESCRIPTION
This PR adds the Savings Planner add flow.

Currently, the pr:
- Adds “Add plan” button to Savings Planner card view to get to add screen
- Adds breadcrumb link back to savings planner list
- Adds in wizard component with hash-linkable steps (the hash linking will be needed for edit view)
- Adds in grid-based form from PF
    - Some fields needed the ? Help popover link in the label of the field…I pulled in this component from awx.
- Adds in drag-orderable task adding list
    - Task add input allows both enter key-down and clicking “+” button to add
    - Clicking the “x” in the remove will remove the task from the list.  I talked with Taufique and we decided against any sort of confirmation dialog for this particular interaction.
- Adds in radio single-select template list
    - Note, this is a simple, non-paginated DataList currently.  Will need to figure out with @akarve on the backend about pagination, searching, etc. in a follow-up PR
- Make save POST things to the API.

This is also my attempt at utilizing the naming conventions we discussed in our Monday sync-up meeting.  Please let me know what y'all think about this...happy to tweak names and file locations!

These TODOs I will do in a follow-up PR:
- TODO: Add unit tests
- TODO: Any tweaks @kyleabenson wants to category/platform/cloud on details form screen.
- TODO: Disable save button when required fields aren’t entered, and have a tooltip of what needs to be added/where you need to go to do that.
- TODO: Show informative error message when API POST fails to add.
- TODO: Hide add button and do the redirection notice from the add view when user has read-only role (RBAC)
