### PR TITLE
Fix: Toolbar props accepts number or string array as it should

### DIFF
--- a/src/Components/Toolbar/Groups/ToolbarInput/Select.js
+++ b/src/Components/Toolbar/Groups/ToolbarInput/Select.js
@@ -115,8 +115,11 @@ const Select = ({
 Select.propTypes = {
   categoryKey: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
+    PropTypes.number,
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
   ]).isRequired,
   selectOptions: PropTypes.array,
   isVisible: PropTypes.bool,

--- a/src/Components/Toolbar/Groups/ToolbarInput/index.js
+++ b/src/Components/Toolbar/Groups/ToolbarInput/index.js
@@ -47,8 +47,11 @@ const ToolbarInput = ({
 ToolbarInput.propTypes = {
   categoryKey: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
+    PropTypes.number,
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
   ]),
   selectOptions: PropTypes.array,
   isVisible: PropTypes.bool,


### PR DESCRIPTION
I got it wrong how the `PropTypes.arrayOf()` works. My bad. This commit fixes the warnings that it was throwing when using the toolbar.