### PR TITLE
Added Delete button on List and Details view

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -143,6 +143,13 @@ export const createPlan = ({ params = {} }) => {
   }).then(handleResponse);
 };
 
+export const deletePlan = ({ params = {} }) => {
+  let url = new URL(`${planEndpoint}${params.id}`, window.location.origin);
+  return authenticatedFetch(url, {
+    method: 'DELETE'
+  }).then(handleResponse);
+};
+
 export const updatePlan = ({ id, params = {} }) => {
   let url = new URL(`${planEndpoint}${id}`, window.location.origin);
   return authenticatedFetch(url, {

--- a/src/Components/AlertModal/AlertModal.js
+++ b/src/Components/AlertModal/AlertModal.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Modal, Title } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+  TimesCircleIcon,
+} from '@patternfly/react-icons';
+import styled from 'styled-components';
+
+const Header = styled.div`
+  display: flex;
+  svg {
+    margin-right: 16px;
+  }
+`;
+
+function AlertModal({
+  isOpen = null,
+  title,
+  label,
+  variant,
+  children,
+  ...props
+}) {
+  const variantIcons = {
+    danger: (
+      <ExclamationCircleIcon
+        size="lg"
+        css="color: var(--pf-global--danger-color--100)"
+      />
+    ),
+    error: (
+      <TimesCircleIcon
+        size="lg"
+        css="color: var(--pf-global--danger-color--100)"
+      />
+    ),
+    info: (
+      <InfoCircleIcon
+        size="lg"
+        css="color: var(--pf-global--info-color--100)"
+      />
+    ),
+    success: (
+      <CheckCircleIcon
+        size="lg"
+        css="color: var(--pf-global--success-color--100)"
+      />
+    ),
+    warning: (
+      <ExclamationTriangleIcon
+        size="lg"
+        css="color: var(--pf-global--warning-color--100)"
+      />
+    ),
+  };
+
+  const customHeader = (
+    <Header>
+      {variant ? variantIcons[variant] : null}
+      <Title id="alert-modal-header-label" size="2xl" headingLevel="h2">
+        {title}
+      </Title>
+    </Header>
+  );
+
+  return (
+    <Modal
+      header={customHeader}
+      aria-label={label || 'Alert modal'}
+      aria-labelledby="alert-modal-header-label"
+      isOpen={Boolean(isOpen)}
+      variant="small"
+      title={title}
+      {...props}
+    >
+      {children}
+    </Modal>
+  );
+}
+
+export default AlertModal;

--- a/src/Components/AlertModal/AlertModal.test.js
+++ b/src/Components/AlertModal/AlertModal.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import {MemoryRouter} from "react-router-dom";
+import AlertModal from './AlertModal';
+
+describe('<AlertModal />', () => {
+  it('renders the expected content', () => {
+      render(
+        <MemoryRouter>
+          <AlertModal isOpen='true' title='Danger!' variant='warning'>Are you sure?</AlertModal>
+        </MemoryRouter>
+      );
+      expect(screen.getByText('Danger!')).toBeTruthy();
+  });
+});

--- a/src/Components/AlertModal/index.js
+++ b/src/Components/AlertModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './AlertModal';

--- a/src/Components/CardActionsRow.js
+++ b/src/Components/CardActionsRow.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CardActions } from '@patternfly/react-core';
+import styled from 'styled-components';
+
+const CardActionsWrapper = styled.div`
+  margin-top: 20px;
+  --pf-c-card__actions--PaddingLeft: 0;
+`;
+
+function CardActionsRow({ children }) {
+  return (
+    <CardActionsWrapper>
+      <CardActions>{children}</CardActions>
+    </CardActionsWrapper>
+  );
+}
+
+export default CardActionsRow;

--- a/src/Components/DeleteButton/DeleteButton.js
+++ b/src/Components/DeleteButton/DeleteButton.js
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import styled from 'styled-components';
+import { Button, Badge, Alert, Tooltip } from '@patternfly/react-core';
+import AlertModal from '../AlertModal';
+import { getRelatedResourceDeleteCounts } from '../../Utilities/getRelatedResourceDeleteDetails';
+import ErrorDetail from '../ErrorDetail';
+
+const WarningMessage = styled(Alert)`
+  margin-top: 10px;
+`;
+const Label = styled.span`
+  && {
+    margin-right: 10px;
+  }
+`;
+function DeleteButton({
+  onConfirm,
+  modalTitle,
+  name,
+  variant,
+  children,
+  isDisabled,
+  ouiaId,
+  deleteMessage,
+  deleteDetailsRequests,
+  disabledTooltip,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [deleteMessageError, setDeleteMessageError] = useState();
+  const [deleteDetails, setDeleteDetails] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const toggleModal = async isModalOpen => {
+    setIsLoading(true);
+    if (deleteDetailsRequests?.length && isModalOpen) {
+      const { results, error } = await getRelatedResourceDeleteCounts(
+        deleteDetailsRequests
+      );
+      if (error) {
+        setDeleteMessageError(error);
+      } else {
+        setDeleteDetails(results);
+      }
+    }
+    setIsLoading(false);
+    setIsOpen(isModalOpen);
+  };
+
+  if (deleteMessageError) {
+    return (
+      <AlertModal
+        isOpen={deleteMessageError}
+        title={'Error!'}
+        onClose={() => {
+          toggleModal(false);
+          setDeleteMessageError();
+        }}
+      >
+        <ErrorDetail error={deleteMessageError} />
+      </AlertModal>
+    );
+  }
+  return (
+    <>
+      {disabledTooltip ? (
+        <Tooltip content={disabledTooltip} position="top">
+          <div>
+            <Button
+              spinnerAriaValueText={isLoading ? 'Loading' : undefined}
+              variant={variant || 'secondary'}
+              aria-label={'Delete'}
+              isDisabled={isDisabled}
+              onClick={() => toggleModal(true)}
+              ouiaId={ouiaId}
+            >
+              {children || 'Delete'}
+            </Button>
+          </div>
+        </Tooltip>
+      ) : (
+        <Button
+          ouiaId={ouiaId}
+          spinnerAriaValueText={isLoading ? 'Loading' : undefined}
+          variant={variant || 'secondary'}
+          aria-label={'Delete'}
+          isDisabled={isDisabled}
+          onClick={() => toggleModal(true)}
+        >
+          {children || 'Delete'}
+        </Button>
+      )}
+      <AlertModal
+        isOpen={isOpen}
+        title={modalTitle}
+        variant="danger"
+        onClose={() => toggleModal(false)}
+        actions={[
+          <Button
+            ouiaId="delete-modal-confirm"
+            key="delete"
+            variant="danger"
+            aria-label={'Confirm Delete'}
+            isDisabled={isDisabled}
+            onClick={() => {
+              onConfirm();
+              toggleModal(false);
+            }}
+          >
+            {'Delete'}
+          </Button>,
+          <Button
+            ouiaId="delete-modal-cancel"
+            key="cancel"
+            variant="link"
+            aria-label={'Cancel'}
+            onClick={() => toggleModal(false)}
+          >
+            {'Cancel'}
+          </Button>,
+        ]}
+      >
+        {'Are you sure you want to delete:'}
+        <br />
+        <strong>{name}</strong>
+        {Object.values(deleteDetails).length > 0 && (
+          <WarningMessage
+            variant="warning"
+            isInline
+            title={
+              <div>
+                <div aria-label={deleteMessage}>{deleteMessage}</div>
+                <br />
+                {Object.entries(deleteDetails).map(([key, value]) => (
+                  <div aria-label={`${key}: ${value}`} key={key}>
+                    <Label>{key}</Label> <Badge>{value}</Badge>
+                  </div>
+                ))}
+              </div>
+            }
+          />
+        )}
+      </AlertModal>
+    </>
+  );
+}
+
+DeleteButton.propTypes = {
+  ouiaId: PropTypes.string,
+};
+
+DeleteButton.defaultProps = {
+  ouiaId: null,
+};
+
+export default DeleteButton;

--- a/src/Components/DeleteButton/DeleteButton.test.js
+++ b/src/Components/DeleteButton/DeleteButton.test.js
@@ -1,0 +1,64 @@
+import { readPlan } from '../../Api';
+import { act } from 'react-dom/test-utils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DeleteButton from './DeleteButton';
+
+import mockResponses from '../../Utilities/__fixtures__/';
+import * as api from '../../Api';
+jest.mock('../../Api');
+
+describe('<DeleteButton />', () => {
+  test('should render button', async () => {
+    render (
+      <DeleteButton onConfirm={() => {}} name="Foo" />
+    );
+    await (() => screen.getById('button'));
+  });
+
+  test('should open confirmation modal', async() => {
+    render (
+        <DeleteButton
+          onConfirm={() => {}}
+          name="Foo"
+          deleteDetailsRequests={[
+            {
+              label: 'Plan',
+              request: readPlan.mockResolvedValue({
+                data: { count: 1 },
+              }),
+            },
+          ]}
+          deleteMessage="Delete this?"
+          warningMessage="Are you sure to want to delete this"
+        />
+    )
+    expect(screen.getByLabelText('Delete'));
+    const button = await waitFor(() => screen.getByRole('button'));
+    await act(async () => {
+      fireEvent.click(button)
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+  });
+
+  test('should show delete details error', async () => {
+      const onConfirm = jest.fn();
+      render (
+        <DeleteButton
+          onConfirm={onConfirm}
+          itemsToDelete="foo"
+          deleteDetailsRequests={[
+            {
+              label: 'Plan',
+              request: api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest403),
+            },
+          ]}
+        />
+      );
+      expect(screen.getByRole('button')).toBeTruthy();
+      const button = screen.getByRole('button');
+      await act(async () => {
+          fireEvent.click(button)
+      });
+      expect(screen.getByText('Error!')).toBeTruthy();
+  })
+});

--- a/src/Components/DeleteButton/index.js
+++ b/src/Components/DeleteButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './DeleteButton';

--- a/src/Components/ErrorDetail/ErrorDetail.js
+++ b/src/Components/ErrorDetail/ErrorDetail.js
@@ -1,0 +1,88 @@
+import React, { useState, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import {
+  Card as PFCard,
+  CardBody as PFCardBody,
+  ExpandableSection as PFExpandable,
+} from '@patternfly/react-core';
+import getErrorMessage from './getErrorMessage';
+
+const Card = styled(PFCard)`
+  background-color: var(--pf-global--BackgroundColor--200);
+  overflow-wrap: break-word;
+`;
+
+const CardBody = styled(PFCardBody)`
+  max-height: 200px;
+  overflow: scroll;
+`;
+
+const Expandable = styled(PFExpandable)`
+  text-align: left;
+
+  & .pf-c-expandable__toggle {
+    padding-left: 10px;
+    margin-left: 5px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+`;
+
+function ErrorDetail({ error }) {
+  const { response } = error;
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const renderNetworkError = () => {
+    const message = getErrorMessage(response);
+
+    return (
+      <Fragment>
+        <CardBody>
+          {response?.config?.method.toUpperCase()} {response?.config?.url}{' '}
+          <strong>{response?.status}</strong>
+        </CardBody>
+        <CardBody>
+          {Array.isArray(message) ? (
+            <ul>
+              {message.map(m =>
+                typeof m === 'string' ? <li key={m}>{m}</li> : null
+              )}
+            </ul>
+          ) : (
+            message
+          )}
+        </CardBody>
+      </Fragment>
+    );
+  };
+
+  const renderStack = () => {
+    return <CardBody>{error.stack}</CardBody>;
+  };
+
+  return (
+    <Expandable
+      toggleText={'Details'}
+      onToggle={handleToggle}
+      isExpanded={isExpanded}
+    >
+      <Card>
+        {Object.prototype.hasOwnProperty.call(error, 'response')
+          ? renderNetworkError()
+          : renderStack()}
+      </Card>
+    </Expandable>
+  );
+}
+
+ErrorDetail.propTypes = {
+  error: PropTypes.instanceOf(Error).isRequired,
+};
+
+export default ErrorDetail;

--- a/src/Components/ErrorDetail/ErrorDetail.test.js
+++ b/src/Components/ErrorDetail/ErrorDetail.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import ErrorDetail from './ErrorDetail';
+
+describe('<ErrorDetail />', () => {
+  it('renders the expected content', async() => {
+    render(
+      <ErrorDetail
+        error={
+          new Error({
+            response: {
+              config: {
+                method: 'post',
+              },
+              data: 'An error occurred',
+            },
+          })
+        }
+      />
+    );
+    await (() => expect(screen.getByText('Error:')).toBeTruthy());
+  })
+
+  it('testing errors', async() => {
+    render(
+      <ErrorDetail
+        error={
+          new Error({
+            response: {
+              config: {
+                method: 'patch',
+              },
+              data: {
+                project: ['project error'],
+                inventory: ['inventory error'],
+              },
+            },
+          })
+        }
+      />
+    );
+    await (() => {
+     expect(screen.getByRole('pf-c-expandable-section__toggle')).toBeTruthy();
+    });
+  });
+});

--- a/src/Components/ErrorDetail/getErrorMessage.js
+++ b/src/Components/ErrorDetail/getErrorMessage.js
@@ -1,0 +1,15 @@
+export default function getErrorMessage(response) {
+  if (!response?.data) {
+    return null;
+  }
+  if (typeof response.data === 'string') {
+    return response.data;
+  }
+  if (response.data.detail) {
+    return response.data.detail;
+  }
+  return Object.values(response.data).reduce(
+    (acc, currentValue) => acc.concat(currentValue),
+    []
+  );
+}

--- a/src/Components/ErrorDetail/getErrorMessage.test.js
+++ b/src/Components/ErrorDetail/getErrorMessage.test.js
@@ -1,0 +1,60 @@
+import getErrorMessage from './getErrorMessage';
+
+describe('getErrorMessage', () => {
+  test('should return data string', () => {
+    const response = {
+      data: 'error response',
+    };
+    expect(getErrorMessage(response)).toEqual('error response');
+  });
+  test('should return detail string', () => {
+    const response = {
+      data: {
+        detail: 'detail string',
+      },
+    };
+    expect(getErrorMessage(response)).toEqual('detail string');
+  });
+  test('should return an array of strings', () => {
+    const response = {
+      data: {
+        project: ['project error response'],
+      },
+    };
+    expect(getErrorMessage(response)).toEqual(['project error response']);
+  });
+  test('should consolidate error messages from multiple keys into an array', () => {
+    const response = {
+      data: {
+        project: ['project error response'],
+        inventory: ['inventory error response'],
+        organization: ['org error response'],
+      },
+    };
+    expect(getErrorMessage(response)).toEqual([
+      'project error response',
+      'inventory error response',
+      'org error response',
+    ]);
+  });
+  test('should handle no response.data', () => {
+    const response = {};
+    expect(getErrorMessage(response)).toEqual(null);
+  });
+  test('should consolidate multiple error messages from multiple keys into an array', () => {
+    const response = {
+      data: {
+        project: ['project error response'],
+        inventory: [
+          'inventory error response',
+          'another inventory error response',
+        ],
+      },
+    };
+    expect(getErrorMessage(response)).toEqual([
+      'project error response',
+      'inventory error response',
+      'another inventory error response',
+    ]);
+  });
+});

--- a/src/Components/ErrorDetail/index.js
+++ b/src/Components/ErrorDetail/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorDetail';

--- a/src/Components/Toolbar/ToolbarDeleteButton.js
+++ b/src/Components/Toolbar/ToolbarDeleteButton.js
@@ -1,0 +1,281 @@
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  func,
+  bool,
+  node,
+  number,
+  string,
+  arrayOf,
+  shape,
+  checkPropTypes,
+} from 'prop-types';
+import styled from 'styled-components';
+import {
+  Alert,
+  Badge,
+  Button,
+  DropdownItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import AlertModal from '../AlertModal';
+
+import { getRelatedResourceDeleteCounts } from '../../Utilities/getRelatedResourceDeleteDetails';
+
+import ErrorDetail from '../ErrorDetail';
+
+const WarningMessage = styled(Alert)`
+  margin-top: 10px;
+`;
+
+const Label = styled.span`
+  && {
+    margin-right: 10px;
+  }
+`;
+
+const requiredField = props => {
+  const { name, username, image } = props;
+  if (!name && !username && !image) {
+    return new Error(
+      `One of 'name', 'username' or 'image' is required by ItemToDelete component.`
+    );
+  }
+  if (name) {
+    checkPropTypes(
+      {
+        name: string,
+      },
+      { name: props.name },
+      'prop',
+      'ItemToDelete'
+    );
+  }
+  if (username) {
+    checkPropTypes(
+      {
+        username: string,
+      },
+      { username: props.username },
+      'prop',
+      'ItemToDelete'
+    );
+  }
+  if (image) {
+    checkPropTypes(
+      {
+        image: string,
+      },
+      { image: props.image },
+      'prop',
+      'ItemToDelete'
+    );
+  }
+  return null;
+};
+
+const ItemToDelete = shape({
+  id: number.isRequired,
+  name: requiredField,
+  username: requiredField,
+  image: requiredField,
+});
+
+function ToolbarDeleteButton({
+  itemsToDelete,
+  pluralizedItemName,
+  errorMessage,
+  onDelete,
+  deleteDetailsRequests,
+  warningMessage,
+  deleteMessage,
+  cannotDelete,
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [deleteDetails, setDeleteDetails] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [deleteMessageError, setDeleteMessageError] = useState();
+  const handleDelete = () => {
+    onDelete();
+    toggleModal();
+  };
+
+  const toggleModal = async isOpen => {
+    setIsLoading(true);
+    setDeleteDetails(null);
+    if (
+      isOpen &&
+      itemsToDelete.length === 1 &&
+      deleteDetailsRequests?.length > 0
+    ) {
+      const { results, error } = await getRelatedResourceDeleteCounts(
+        deleteDetailsRequests
+      );
+
+      if (error) {
+        setDeleteMessageError(error);
+      } else {
+        setDeleteDetails(results);
+      }
+    }
+    setIsLoading(false);
+    setIsModalOpen(isOpen);
+  };
+
+  const renderTooltip = () => {
+    const itemsUnableToDelete = itemsToDelete
+      .filter(cannotDelete)
+      .map(item => item.name || item.username)
+      .join(', ');
+    if (itemsToDelete.some(cannotDelete)) {
+      return (
+        <div>
+          {errorMessage ? (
+            <>
+              <span>{errorMessage}</span>
+              <span>{`: ${itemsUnableToDelete}`}</span>
+            </>
+          ) : (
+            `You do not have permission to delete ${pluralizedItemName}: ${itemsUnableToDelete}`
+          )}
+        </div>
+      );
+    }
+    if (itemsToDelete.length) {
+      return 'Delete';
+    }
+    return 'Select a plan to delete';
+  };
+
+  const modalTitle = `Delete ${pluralizedItemName}?`;
+
+  const isDisabled =
+    itemsToDelete.length === 0 || itemsToDelete.some(cannotDelete);
+
+  const buildDeleteWarning = () => {
+    const deleteMessages = [];
+    if (warningMessage) {
+      deleteMessages.push(warningMessage);
+    }
+    if (deleteMessage) {
+      if (deleteDetails || itemsToDelete.length > 1) {
+        deleteMessages.push(deleteMessage);
+      }
+    }
+
+    return (
+      <div>
+        {deleteMessages.map(message => (
+          <div aria-label={message} key={message}>
+            {message}
+          </div>
+        ))}
+        {deleteDetails &&
+          Object.entries(deleteDetails).map(([key, value]) => (
+            <div key={key} aria-label={`${key}: ${value}`}>
+              <Label>{key}</Label>
+              <Badge>{value}</Badge>
+            </div>
+          ))}
+      </div>
+    );
+  };
+
+  if (deleteMessageError) {
+    return (
+      <AlertModal
+        isOpen={deleteMessageError}
+        title={'Error!'}
+        onClose={() => {
+          toggleModal(false);
+          setDeleteMessageError();
+        }}
+      >
+        <ErrorDetail error={deleteMessageError} />
+      </AlertModal>
+    );
+  }
+  const shouldShowDeleteWarning =
+    warningMessage ||
+    (itemsToDelete.length === 1 && deleteDetails) ||
+    (itemsToDelete.length > 1 && deleteMessage);
+
+  return (
+    <>
+      <Tooltip content={renderTooltip()} position="top">
+        <Button
+          variant="secondary"
+          ouiaId="delete-button"
+          spinnerAriaValueText={isLoading ? 'Loading' : undefined}
+          aria-label={'Delete'}
+          onClick={() => toggleModal(true)}
+          isDisabled={isDisabled}
+        >
+          {'Delete'}
+        </Button>
+      </Tooltip>
+
+      {isModalOpen && (
+        <AlertModal
+          variant="danger"
+          title={modalTitle}
+          isOpen={isModalOpen}
+          onClose={() => toggleModal(false)}
+          actions={[
+            <Button
+              ouiaId="delete-modal-confirm"
+              key="delete"
+              variant="danger"
+              aria-label={'confirm delete'}
+              isDisabled={Boolean(
+                deleteDetails //&& itemsToDelete[0]?.type === 'credential_type'
+              )}
+              onClick={handleDelete}
+            >
+              {'Delete'}
+            </Button>,
+            <Button
+              key="cancel"
+              variant="link"
+              aria-label={'cancel delete'}
+              onClick={() => toggleModal(false)}
+            >
+              {'Cancel'}
+            </Button>,
+          ]}
+        >
+          <div>{'This action will delete the following:'}</div>
+          {itemsToDelete.map(item => (
+            <span key={item.id}>
+              <strong>{item.name || item.username || item.image}</strong>
+              <br />
+            </span>
+          ))}
+          {shouldShowDeleteWarning && (
+            <WarningMessage
+              variant="warning"
+              isInline
+              title={buildDeleteWarning()}
+            />
+          )}
+        </AlertModal>
+      )}
+    </>
+  );
+}
+
+ToolbarDeleteButton.propTypes = {
+  onDelete: func.isRequired,
+  itemsToDelete: arrayOf(ItemToDelete).isRequired,
+  pluralizedItemName: string,
+  warningMessage: node,
+  cannotDelete: func,
+};
+
+ToolbarDeleteButton.defaultProps = {
+  pluralizedItemName: 'Items',
+  warningMessage: null,
+  cannotDelete: item => !item,
+};
+
+export default ToolbarDeleteButton;

--- a/src/Components/Toolbar/ToolbarDeleteButton.test.js
+++ b/src/Components/Toolbar/ToolbarDeleteButton.test.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { readPlan } from "../../Api";
+import ToolbarDeleteButton from './ToolbarDeleteButton';
+jest.mock('../../Api');
+
+const itemA = {
+  id: 1,
+  name: 'Foo',
+  summary_fields: { user_capabilities: { delete: true } },
+};
+
+describe('<ToolbarDeleteButton />', () => {
+  let deleteDetailsRequests;
+  beforeEach(() => {
+    deleteDetailsRequests = [
+      {
+        label: 'Plan',
+        request: readPlan.mockImplementation(() => Promise.resolve({ items: { count: 1 } })),
+      },
+    ];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should render button', () => {
+    render(
+      <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[]} />
+    );
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  test('should open confirmation modal', async () => {
+    render(
+      <ToolbarDeleteButton
+        onDelete={() => {}}
+        itemsToDelete={[itemA]}
+        deleteDetailsRequests={deleteDetailsRequests}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
+    expect(screen.getByLabelText('Delete'));
+    await act(async () => {
+       fireEvent.click(screen.getByRole('button'));
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+  });
+
+  test('should open confirmation with enabled delete button modal', async () => {
+    await act(async () => {
+      render(
+        <ToolbarDeleteButton
+          onDelete={() => {}}
+          itemsToDelete={[
+            {
+              name: 'foo',
+              id: 1,
+            },
+            {
+              name: 'bar',
+              id: 2,
+            },
+          ]}
+          deleteDetailsRequests={deleteDetailsRequests}
+          deleteMessage="Delete this?"
+          warningMessage="Are you sure to want to delete this"
+        />
+      );
+    });
+    expect(screen.getByLabelText('Delete'));
+    const button = await waitFor(() => screen.getByRole('button'));
+    await act(async () => {
+      fireEvent.click(button)
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+    expect(screen.getByLabelText('confirm delete').closest('button').hasAttribute('disabled')).toBe(false);
+  });
+
+  test('should disable confirm delete button', async () => {
+    const request = {
+      request: readPlan.mockImplementation(() => Promise.resolve({ items: { count: 3 } })),
+      label: 'Plan'
+    };
+    await act(async () => {
+      render(
+        <ToolbarDeleteButton
+          onDelete={() => {}}
+          itemsToDelete={[
+            {
+              name: 'foo',
+              id: 1,
+            }
+          ]}
+          deleteDetailsRequests={[request]}
+          deleteMessage="Delete this?"
+          warningMessage="Are you sure to want to delete this"
+        />
+      );
+    })
+
+    expect(screen.getByLabelText('Delete'));
+    const button = await waitFor(() => screen.getByRole('button'));
+    await act(async () => {
+      fireEvent.click(button)
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+    expect(screen.getByLabelText('confirm delete').closest('button').hasAttribute('disabled')).toBe(true);
+  });
+
+  test('should open delete error modal', async () => {
+    const request =
+      {
+        label: 'Plan',
+        request: readPlan.mockImplementation(() => Promise.reject({ response: {data: 'An error occurred', status: 403,  }})),
+      };
+
+    await act(async () => {
+      render(
+        <ToolbarDeleteButton
+          onDelete={() => {}}
+          itemsToDelete={[itemA]}
+          deleteDetailsRequests={[request]}
+          deleteMessage="Delete this?"
+          warningMessage="Are you sure to want to delete this"
+        />
+      );
+    });
+
+    const button = await waitFor(() => screen.getByRole('button'));
+    await act(async () => {
+      fireEvent.click(button)
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+    expect(screen.getByText('An error occurred')).toBeTruthy();
+  });
+
+  test('should invoke onDelete prop', async() => {
+    const onDelete = jest.fn();
+    render(
+      <ToolbarDeleteButton onDelete={onDelete} itemsToDelete={[itemA]} />
+    );
+    const button = await waitFor(() => screen.getByRole('button'));
+    await act(async () => {
+      fireEvent.click(button)
+    });
+    expect(screen.getByLabelText('Alert modal')).toBeTruthy();
+    expect(screen.getByLabelText('confirm delete').closest('button').hasAttribute('disabled')).toBe(false);
+    const deleteButton = screen.getByLabelText('confirm delete');
+    await act(async () => {
+      fireEvent.click(deleteButton)
+    });
+    expect(screen.queryByLabelText('Alert modal')).toBe(null);
+  });
+});

--- a/src/Containers/SavingsPlanner/PlanCard.js
+++ b/src/Containers/SavingsPlanner/PlanCard.js
@@ -29,22 +29,28 @@ import styled from 'styled-components';
 import { stringify } from 'query-string';
 
 import { Link, useRouteMatch } from 'react-router-dom';
+// import useSelected from "../../Utilities/useSelected";
 
 const CardLabel = styled.span`
   margin-right: 5px;
 `;
 
 const PlanCard = ({
-  name,
-  id = null,
-  description = '',
-  frequency_period = '',
-  template_details = {},
-  automation_status = {},
-  modified = '',
-  category = '',
   isSuccess,
+  plan,
+  selected = [],
+  handleSelect = () => {},
 }) => {
+  const {
+    id,
+    automation_status,
+    category,
+    description,
+    frequency_period,
+    modified,
+    name,
+    template_details,
+  } = plan;
   const [isCardKebabOpen, setIsCardKebabOpen] = useState(false);
 
   const match = useRouteMatch();
@@ -103,8 +109,8 @@ const PlanCard = ({
             position={'right'}
           />
           <Checkbox
-            isChecked={false}
-            onChange={() => {}}
+            onChange={() => handleSelect(plan)}
+            isChecked={selected.some(row => row.id === plan.id)}
             aria-label="card checkbox"
             id="check-1"
             name="check1"
@@ -155,14 +161,9 @@ const PlanCard = ({
 
 PlanCard.propTypes = {
   isSuccess: PropTypes.bool.isRequired,
-  name: PropTypes.string.isRequired,
-  id: PropTypes.number,
-  description: PropTypes.string,
-  frequency_period: PropTypes.string,
-  template_details: PropTypes.object,
-  modified: PropTypes.string,
-  category: PropTypes.string,
-  automation_status: PropTypes.object,
+  selected: PropTypes.array,
+  handleSelect: PropTypes.func,
+  plan: PropTypes.object,
 };
 
 export default PlanCard;

--- a/src/Utilities/getRelatedResouceDeleteDetails.test.js
+++ b/src/Utilities/getRelatedResouceDeleteDetails.test.js
@@ -1,0 +1,28 @@
+import {
+  getRelatedResourceDeleteCounts,
+  relatedResourceDeleteRequests,
+} from './getRelatedResourceDeleteDetails';
+import mockResponses from './__fixtures__/';
+import * as api from '../Api';
+jest.mock('../Api');
+
+describe('delete details', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call api for savings plan list', () => {
+    const plan = api.readJobExplorer.mockResolvedValue(mockResponses.readPlan);
+    getRelatedResourceDeleteCounts(
+      relatedResourceDeleteRequests.savingsPlan({ id: 1 }, plan)
+    );
+    expect(plan).toBeCalledWith({
+      "params":  {
+         "id": [
+           1,
+         ],
+       },
+    });
+  });
+
+});

--- a/src/Utilities/getRelatedResourceDeleteDetails.js
+++ b/src/Utilities/getRelatedResourceDeleteDetails.js
@@ -1,0 +1,38 @@
+export async function getRelatedResourceDeleteCounts(requests) {
+  const results = {};
+  let error = null;
+  let hasCount = false;
+
+  try {
+    await Promise.all(
+      requests.map(async ({ request, label }) => {
+        const {
+          items: { count },
+        } = await request();
+        if (count > 0) {
+          results[label] = count;
+          hasCount = true;
+        }
+      })
+    );
+  } catch (err) {
+    error = err;
+  }
+
+  return {
+    results: hasCount && results,
+    error,
+  };
+}
+
+export const relatedResourceDeleteRequests = {
+  savingsPlan: (selected, readRecordApi) => [
+    {
+      request: async () =>
+        readRecordApi({
+          params: {id: [selected.id]}
+        }),
+      label: 'Plan',
+    },
+  ],
+};

--- a/src/Utilities/useIsMounted.js
+++ b/src/Utilities/useIsMounted.js
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react';
+
+export default function useIsMounted() {
+  const isMounted = useRef(null);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  });
+  return isMounted;
+}

--- a/src/Utilities/useRequest.js
+++ b/src/Utilities/useRequest.js
@@ -1,0 +1,116 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
+import useIsMounted from './useIsMounted';
+
+/*
+ * The useRequest hook accepts a request function and returns an object with
+ * five values:
+ *   request: a function to call to invoke the request
+ *   result: the value returned from the request function (once invoked)
+ *   isLoading: boolean state indicating whether the request is in active/in flight
+ *   error: any caught error resulting from the request
+ *   setValue: setter to explicitly set the result value
+ *
+ * The hook also accepts an optional second parameter which is a default
+ * value to set as result before the first time the request is made.
+ */
+export default function useRequest(makeRequest, initialValue) {
+  const [result, setResult] = useState(initialValue);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const isMounted = useIsMounted();
+
+  return {
+    result,
+    error,
+    isLoading,
+    request: useCallback(
+      async (...args) => {
+        setIsLoading(true);
+        try {
+          const response = await makeRequest(...args);
+          if (isMounted.current) {
+            setResult(response);
+            setError(null);
+          }
+        } catch (err) {
+          if (isMounted.current) {
+            setError(err);
+            setResult(initialValue);
+          }
+        } finally {
+          if (isMounted.current) {
+            setIsLoading(false);
+          }
+        }
+      },
+      /* eslint-disable-next-line react-hooks/exhaustive-deps */
+      [makeRequest]
+    ),
+    setValue: setResult,
+  };
+}
+
+/*
+ * Provides controls for "dismissing" an error message
+ *
+ * Params: an error object
+ * Returns: { error, dismissError }
+ *   The returned error object is the same object passed in via the paremeter,
+ *   until the dismissError function is called, at which point the returned
+ *   error will be set to null on the subsequent render.
+ */
+export function useDismissableError(error) {
+  const [showError, setShowError] = useState(false);
+
+  useEffect(() => {
+    if (error) {
+      setShowError(true);
+    }
+  }, [error]);
+
+  return {
+    error: showError ? error : null,
+    dismissError: () => {
+      setShowError(false);
+    },
+  };
+}
+
+/*
+ * Hook to assist with deletion of items from a paginated item list. The page
+ * url will be navigated back one page on a paginated list if needed to prevent
+ * the UI from re-loading an empty set and displaying a "No items found"
+ * message.
+ *
+ * Params: a callback function that will be invoked in order to delete items,
+ *   and an object with structure { qsConfig, allItemsSelected, fetchItems }
+ * Returns: { isLoading, deleteItems, deletionError, clearDeletionError }
+ */
+export function useDeleteItems(
+  makeRequest,
+  { qsConfig = null, allItemsSelected = false, fetchItems = null } = {}
+) {
+  const location = useLocation();
+  const history = useHistory();
+
+  const { error: requestError, isLoading, request } = useRequest(
+    makeRequest,
+    null
+  );
+  const { error, dismissError } = useDismissableError(requestError);
+  const deleteItems = async () => {
+    await request();
+    if (!qsConfig) {
+      return;
+    }
+    fetchItems();
+  };
+
+  return {
+    isLoading,
+    deleteItems,
+    deletionError: error,
+    clearDeletionError: dismissError,
+  };
+}

--- a/src/Utilities/useSelected.js
+++ b/src/Utilities/useSelected.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+/**
+ * useSelected hook provides a way to read and update a selected list
+ * Param: array of list items
+ * Returns: {
+ *  selected: array of selected list items
+ *  isAllSelected: boolean that indicates if all items are selected
+ *  handleSelect: function that adds and removes items from selected list
+ *  setSelected: setter function
+ * }
+ */
+
+export default function useSelected(list = []) {
+  const [selected, setSelected] = useState([]);
+  const isAllSelected = selected.length > 0 && selected.length === list.length;
+
+  const handleSelect = row => {
+    if (selected.some(s => s.id === row.id)) {
+      setSelected(prevState => [...prevState.filter(i => i.id !== row.id)]);
+    } else {
+      setSelected(prevState => [...prevState, row]);
+    }
+  };
+  return { selected, isAllSelected, handleSelect, setSelected };
+}

--- a/src/Utilities/useSelected.test.js
+++ b/src/Utilities/useSelected.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import useSelected from './useSelected';
+import { render } from '@testing-library/react';
+
+const array = [{ id: '1' }, { id: '2' }, { id: '3' }];
+
+const TestHook = ({ callback }) => {
+  callback();
+  return null;
+};
+
+const testHook = callback => {
+  render(<TestHook callback={callback} />);
+};
+
+describe('useSelected hook', () => {
+  let selected;
+  let isAllSelected;
+  let handleSelect;
+  let setSelected;
+
+  test('should return expected initial values', () => {
+    testHook(() => {
+      ({ selected, isAllSelected, handleSelect, setSelected } = useSelected());
+    });
+    expect(selected).toEqual([]);
+    expect(isAllSelected).toEqual(false);
+    expect(handleSelect).toBeInstanceOf(Function);
+    expect(setSelected).toBeInstanceOf(Function);
+  });
+
+  test('handleSelect should update and filter selected items', () => {
+    testHook(() => {
+      ({ selected, isAllSelected, handleSelect, setSelected } = useSelected());
+    });
+
+    act(() => {
+      handleSelect(array[0]);
+    });
+    expect(selected).toEqual([array[0]]);
+
+    act(() => {
+      handleSelect(array[0]);
+    });
+    expect(selected).toEqual([]);
+  });
+
+  test('should return expected isAllSelected value', () => {
+    testHook(() => {
+      ({ selected, isAllSelected, handleSelect, setSelected } = useSelected(
+        array
+      ));
+    });
+
+    act(() => {
+      handleSelect(array[0]);
+    });
+    expect(selected).toEqual([array[0]]);
+    expect(isAllSelected).toEqual(false);
+
+    act(() => {
+      handleSelect(array[1]);
+      handleSelect(array[2]);
+    });
+    expect(selected).toEqual(array);
+    expect(isAllSelected).toEqual(true);
+
+    act(() => {
+      setSelected([]);
+    });
+    expect(selected).toEqual([]);
+    expect(isAllSelected).toEqual(false);
+  });
+});


### PR DESCRIPTION
- This commit adds a delete button in toolbar if user has RBAC Access. Clicking on delete button will open up a confirmation modal with  All selected plan names displayed in modal. Upon confirmation, records will be deleted and list view will be refreshed to show a list of plans.
- Added Delete button on the details tab with same confirmation modal, upon confirmation, record will be deleted and user will be redirected back to refreshed list view screen

List screen
![Screen Shot 2021-06-07 at 4 34 39 PM](https://user-images.githubusercontent.com/3450808/121084276-74a2df00-c7ae-11eb-94dd-5a0c658c8a15.png)

![Screen Shot 2021-06-07 at 4 34 55 PM](https://user-images.githubusercontent.com/3450808/121084273-740a4880-c7ae-11eb-80a4-68ed0082e774.png)


Details screen
![Screen Shot 2021-06-07 at 4 35 09 PM](https://user-images.githubusercontent.com/3450808/121084294-7a98c000-c7ae-11eb-8ac8-c1d636a92cfa.png)

![Screen Shot 2021-06-07 at 4 35 19 PM](https://user-images.githubusercontent.com/3450808/121084291-79679300-c7ae-11eb-95dd-62b8309cc03f.png)
