### PR TITLE
AA-544 add basic RBAC for add, edit, delete Savings Plan.

### DIFF
--- a/src/Containers/SavingsPlanner/Add/index.js
+++ b/src/Containers/SavingsPlanner/Add/index.js
@@ -24,7 +24,7 @@ const Add = () => {
   useEffect(() => {
     setOptions(readPlanOptions());
   }, []);
-  const canWrite = (options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true));
+  const canWrite = (options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true));
   const title = 'Create new plan';
 
   const showAdd = () => (

--- a/src/Containers/SavingsPlanner/Add/index.js
+++ b/src/Containers/SavingsPlanner/Add/index.js
@@ -24,7 +24,10 @@ const Add = () => {
   useEffect(() => {
     setOptions(readPlanOptions());
   }, []);
-  const canWrite = (options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true));
+  const canWrite =
+    options.isSuccess &&
+    (options.data?.meta?.rbac?.perms?.write === true ||
+      options.data?.meta?.rbac?.perms?.all === true);
   const title = 'Create new plan';
 
   const showAdd = () => (
@@ -43,7 +46,7 @@ const Add = () => {
         </Card>
       </Main>
     </>
-  )
+  );
   if (options.isSuccess) {
     return canWrite ? showAdd() : <Redirect to={Paths.savingsPlanner} />;
   }

--- a/src/Containers/SavingsPlanner/Add/index.js
+++ b/src/Containers/SavingsPlanner/Add/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { Card, CardBody } from '@patternfly/react-core';
 
@@ -16,16 +17,17 @@ import { readPlanOptions } from '../../../Api';
 
 import Form from '../Shared/Form';
 
+import { Paths } from '../../../paths';
+
 const Add = () => {
   const [options, setOptions] = useApi({});
-
   useEffect(() => {
     setOptions(readPlanOptions());
   }, []);
-
+  const canWrite = (options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true));
   const title = 'Create new plan';
 
-  return (
+  const showAdd = () => (
     <>
       <PageHeader>
         <Breadcrumbs
@@ -36,12 +38,16 @@ const Add = () => {
       <Main>
         <Card>
           <CardBody>
-            {options.isSuccess && <Form title={title} options={options} />}
+            <Form title={title} options={options} />
           </CardBody>
         </Card>
       </Main>
     </>
-  );
+  )
+  if (options.isSuccess) {
+    return canWrite ? showAdd() : <Redirect to={Paths.savingsPlanner} />;
+  }
+  return null;
 };
 
 export default Add;

--- a/src/Containers/SavingsPlanner/DetailsTab.js
+++ b/src/Containers/SavingsPlanner/DetailsTab.js
@@ -27,7 +27,7 @@ import {
   relatedResourceDeleteRequests,
   getRelatedResourceDeleteCounts,
 } from '../../Utilities/getRelatedResourceDeleteDetails';
-import {deletePlan, readPlan} from '../../Api';
+import { deletePlan, readPlan } from '../../Api';
 import useRequest, { useDismissableError } from '../../Utilities/useRequest';
 import DeleteButton from '../../Components/DeleteButton/DeleteButton';
 import {
@@ -197,7 +197,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite }) => {
                   }}
                 >
                   Edit
-              </Button>
+                </Button>
                 <DeleteButton
                   key={'delete-plan-button'}
                   name={name}
@@ -231,7 +231,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite }) => {
 DetailsTab.propTypes = {
   plans: PropTypes.array,
   tabsArray: PropTypes.array,
-  canWrite: PropTypes.bool.isRequired
+  canWrite: PropTypes.bool.isRequired,
 };
 
 export default DetailsTab;

--- a/src/Containers/SavingsPlanner/DetailsTab.js
+++ b/src/Containers/SavingsPlanner/DetailsTab.js
@@ -49,7 +49,7 @@ const CardBody = styled(PFCardBody)`
   }
 `;
 
-const DetailsTab = ({ tabsArray, plans }) => {
+const DetailsTab = ({ tabsArray, plans, canWrite }) => {
   let history = useHistory();
   const {
     id,
@@ -183,43 +183,45 @@ const DetailsTab = ({ tabsArray, plans }) => {
               )}
             </div>
           </CardBody>
-          <CardFooter>
-            <CardActionsRow>
-              <Button
-                key="edit-plan-button"
-                variant="primary"
-                aria-label="Edit plan"
-                onClick={() => {
-                  history.push({
-                    pathname: `${Paths.savingsPlan}${id}/edit`,
-                  });
-                }}
-              >
-                Edit
+          {canWrite && (
+            <CardFooter>
+              <CardActionsRow>
+                <Button
+                  key="edit-plan-button"
+                  variant="primary"
+                  aria-label="Edit plan"
+                  onClick={() => {
+                    history.push({
+                      pathname: `${Paths.savingsPlan}${id}/edit`,
+                    });
+                  }}
+                >
+                  Edit
               </Button>
-              <DeleteButton
-                key={'delete-plan-button'}
-                name={name}
-                modalTitle={'Delete Plan'}
-                onConfirm={deletePlans}
-                disabledTooltip={
-                  isDeleteDisabled && 'This plan cannot be deleted'
-                }
-              >
-                {'Delete'}
-              </DeleteButton>
-            </CardActionsRow>
-            {error && (
-              <AlertModal
-                isOpen={error}
-                onClose={dismissError}
-                title={'Error'}
-                variant="error"
-              >
-                <ErrorDetail error={error} />
-              </AlertModal>
-            )}
-          </CardFooter>
+                <DeleteButton
+                  key={'delete-plan-button'}
+                  name={name}
+                  modalTitle={'Delete Plan'}
+                  onConfirm={deletePlans}
+                  disabledTooltip={
+                    isDeleteDisabled && 'This plan cannot be deleted'
+                  }
+                >
+                  {'Delete'}
+                </DeleteButton>
+              </CardActionsRow>
+              {error && (
+                <AlertModal
+                  isOpen={error}
+                  onClose={dismissError}
+                  title={'Error'}
+                  variant="error"
+                >
+                  <ErrorDetail error={error} />
+                </AlertModal>
+              )}
+            </CardFooter>
+          )}
         </>
       )}
     </>
@@ -229,6 +231,7 @@ const DetailsTab = ({ tabsArray, plans }) => {
 DetailsTab.propTypes = {
   plans: PropTypes.array,
   tabsArray: PropTypes.array,
+  canWrite: PropTypes.bool.isRequired
 };
 
 export default DetailsTab;

--- a/src/Containers/SavingsPlanner/DetailsTab.test.js
+++ b/src/Containers/SavingsPlanner/DetailsTab.test.js
@@ -56,7 +56,7 @@ const dummyData = [
 
 let wrapper;
 it('should render successfully', () => {
-  wrapper = mount(<DetailsTab tabsArray={tabs} plans={dummyData} />);
+  wrapper = mount(<DetailsTab tabsArray={tabs} plans={dummyData} canWrite={true} />);
   wrapper.update();
   expect(wrapper.find('div.pf-c-description-list__text')).toHaveLength(9);
 });

--- a/src/Containers/SavingsPlanner/DetailsTab.test.js
+++ b/src/Containers/SavingsPlanner/DetailsTab.test.js
@@ -56,7 +56,9 @@ const dummyData = [
 
 let wrapper;
 it('should render successfully', () => {
-  wrapper = mount(<DetailsTab tabsArray={tabs} plans={dummyData} canWrite={true} />);
+  wrapper = mount(
+    <DetailsTab tabsArray={tabs} plans={dummyData} canWrite={true} />
+  );
   wrapper.update();
   expect(wrapper.find('div.pf-c-description-list__text')).toHaveLength(9);
 });

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -17,7 +17,7 @@ const Edit = ({ data }) => {
     setOptions(readPlanOptions());
   }, []);
 
-  const canWrite = (options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true));
+  const canWrite = (options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true));
 
   const showEdit = () => (
     <>

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -1,14 +1,17 @@
 import React, { useEffect } from 'react';
+import { Redirect, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import useApi from '../../../Utilities/useApi';
 
 import { readPlanOptions } from '../../../Api';
+import { Paths } from '../../../paths';
 
 import Form from '../Shared/Form';
 
 const Edit = ({ data }) => {
   const [options, setOptions] = useApi({});
+  const { id } = useParams();
 
   useEffect(() => {
     setOptions(readPlanOptions());
@@ -23,7 +26,7 @@ const Edit = ({ data }) => {
   )
 
   if (options.isSuccess) {
-    return canWrite ? showEdit() : <Redirect to={Paths.savingsPlanner} />;
+    return canWrite ? showEdit() : <Redirect to={`${Paths.savingsPlanner}/${id}`} />;
   }
   return null;
 };

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -14,15 +14,18 @@ const Edit = ({ data }) => {
     setOptions(readPlanOptions());
   }, []);
 
-  const title = 'Edit plan';
+  const canWrite = (options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true));
 
-  return (
+  const showEdit = () => (
     <>
-      {options.isSuccess && (
-        <Form title={title} options={options} data={data} />
-      )}
+      <Form title="Edit plan" options={options} data={data} />
     </>
-  );
+  )
+
+  if (options.isSuccess) {
+    return canWrite ? showEdit() : <Redirect to={Paths.savingsPlanner} />;
+  }
+  return null;
 };
 
 Edit.propTypes = {

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -17,16 +17,23 @@ const Edit = ({ data }) => {
     setOptions(readPlanOptions());
   }, []);
 
-  const canWrite = (options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true));
+  const canWrite =
+    options.isSuccess &&
+    (options.data?.meta?.rbac?.perms?.write === true ||
+      options.data?.meta?.rbac?.perms?.all === true);
 
   const showEdit = () => (
     <>
       <Form title="Edit plan" options={options} data={data} />
     </>
-  )
+  );
 
   if (options.isSuccess) {
-    return canWrite ? showEdit() : <Redirect to={`${Paths.savingsPlanner}/${id}`} />;
+    return canWrite ? (
+      showEdit()
+    ) : (
+      <Redirect to={`${Paths.savingsPlanner}/${id}`} />
+    );
   }
   return null;
 };

--- a/src/Containers/SavingsPlanner/PlanCard.js
+++ b/src/Containers/SavingsPlanner/PlanCard.js
@@ -40,7 +40,7 @@ const PlanCard = ({
   plan,
   selected = [],
   handleSelect = () => {},
-  canWrite
+  canWrite,
 }) => {
   const {
     id,
@@ -96,29 +96,29 @@ const PlanCard = ({
             <Link to={`${match.url}/${id}`}>{name}</Link>
           </CardTitle>
         </CardHeaderMain>
-          {canWrite && (
-            <CardActions>
-                <Dropdown
-                  onSelect={() => {}}
-                  toggle={
-                    <KebabToggle
-                      onToggle={() => setIsCardKebabOpen(!isCardKebabOpen)}
-                    />
-                  }
-                  isOpen={isCardKebabOpen}
-                  isPlain
-                  dropdownItems={kebabDropDownItems}
-                  position={'right'}
+        {canWrite && (
+          <CardActions>
+            <Dropdown
+              onSelect={() => {}}
+              toggle={
+                <KebabToggle
+                  onToggle={() => setIsCardKebabOpen(!isCardKebabOpen)}
                 />
-              <Checkbox
-                onChange={() => handleSelect(plan)}
-                isChecked={selected.some(row => row.id === plan.id)}
-                aria-label="card checkbox"
-                id="check-1"
-                name="check1"
-              />
-            </CardActions>
-          )}
+              }
+              isOpen={isCardKebabOpen}
+              isPlain
+              dropdownItems={kebabDropDownItems}
+              position={'right'}
+            />
+            <Checkbox
+              onChange={() => handleSelect(plan)}
+              isChecked={selected.some((row) => row.id === plan.id)}
+              aria-label="card checkbox"
+              id="check-1"
+              name="check1"
+            />
+          </CardActions>
+        )}
       </CardHeader>
       <CardBody>
         {description ? <p>{description}</p> : null}

--- a/src/Containers/SavingsPlanner/PlanCard.js
+++ b/src/Containers/SavingsPlanner/PlanCard.js
@@ -40,6 +40,7 @@ const PlanCard = ({
   plan,
   selected = [],
   handleSelect = () => {},
+  canWrite
 }) => {
   const {
     id,
@@ -95,27 +96,29 @@ const PlanCard = ({
             <Link to={`${match.url}/${id}`}>{name}</Link>
           </CardTitle>
         </CardHeaderMain>
-        <CardActions>
-          <Dropdown
-            onSelect={() => {}}
-            toggle={
-              <KebabToggle
-                onToggle={() => setIsCardKebabOpen(!isCardKebabOpen)}
+          {canWrite && (
+            <CardActions>
+                <Dropdown
+                  onSelect={() => {}}
+                  toggle={
+                    <KebabToggle
+                      onToggle={() => setIsCardKebabOpen(!isCardKebabOpen)}
+                    />
+                  }
+                  isOpen={isCardKebabOpen}
+                  isPlain
+                  dropdownItems={kebabDropDownItems}
+                  position={'right'}
+                />
+              <Checkbox
+                onChange={() => handleSelect(plan)}
+                isChecked={selected.some(row => row.id === plan.id)}
+                aria-label="card checkbox"
+                id="check-1"
+                name="check1"
               />
-            }
-            isOpen={isCardKebabOpen}
-            isPlain
-            dropdownItems={kebabDropDownItems}
-            position={'right'}
-          />
-          <Checkbox
-            onChange={() => handleSelect(plan)}
-            isChecked={selected.some(row => row.id === plan.id)}
-            aria-label="card checkbox"
-            id="check-1"
-            name="check1"
-          />
-        </CardActions>
+            </CardActions>
+          )}
       </CardHeader>
       <CardBody>
         {description ? <p>{description}</p> : null}
@@ -161,6 +164,7 @@ const PlanCard = ({
 
 PlanCard.propTypes = {
   isSuccess: PropTypes.bool.isRequired,
+  canWrite: PropTypes.bool.isRequired,
   selected: PropTypes.array,
   handleSelect: PropTypes.func,
   plan: PropTypes.object,

--- a/src/Containers/SavingsPlanner/SavingsPlan.js
+++ b/src/Containers/SavingsPlanner/SavingsPlan.js
@@ -39,10 +39,10 @@ const SavingsPlan = () => {
     {
       isSuccess,
       error,
-      data: { items: plans = [] },
+      data: { rbac = {}, items: plans = [] },
     },
     setData,
-  ] = useApi({ items: [] });
+  ] = useApi({ rbac: {}, items: [] });
   const queryParams = { id: [selectedId] };
 
   useEffect(() => {
@@ -57,6 +57,7 @@ const SavingsPlan = () => {
     fetchEndpoints();
   }, []);
 
+  const canWrite = isSuccess && (rbac.perms.write === true || rbac.perms.all === true);
   const tabsArray = [
     {
       id: 0,
@@ -110,13 +111,13 @@ const SavingsPlan = () => {
                   />
                 </Route>
                 <Route path="/savings-planner/:id/details">
-                  <DetailsTab plans={plans} tabsArray={tabsArray} />
+                  <DetailsTab plans={plans} tabsArray={tabsArray} canWrite={canWrite} />
                 </Route>
                 <Route path="/savings-planner/:id/edit">
                   <SavingsPlanEdit data={plans[0]} />
                 </Route>
                 <Route path="/savings-planner/:id">
-                  <DetailsTab plans={plans} tabsArray={tabsArray} />
+                  <DetailsTab plans={plans} tabsArray={tabsArray} canWrite={canWrite} />
                 </Route>
                 <Route exact path="/savings-planner">
                   <SavingsPlanner />

--- a/src/Containers/SavingsPlanner/SavingsPlan.js
+++ b/src/Containers/SavingsPlanner/SavingsPlan.js
@@ -57,7 +57,7 @@ const SavingsPlan = () => {
     fetchEndpoints();
   }, []);
 
-  const canWrite = isSuccess && (rbac.perms.write === true || rbac.perms.all === true);
+  const canWrite = isSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
   const tabsArray = [
     {
       id: 0,

--- a/src/Containers/SavingsPlanner/SavingsPlan.js
+++ b/src/Containers/SavingsPlanner/SavingsPlan.js
@@ -57,7 +57,8 @@ const SavingsPlan = () => {
     fetchEndpoints();
   }, []);
 
-  const canWrite = isSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
+  const canWrite =
+    isSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
   const tabsArray = [
     {
       id: 0,
@@ -111,13 +112,21 @@ const SavingsPlan = () => {
                   />
                 </Route>
                 <Route path="/savings-planner/:id/details">
-                  <DetailsTab plans={plans} tabsArray={tabsArray} canWrite={canWrite} />
+                  <DetailsTab
+                    plans={plans}
+                    tabsArray={tabsArray}
+                    canWrite={canWrite}
+                  />
                 </Route>
                 <Route path="/savings-planner/:id/edit">
                   <SavingsPlanEdit data={plans[0]} />
                 </Route>
                 <Route path="/savings-planner/:id">
-                  <DetailsTab plans={plans} tabsArray={tabsArray} canWrite={canWrite} />
+                  <DetailsTab
+                    plans={plans}
+                    tabsArray={tabsArray}
+                    canWrite={canWrite}
+                  />
                 </Route>
                 <Route exact path="/savings-planner">
                   <SavingsPlanner />

--- a/src/Containers/SavingsPlanner/SavingsPlan.test.js
+++ b/src/Containers/SavingsPlanner/SavingsPlan.test.js
@@ -31,8 +31,8 @@ const dummyData = {
     error: null,
     rbac: {
       perms: {
-        all: true
-      }
+        all: true,
+      },
     },
     items: [
       {

--- a/src/Containers/SavingsPlanner/SavingsPlan.test.js
+++ b/src/Containers/SavingsPlanner/SavingsPlan.test.js
@@ -29,6 +29,11 @@ const dummyData = {
     isLoading: false,
     isSuccess: true,
     error: null,
+    rbac: {
+      perms: {
+        all: true
+      }
+    },
     items: [
       {
         id: 1,

--- a/src/Containers/SavingsPlanner/SavingsPlanner.js
+++ b/src/Containers/SavingsPlanner/SavingsPlanner.js
@@ -1,6 +1,11 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { deletePlan, preflightRequest, readPlanOptions, readPlans } from '../../Api';
+import {
+  deletePlan,
+  preflightRequest,
+  readPlanOptions,
+  readPlans,
+} from '../../Api';
 import FilterableToolbar from '../../Components/Toolbar/';
 import ApiErrorState from '../../Components/ApiErrorState';
 import LoadingState from '../../Components/LoadingState';
@@ -24,9 +29,9 @@ import { Button, Gallery, PaginationVariant } from '@patternfly/react-core';
 
 import ToolbarDeleteButton from '../../Components/Toolbar/ToolbarDeleteButton';
 import useSelected from '../../Utilities/useSelected';
-import { useDeleteItems } from "../../Utilities/useRequest";
-import ErrorDetail from "../../Components/ErrorDetail";
-import AlertModal from "../../Components/AlertModal";
+import { useDeleteItems } from '../../Utilities/useRequest';
+import ErrorDetail from '../../Components/ErrorDetail';
+import AlertModal from '../../Components/AlertModal';
 
 const SavingsPlanner = () => {
   const history = useHistory();
@@ -63,12 +68,14 @@ const SavingsPlanner = () => {
   useEffect(() => {
     fetchEndpoints();
   }, [queryParams]);
-  
-  const canWrite = options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true);
 
-  const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
-    data
-  );
+  const canWrite =
+    options.isSuccess &&
+    (options.data?.meta?.rbac?.perms?.write === true ||
+      options.data?.meta?.rbac?.perms?.all === true);
+
+  const { selected, isAllSelected, handleSelect, setSelected } =
+    useSelected(data);
 
   const {
     isLoading: deleteLoading,
@@ -78,7 +85,7 @@ const SavingsPlanner = () => {
   } = useDeleteItems(
     useCallback(async () => {
       return Promise.all(
-        selected.map((plan) => deletePlan({ params: {id: plan.id }}))
+        selected.map((plan) => deletePlan({ params: { id: plan.id } }))
       );
     }, [selected]),
     {
@@ -89,7 +96,7 @@ const SavingsPlanner = () => {
   );
 
   const handleDelete = async () => {
-    await deleteItems()
+    await deleteItems();
     setSelected([]);
   };
 
@@ -122,14 +129,14 @@ const SavingsPlanner = () => {
                   </Button>,
                 ]
               : []),
-              (canWrite &&
-                <ToolbarDeleteButton
-                  key="delete-plan-button"
-                  onDelete={handleDelete}
-                  itemsToDelete={selected}
-                  pluralizedItemName={'Savings plan'}
-                />
-              )
+            canWrite && (
+              <ToolbarDeleteButton
+                key="delete-plan-button"
+                onDelete={handleDelete}
+                itemsToDelete={selected}
+                pluralizedItemName={'Savings plan'}
+              />
+            ),
           ]}
           pagination={
             <Pagination
@@ -198,16 +205,16 @@ const SavingsPlanner = () => {
         isSticky
       />
       {deletionError && (
-          <AlertModal
-            aria-label={'Deletion error'}
-            isOpen={deletionError}
-            onClose={clearDeletionError}
-            title={'Error'}
-            variant="error"
-          >
-            {'Failed to delete one or more plans.'}
-            <ErrorDetail error={deletionError} />
-          </AlertModal>
+        <AlertModal
+          aria-label={'Deletion error'}
+          isOpen={deletionError}
+          onClose={clearDeletionError}
+          title={'Error'}
+          variant="error"
+        >
+          {'Failed to delete one or more plans.'}
+          <ErrorDetail error={deletionError} />
+        </AlertModal>
       )}
     </React.Fragment>
   );

--- a/src/Containers/SavingsPlanner/SavingsPlanner.js
+++ b/src/Containers/SavingsPlanner/SavingsPlanner.js
@@ -171,8 +171,8 @@ const SavingsPlanner = () => {
           <EmptyList
             label={'Add plan'}
             title={'No plans added'}
-            message={canAddPlan ? 'No plans have been added yet. Add your first plan.' : 'No plans have been added yet.'}
-            canAdd={canAddPlan}
+            message={canWrite ? 'No plans have been added yet. Add your first plan.' : 'No plans have been added yet.'}
+            canAdd={canWrite}
             path={`${pathname}/add`}
            />
         </Main>

--- a/src/Containers/SavingsPlanner/SavingsPlanner.js
+++ b/src/Containers/SavingsPlanner/SavingsPlanner.js
@@ -64,7 +64,7 @@ const SavingsPlanner = () => {
     fetchEndpoints();
   }, [queryParams]);
   
-  const canWrite = options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true);
+  const canWrite = options.isSuccess && (options.data?.meta?.rbac?.perms?.write === true || options.data?.meta?.rbac?.perms?.all === true);
 
   const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
     data

--- a/src/Containers/SavingsPlanner/SavingsPlanner.js
+++ b/src/Containers/SavingsPlanner/SavingsPlanner.js
@@ -28,11 +28,6 @@ import { useDeleteItems } from "../../Utilities/useRequest";
 import ErrorDetail from "../../Components/ErrorDetail";
 import AlertModal from "../../Components/AlertModal";
 
-
-// TODO: update to fining this out from API RBAC
-const canAddPlan = true;
-const canDeletePlan = true;
-
 const SavingsPlanner = () => {
   const history = useHistory();
   const { pathname } = useLocation();
@@ -68,6 +63,8 @@ const SavingsPlanner = () => {
   useEffect(() => {
     fetchEndpoints();
   }, [queryParams]);
+  
+  const canWrite = options.isSuccess && (options.data.meta.rbac.perms.write === true || options.data.meta.rbac.perms.all === true);
 
   const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
     data
@@ -109,7 +106,7 @@ const SavingsPlanner = () => {
           filters={queryParams}
           setFilters={setFromToolbar}
           additionalControls={[
-            ...(canAddPlan
+            ...(canWrite
               ? [
                   <Button
                     key="add-plan-button"
@@ -125,7 +122,7 @@ const SavingsPlanner = () => {
                   </Button>,
                 ]
               : []),
-              (canDeletePlan &&
+              (canWrite &&
                 <ToolbarDeleteButton
                   key="delete-plan-button"
                   onDelete={handleDelete}
@@ -184,6 +181,7 @@ const SavingsPlanner = () => {
                   selected={selected}
                   plan={datum}
                   handleSelect={handleSelect}
+                  canWrite={canWrite}
                 />
               ))}
           </Gallery>

--- a/src/Containers/SavingsPlanner/Shared/Tasks.test.js
+++ b/src/Containers/SavingsPlanner/Shared/Tasks.test.js
@@ -23,7 +23,10 @@ describe('SavingsPlanner/Shared/Tasks', () => {
       'qux'
     );
     fireEvent.click(screen.getByRole('button', { name: 'Add task' }));
-    expect(mockDispatch).toHaveBeenCalledWith({"type": "SET_TASKS", "value": mockTasks.concat('qux')});
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_TASKS',
+      value: mockTasks.concat('qux'),
+    });
   });
 
   it('can add a task by hitting "enter" key', () => {
@@ -33,12 +36,18 @@ describe('SavingsPlanner/Shared/Tasks', () => {
     });
     userEvent.type(taskInput, 'quux');
     fireEvent.keyDown(taskInput, { key: 'Enter', code: 'Enter' });
-    expect(mockDispatch).toHaveBeenCalledWith({ "type": "SET_TASKS", "value": mockTasks.concat('quux') });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_TASKS',
+      value: mockTasks.concat('quux'),
+    });
   });
 
   it('can delete a task', () => {
     render(<Tasks tasks={mockTasks} dispatch={mockDispatch} />);
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
-    expect(mockDispatch).toHaveBeenCalledWith({ "type": "SET_TASKS", "value": mockTasks.slice(1) });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_TASKS',
+      value: mockTasks.slice(1),
+    });
   });
 });

--- a/src/Utilities/__fixtures__/readPlansOptions.js
+++ b/src/Utilities/__fixtures__/readPlansOptions.js
@@ -1,51 +1,51 @@
 export default {
-    meta: {
-      rbac: {
-        perms: {
-          all: true
-        }
-      }
+  meta: {
+    rbac: {
+      perms: {
+        all: true,
+      },
     },
-    items: {
-      template_id: [
-        {
-          key: 1,
-          value: 'template_name_2',
-        },
-      ],
-      automation_status: [
-        {
-          key: 'none',
-          value: 'None',
-        },
-        {
-          key: 'successful',
-          value: 'Successful',
-        },
-        {
-          key: 'failed',
-          value: 'Failed',
-        },
-      ],
-      category: [
-        {
-          key: 'system',
-          value: 'System',
-        },
-      ],
-      frequency_period: [
-        {
-          key: 'daily',
-          value: 'Daily',
-        },
-      ],
-      sort_options: [
-        {
-          key: 'name',
-          value: 'Name',
-        },
-      ],
-    },
+  },
+  items: {
+    template_id: [
+      {
+        key: 1,
+        value: 'template_name_2',
+      },
+    ],
+    automation_status: [
+      {
+        key: 'none',
+        value: 'None',
+      },
+      {
+        key: 'successful',
+        value: 'Successful',
+      },
+      {
+        key: 'failed',
+        value: 'Failed',
+      },
+    ],
+    category: [
+      {
+        key: 'system',
+        value: 'System',
+      },
+    ],
+    frequency_period: [
+      {
+        key: 'daily',
+        value: 'Daily',
+      },
+    ],
+    sort_options: [
+      {
+        key: 'name',
+        value: 'Name',
+      },
+    ],
+  },
   response: { msg: 'Success' },
   url: '/api/tower-analytics/v1/plan_options/',
 };

--- a/src/Utilities/__fixtures__/readPlansOptions.js
+++ b/src/Utilities/__fixtures__/readPlansOptions.js
@@ -1,5 +1,11 @@
 export default {
-  data: {
+    meta: {
+      rbac: {
+        perms: {
+          all: true
+        }
+      }
+    },
     items: {
       template_id: [
         {
@@ -40,7 +46,6 @@ export default {
         },
       ],
     },
-  },
   response: { msg: 'Success' },
   url: '/api/tower-analytics/v1/plan_options/',
 };


### PR DESCRIPTION
related: https://issues.redhat.com/browse/AA-544

view only users see a list of savings plans (if any):
<img width="1502" alt="Screen Shot 2021-06-15 at 2 11 59 PM" src="https://user-images.githubusercontent.com/2293210/122102774-cb7a6b00-cde3-11eb-998a-c397b7e932f7.png">

editor or admin users see Add and Delete buttons as well as kebab menu on the cards for Edit and Link Template workflows:
<img width="1502" alt="Screen Shot 2021-06-15 at 2 11 24 PM" src="https://user-images.githubusercontent.com/2293210/122102799-d46b3c80-cde3-11eb-99fc-869e0767358e.png">


This PR implements a _basic_ RBAC UX workflow based on the permissions returned from the `plan_options` endpoint. There are no additional required API calls made to determine RBAC, so this is basically setting a boolean and showing/hiding/redirecting based on that boolean.