### PR TITLE
Link template list

### DIFF
--- a/src/Components/Toolbar/Toolbar.js
+++ b/src/Components/Toolbar/Toolbar.js
@@ -24,6 +24,8 @@ const FilterableToolbar = ({
   pagination = null,
   hasSettings = false,
   additionalControls = [],
+  hideQuickDateRange = false,
+  hideSortOptions = false,
 }) => {
   const [settingsExpanded, setSettingsExpanded] = useState(false);
   const { quick_date_range, sort_options, ...restCategories } = categories;
@@ -56,14 +58,14 @@ const FilterableToolbar = ({
               setFilters={setFilters}
             />
           )}
-          {quick_date_range && (
+          {!hideQuickDateRange && quick_date_range && (
             <QuickDateGroup
               filters={filters}
               setFilters={setFilters}
               values={quick_date_range}
             />
           )}
-          {sort_options && (
+          {!hideSortOptions && sort_options && (
             <SortByGroup
               filters={filters}
               setFilters={setFilters}
@@ -118,6 +120,8 @@ FilterableToolbar.propTypes = {
   pagination: PropTypes.object,
   hasSettings: PropTypes.bool,
   additionalControls: PropTypes.array,
+  hideSortOptions: PropTypes.bool,
+  hideQuickDateRange: PropTypes.bool,
 };
 
 export default FilterableToolbar;

--- a/src/Containers/SavingsPlanner/PlanCard.js
+++ b/src/Containers/SavingsPlanner/PlanCard.js
@@ -78,10 +78,18 @@ const PlanCard = ({
 
   const kebabDropDownItems = [
     <React.Fragment key={id}>
-      <DropdownItem key="edit" onClick={() => {}} position="right">
+      <DropdownItem
+        key="edit"
+        onClick={() => history.push(`${match.url}/${id}/edit`)}
+        position="right"
+      >
         Edit
       </DropdownItem>
-      <DropdownItem key="link" onClick={() => {}} position="right">
+      <DropdownItem
+        key="link"
+        onClick={() => history.push(`${match.url}/${id}/edit#link_template`)}
+        position="right"
+      >
         Link template
       </DropdownItem>
     </React.Fragment>,
@@ -110,7 +118,7 @@ const PlanCard = ({
           />
           <Checkbox
             onChange={() => handleSelect(plan)}
-            isChecked={selected.some(row => row.id === plan.id)}
+            isChecked={selected.some((row) => row.id === plan.id)}
             aria-label="card checkbox"
             id="check-1"
             name="check1"

--- a/src/Containers/SavingsPlanner/Shared/Form.js
+++ b/src/Containers/SavingsPlanner/Shared/Form.js
@@ -44,11 +44,7 @@ const Form = ({ title, options, data = {} }) => {
       id: 'link_template',
       name: 'Link template',
       component: (
-        <Templates
-          templates={options?.data?.template_id}
-          template_id={formData.template_id}
-          dispatch={dispatch}
-        />
+        <Templates template_id={formData.template_id} dispatch={dispatch} />
       ),
       nextButtonText: 'Save',
     },

--- a/src/Containers/SavingsPlanner/Shared/Templates.js
+++ b/src/Containers/SavingsPlanner/Shared/Templates.js
@@ -1,74 +1,220 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { parse, stringify } from 'query-string';
+import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
-  DataList,
-  DataListItem,
-  DataListCell,
-  DataListItemRow,
-  DataListControl,
-  DataListItemCells,
+  Button,
   Form,
   FormGroup,
-  Radio,
+  PaginationVariant,
 } from '@patternfly/react-core';
+import {
+  TableComposable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from '@patternfly/react-table';
+
+import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
+
+import LoadingState from '../../../Components/LoadingState';
+import EmptyState from '../../../Components/EmptyState';
+import NoResults from '../../../Components/NoResults';
+import ApiErrorState from '../../../Components/ApiErrorState';
+import Pagination from '../../../Components/Pagination';
+
+import { notAuthorizedParams } from '../../../Utilities/constants';
+import { useQueryParams } from '../../../Utilities/useQueryParams';
+import useApi from '../../../Utilities/useApi';
+
+import {
+  preflightRequest,
+  readJobExplorer,
+  readJobExplorerOptions,
+} from '../../../Api';
+
+import FilterableToolbar from '../../../Components/Toolbar/';
 
 import { actions } from './constants';
 
-const TemplateRow = styled(DataListItemRow)`
+const ListFooter = styled.div`
+  display: flex;
   align-items: center;
+  justify-content: space-between;
 `;
 
-const Templates = ({ templates = [], template_id, dispatch }) => {
+const initialQueryParams = {
+  group_by: 'template',
+  limit: 10,
+  group_by_time: false,
+  offset: 0,
+};
+
+const Templates = ({ template_id, dispatch: formDispatch }) => {
+  const { pathname, hash, search } = useLocation();
+  const history = useHistory();
+
+  const [preflightError, setPreFlightError] = useState(null);
+  const [
+    {
+      isLoading,
+      isSuccess,
+      error,
+      data: { meta = {}, items: templates = [] },
+    },
+    setData,
+  ] = useApi({ meta: {}, items: [] });
+  const [options, setOptions] = useApi({});
+
+  const {
+    queryParams,
+    setFromPagination,
+    setFromToolbar,
+    dispatch: queryParamsDispatch,
+  } = useQueryParams(initialQueryParams);
+
+  useEffect(() => {
+    insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
+
+    preflightRequest().catch((error) => {
+      setPreFlightError({ preflightError: error });
+    });
+
+    const initialSearchParams = parse(search, {
+      arrayFormat: 'bracket',
+      parseBooleans: true,
+      parseNumbers: true,
+    });
+
+    queryParamsDispatch({
+      type: 'REINITIALIZE',
+      value: {
+        ...initialQueryParams,
+        ...initialSearchParams,
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    setData(readJobExplorer({ params: queryParams }));
+    setOptions(readJobExplorerOptions({ params: queryParams }));
+    history.replace({
+      pathname,
+      hash,
+      search: stringify(queryParams, { arrayFormat: 'bracket' }),
+    });
+  }, [queryParams]);
+
+  if (preflightError?.preflightError?.status === 403) {
+    return <NotAuthorized {...notAuthorizedParams} />;
+  }
+
   return (
-    <Form>
-      <>
-        <FormGroup
-          label="Link a template to this plan:"
-          fieldId="template-link-field"
-        >
-          <DataList aria-label="draggable data list example" isCompact>
-            {templates.map(({ key, value }) => (
-              <DataListItem aria-labelledby={`cell-${key}`} id={key} key={key}>
-                <TemplateRow>
-                  <DataListControl>
-                    <Radio
-                      isChecked={template_id === key}
-                      name={`radio-${key}`}
-                      onChange={() =>
-                        dispatch({ type: actions.SET_TEMPLATE_ID, value: key })
-                      }
-                      aria-label={`Radio selector for template ${key}.`}
-                      id={`radio-${key}`}
-                      value={key}
-                    />
-                  </DataListControl>
-                  <DataListItemCells
-                    dataListCells={[
-                      <DataListCell key={key}>
-                        <span id={`cell-${key}`}>{value}</span>
-                      </DataListCell>,
-                    ]}
-                  />
-                </TemplateRow>
-              </DataListItem>
-            ))}
-          </DataList>
-        </FormGroup>
-      </>
-    </Form>
+    <>
+      {preflightError && <EmptyState {...preflightError} />}
+
+      {!preflightError && (
+        <Form>
+          <FormGroup
+            label="Link a template to this plan:"
+            fieldId="template-link-field"
+          >
+            <FilterableToolbar
+              hideQuickDateRange
+              hideSortOptions
+              categories={options.data}
+              filters={queryParams}
+              setFilters={setFromToolbar}
+              pagination={
+                <Pagination
+                  count={meta?.count}
+                  params={{
+                    limit: queryParams.limit,
+                    offset: queryParams.offset,
+                  }}
+                  setPagination={setFromPagination}
+                  isCompact
+                />
+              }
+            />
+            {error && <ApiErrorState message={error.error} />}
+            {isLoading && <LoadingState />}
+            {isSuccess && templates.length <= 0 && <NoResults />}
+            {isSuccess && templates.length > 0 && (
+              <TableComposable
+                aria-label="Template link table"
+                variant="compact"
+              >
+                <Thead>
+                  <Tr>
+                    <Th />
+                    <Th key="template-name-column-header">Name</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {templates.map(({ id, name }) => (
+                    <Tr key={`template-detail-${id}`}>
+                      <Td
+                        key={`template-detail-${id}-radio-td`}
+                        select={{
+                          rowIndex: id,
+                          onSelect: (event, isSelected, value) =>
+                            formDispatch({
+                              type: actions.SET_TEMPLATE_ID,
+                              value,
+                            }),
+                          isSelected: template_id === id,
+                          variant: 'radio',
+                        }}
+                      />
+                      <Td>{name}</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </TableComposable>
+            )}
+            <ListFooter>
+              <div>
+                {template_id !== -2 && (
+                  <Button
+                    key="clear-selection-button"
+                    variant="link"
+                    aria-label="Clear selection"
+                    onClick={() => {
+                      formDispatch({
+                        type: actions.SET_TEMPLATE_ID,
+                        value: -2,
+                      });
+                    }}
+                  >
+                    Clear selection
+                  </Button>
+                )}
+              </div>
+              <Pagination
+                count={meta?.count}
+                params={{
+                  limit: queryParams.limit,
+                  offset: queryParams.offset,
+                }}
+                setPagination={setFromPagination}
+                variant={PaginationVariant.bottom}
+              />
+            </ListFooter>
+          </FormGroup>
+        </Form>
+      )}
+    </>
   );
 };
 
 Templates.propTypes = {
-  templates: PropTypes.array,
   template_id: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,
-};
-
-Templates.defaultProps = {
-  templates: [],
 };
 
 export default Templates;


### PR DESCRIPTION
This PR:
- makes kebab actions of "edit" and "link template" on the plan cards work
- allows configurable hiding of certain subsections of the toolbar by passing props
- updates the plan add/edit link template list to using the paginated, react-table composable pf components.

![Screen Shot 2021-06-16 at 9 26 35 AM](https://user-images.githubusercontent.com/1342624/122227544-f8328f00-ce84-11eb-9db8-41e7d0444216.png)

NOTE:
- only the name column is shown currently.  I talked with @AparnaKarve and opened an issue to track adding the type information.  also to add sorting for template name and type.
- filtering by status also seems a little messed up, commented that in the issue as well
- currently if you try to "clear" a template to "no template selected", it will not work.  @AparnaKarve is working on allowing -2 to be passed for no template on both POST and PUT.  I'm opening a PR to remove that conditional from the usePlanData payload formatter.