### PR TITLE
remove -2 delete template savings plan POST/PUT payload formatter

### DIFF
--- a/src/Containers/SavingsPlanner/Shared/usePlanData.js
+++ b/src/Containers/SavingsPlanner/Shared/usePlanData.js
@@ -3,10 +3,6 @@ import { useReducer } from 'react';
 import { actions } from './constants';
 
 const formatPayload = (data) => {
-  if (data.template_id === -2) {
-    delete data.template_id;
-  }
-
   data.tasks = data.tasks.map((task, index) => ({
     task,
     task_order: index + 1,


### PR DESCRIPTION
The API will support passing -2 as the official indication that "no template is added to this plan".  This allows us to fix the corner case where the user creates a plan with a template linked and later wants to remove that template.