### PR TITLE
Fixed to display tooltips on disabled `Delete` button on list

### DIFF
--- a/src/Components/Toolbar/ToolbarDeleteButton.js
+++ b/src/Components/Toolbar/ToolbarDeleteButton.js
@@ -203,16 +203,18 @@ function ToolbarDeleteButton({
   return (
     <>
       <Tooltip content={renderTooltip()} position="top">
-        <Button
-          variant="secondary"
-          ouiaId="delete-button"
-          spinnerAriaValueText={isLoading ? 'Loading' : undefined}
-          aria-label={'Delete'}
-          onClick={() => toggleModal(true)}
-          isDisabled={isDisabled}
-        >
-          {'Delete'}
-        </Button>
+        <div>
+          <Button
+            variant="secondary"
+            ouiaId="delete-button"
+            spinnerAriaValueText={isLoading ? 'Loading' : undefined}
+            aria-label={'Delete'}
+            onClick={() => toggleModal(true)}
+            isDisabled={isDisabled}
+          >
+            {'Delete'}
+          </Button>
+        </div>
       </Tooltip>
 
       {isModalOpen && (
@@ -228,7 +230,7 @@ function ToolbarDeleteButton({
               variant="danger"
               aria-label={'confirm delete'}
               isDisabled={Boolean(
-                deleteDetails //&& itemsToDelete[0]?.type === 'credential_type'
+                deleteDetails
               )}
               onClick={handleDelete}
             >


### PR DESCRIPTION
![Screen Shot 2021-06-16 at 2 20 13 PM](https://user-images.githubusercontent.com/3450808/122274106-3002fc00-ceb0-11eb-958e-3ac03f2db2e5.png)

@jlmitch5 it seems during a code cleanup process, I ended up removing a `<div>` element around the button.
The current Tooltip component looks at its child to see if that is disabled. If so, the tooltip is not displayed. In order to always show a tooltip, we need to add a div tag around it.