### PR TITLE
Savings planner QE audit fixes

### DIFF
--- a/src/Components/ErrorDetail/ErrorDetail.js
+++ b/src/Components/ErrorDetail/ErrorDetail.js
@@ -37,25 +37,25 @@ function ErrorDetail({ error }) {
   };
 
   return (
-    <Expandable
-      toggleText={'Details'}
-      onToggle={handleToggle}
-      isExpanded={isExpanded}
-    >
-      <Card>
-        <CardBody>
-          {Array.isArray(error) ? (
-            <ul>
-              {error.map((m) =>
-                typeof m === 'string' ? <li key={m}>{m}</li> : null
-              )}
-            </ul>
-          ) : (
-            error
-          )}
-        </CardBody>
-      </Card>
-    </Expandable>
+    <>
+      {Array.isArray(error) && error.length && (
+        <Expandable
+          toggleText={'Details'}
+          onToggle={handleToggle}
+          isExpanded={isExpanded}
+        >
+          <Card>
+            <CardBody>
+              <ul>
+                {error.map((m) =>
+                  typeof m === 'string' ? <li key={m}>{m}</li> : null
+                )}
+              </ul>
+            </CardBody>
+          </Card>
+        </Expandable>
+      )}
+    </>
   );
 }
 

--- a/src/Components/Toolbar/Groups/ToolbarInput/Text.js
+++ b/src/Components/Toolbar/Groups/ToolbarInput/Text.js
@@ -41,6 +41,12 @@ const Text = ({ categoryKey, isVisible = true, value = '', setValue }) => {
           aria-label={options.name}
           value={searchVal}
           onChange={setSearchVal}
+          onKeyDown={(e) => {
+            if (e.key && e.key === 'Enter') {
+              e.preventDefault();
+              setValue(searchVal);
+            }
+          }}
         />
         <Button
           variant="control"

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
@@ -50,6 +50,7 @@ const Details = ({ options, formData, dispatch }) => {
               isOpen={categoryIsOpen}
               variant={'single'}
               aria-label={'Plan category selector'}
+              maxHeight={390}
               onToggle={() => setCategoryIsOpen(!categoryIsOpen)}
               onSelect={(_event, selection) => {
                 dispatch({

--- a/src/Containers/SavingsPlanner/Shared/usePlanData.js
+++ b/src/Containers/SavingsPlanner/Shared/usePlanData.js
@@ -8,6 +8,10 @@ const formatPayload = (data) => {
     task_order: index + 1,
   }));
 
+  if (!data.hosts || data.hosts === '') {
+    data.hosts = 1;
+  }
+
   // these two are fields the api expects but we don't
   // have form elements for in the MVP.
   data.hourly_rate = 50;


### PR DESCRIPTION
Just a couple of tiny fixes:
- sets a max height for the category dropdown
- pass 1 if no host number is specified, i.e. the default is deleted from the field
- hide details section of error modal if there are none passed by the API for us to display.
- make onKeyDown enter work for the name search.