### PR TITLE
Feature flag proxy url updated

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -23,7 +23,7 @@ const clustersOptionsEndpoint =
   '/api/tower-analytics/v1/dashboard_clusters_options/';
 const planOptionsEndpoint = '/api/tower-analytics/v1/plan_options/';
 
-const featuresEndpoint = '/api/featureflags/v0/';
+const featuresEndpoint = '/api/featureflags/v0';
 
 const handleResponse = (response) => {
   return response.json().then((json) => {


### PR DESCRIPTION
The trailing slash is failing the call.  This is reproducible with `curl`.  Something to do with 3scale config.