### PR TITLE
Enable chrome 2

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,7 +4,8 @@ const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
   https: true,
-  skipChrome2: true,
+  sassPrefix: '.automation-analytics, .automationAnalytics',
+  useCloud: true,
   ...(process.env.BETA && { deployment: 'beta/apps' }),
 });
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -3,7 +3,8 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   https: true,
-  skipChrome2: true,
+  sassPrefix: '.automation-analytics, .automationAnalytics',
+  useCloud: true,
 });
 
 plugins.push(

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.1.0",
-    "@redhat-cloud-services/frontend-components-config": "4.1.10",
+    "@redhat-cloud-services/frontend-components-config": "^4.2.7",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.6",
     "@testing-library/react-hooks": "^5.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -19,16 +19,9 @@ const App = () => {
       appNav();
     };
   }, []);
-  /**
-   * Remove automation-analytics class once main.yml has module config
-   */
 
   return (
-    <div
-      className="automation-analytics"
-      id="automation-analytics-application"
-      version={packageJson.version}
-    >
+    <div id="automation-analytics-application" version={packageJson.version}>
       <Routes />
     </div>
   );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,11 +4,9 @@ import promiseMiddleware from 'redux-promise-middleware';
 let registry;
 
 export function init(...middleware) {
-  if (registry) {
-    throw new Error('store already initialized');
+  if (!registry) {
+    registry = new ReducerRegistry({}, [promiseMiddleware, ...middleware]);
   }
-
-  registry = new ReducerRegistry({}, [promiseMiddleware, ...middleware]);
 
   //If you want to register all of your reducers, this is good place.
   /*


### PR DESCRIPTION
With the new chrome nav changes getting deployed to all environments (prod-beta Wednesday, July 21st and prod-stable Monday, July 26th), we can now safely enable chrome 2 navigation for this application.

It will enable the following:
- Client-side routing when navigating between chrome 2 apps
- Consuming chrome 2 API via `useChrome` hook
  - trough this API all future features will be accessible
- global error boundary to prevent apps from crashing the whole UI

**This PR depends on CSC prs! It will not work without them, we have to make sure we merge them simultaneously.**
- ci/qa/qaproduath/stage-beta envs: https://github.com/RedHatInsights/cloud-services-config/pull/780
- ci-stable: https://github.com/RedHatInsights/cloud-services-config/pull/781
- qa/stage/qaproduath-stable: https://github.com/RedHatInsights/cloud-services-config/pull/782
- prod-beta: https://github.com/RedHatInsights/cloud-services-config/pull/783
- prod-stable: TBD

### Preview:

![tower-nav](https://user-images.githubusercontent.com/22619452/126289041-e8bd7ce6-2952-461e-a0c3-990e68e02c72.gif)
