### PR TITLE
Updated use request so it does not return success and loading

### DIFF
--- a/src/Utilities/useRequest.js
+++ b/src/Utilities/useRequest.js
@@ -28,6 +28,7 @@ export const useRequest = (makeRequest, initialValue) => {
     isSuccess,
     request: useCallback(
       async (...args) => {
+        setIsSuccess(false);
         setIsLoading(true);
         try {
           const response = await makeRequest(...args);


### PR DESCRIPTION
Note: use request could use one state so we change only one state when setting values instead of changing multiple ones.
Changing multiple ones at the same time can potentially make react rerender multiple times, which is not an issue but it is not ideal.

The issue what is fixed:
When loading data the loading screen appears above the data and not instead of it. This is caused by the new useRequest returning `isSuccess` and `isLoading` alongside each other.

This is affecting all of our pages.