### PR TITLE
Added namespace prefix on params in url.

### DIFF
--- a/src/Components/ModalContents.js
+++ b/src/Components/ModalContents.js
@@ -102,8 +102,8 @@ const ModalContents = ({ selectedId, isOpen, handleModal, qp, jobType }) => {
   const redirectToJobExplorer = () => {
     const { jobExplorer } = Paths;
     const initialQueryParams = {
-      template_id: [selectedId],
-      status: [
+      'job-explorer.template_id': selectedId,
+      'job-explorer.status': [
         'successful',
         'failed',
         'new',
@@ -113,8 +113,8 @@ const ModalContents = ({ selectedId, isOpen, handleModal, qp, jobType }) => {
         'canceled',
         'running',
       ],
-      job_type: [jobType],
-      quick_date_range: 'last_30_days',
+      'job-explorer.job_type': [jobType],
+      'job-explorer.quick_date_range': 'last_30_days',
     };
 
     const search = stringify(initialQueryParams, { arrayFormat: 'bracket' });

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -183,8 +183,8 @@ const AutomationCalculator = ({ history }) => {
    */
   const redirectToJobExplorer = (templateId) => {
     const initialQueryParams = {
-      quick_date_range: 'last_30_days',
-      template_id: [templateId],
+      'job-explorer.quick_date_range': 'last_30_days',
+      'job-explorer.template_id': templateId,
     };
     toJobExplorer(initialQueryParams);
   };

--- a/src/Containers/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.test.js
@@ -163,7 +163,7 @@ describe('Containers/AutomationCalculator', () => {
     wrapper.find('a').at(0).simulate('click');
     expect(history.push).toHaveBeenCalledWith({
       pathname: '/job-explorer',
-      search: expect.stringContaining('template_id[]=1'),
+      search: expect.stringContaining('job-explorer.template_id=1'),
     });
   });
 

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -95,10 +95,10 @@ const redirectToJobExplorer =
     const formattedDate = dateForJobExplorer(date);
     const initialQueryParams = {
       ...rest,
-      quick_date_range: 'custom',
-      start_date: formattedDate,
-      end_date: formattedDate,
-      status: [
+      'job-explorer.quick_date_range': 'custom',
+      'job-explorer.start_date': formattedDate,
+      'job-explorer.end_date': formattedDate,
+      'job-explorer.status': [
         'successful',
         'failed',
         'new',
@@ -108,7 +108,7 @@ const redirectToJobExplorer =
         'canceled',
         'running',
       ],
-      org_id: [id],
+      'job-explorer.org_id': [id],
     };
 
     toJobExplorer(initialQueryParams);

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
@@ -73,9 +73,9 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
   const redirectToJobExplorer = (templateId) => {
     const { jobExplorer } = Paths;
     const initialQueryParams = {
-      quick_date_range: 'last_30_days',
-      status: ['failed', 'successful'],
-      template_id: [templateId],
+      'job-explorer.quick_date_range': 'last_30_days',
+      'job-explorer.status': ['failed', 'successful'],
+      'job-explorer.template_id': templateId,
     };
     const search = stringify(initialQueryParams, { arrayFormat: 'bracket' });
     history.push({

--- a/src/Containers/SavingsPlanner/List/ListItem/index.js
+++ b/src/Containers/SavingsPlanner/List/ListItem/index.js
@@ -87,9 +87,9 @@ const ListItem = ({
   const redirectToJobExplorer = (templateId) => {
     const { jobExplorer } = Paths;
     const initialQueryParams = {
-      quick_date_range: 'last_30_days',
-      status: ['failed', 'successful'],
-      template_id: [templateId],
+      'job-explorer.quick_date_range': 'last_30_days',
+      'job-explorer.status': ['failed', 'successful'],
+      'job-explorer.template_id': templateId,
     };
     const search = stringify(initialQueryParams, { arrayFormat: 'bracket' });
     history.push({


### PR DESCRIPTION
params need to be prefixed by namespace when building a link to redirect to job explorer from various screens.

@jlmitch5 please review, this should fix the issue you saw with the link to template from Savings-planner list/details view

