### PR TITLE
useRequest usage unification

### DIFF
--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -79,8 +79,8 @@ export const readPlans = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(plansEndpoint, params);
 export const createPlan = (params: Params): Promise<ApiJson> =>
   post(planEndpoint, params);
-export const readPlan = (params: Params): Promise<ApiJson> =>
-  post(plansEndpoint, params);
+export const readPlan = (id: number): Promise<ApiJson> =>
+  get(`${planEndpoint}${id}/`);
 export const deletePlan = ({ id }: DeleteParams): Promise<ApiJson> =>
   deleteById(planEndpoint, id);
 export const updatePlan = ({

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -18,9 +18,9 @@ import {
 /* v0 endpoints */
 export const clustersEndpoint = `/api/tower-analytics/v0/clusters/`;
 export const notificationsEndpoint = `/api/tower-analytics/v0/notifications/`;
-export const preflightEndpoint = `/api/tower-analytics/v0/authorized/`;
 
 /* v1 endpoints */
+export const preflightEndpoint = `/api/tower-analytics/v1/authorized/`;
 export const jobExplorerEndpoint = '/api/tower-analytics/v1/job_explorer/';
 export const hostExplorerEndpoint = '/api/tower-analytics/v1/host_explorer/';
 export const eventExplorerEndpoint = '/api/tower-analytics/v1/event_explorer/';

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -18,9 +18,9 @@ import {
 /* v0 endpoints */
 export const clustersEndpoint = `/api/tower-analytics/v0/clusters/`;
 export const notificationsEndpoint = `/api/tower-analytics/v0/notifications/`;
+export const preflightEndpoint = `/api/tower-analytics/v0/authorized/`;
 
 /* v1 endpoints */
-export const preflightEndpoint = `/api/tower-analytics/v1/authorized/`;
 export const jobExplorerEndpoint = '/api/tower-analytics/v1/job_explorer/';
 export const hostExplorerEndpoint = '/api/tower-analytics/v1/host_explorer/';
 export const eventExplorerEndpoint = '/api/tower-analytics/v1/event_explorer/';

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -8,8 +8,8 @@ import {
   authenticatedFetch,
 } from './methods';
 import {
-  ReadParams,
-  ReadParamsWithPagination,
+  Params,
+  ParamsWithPagination,
   DeleteParams,
   UpdateParams,
   ApiJson,
@@ -54,40 +54,32 @@ export const getFeatures = async (): Promise<ApiFeatureFlagReturnType> => {
 export const preflightRequest = (): Promise<Response> =>
   authenticatedFetch(preflightEndpoint);
 
-export const readJobExplorer = ({
-  params,
-}: ReadParamsWithPagination): Promise<ApiJson> =>
-  postWithPagination(jobExplorerEndpoint, params);
-export const readJobExplorerOptions = ({
-  params,
-}: ReadParams): Promise<ApiJson> => post(jobExplorerOptionsEndpoint, params);
+export const readJobExplorer = (
+  params: ParamsWithPagination
+): Promise<ApiJson> => postWithPagination(jobExplorerEndpoint, params);
+export const readJobExplorerOptions = (params: Params): Promise<ApiJson> =>
+  post(jobExplorerOptionsEndpoint, params);
 
-export const readEventExplorer = ({
-  params,
-}: ReadParamsWithPagination): Promise<ApiJson> =>
-  postWithPagination(eventExplorerEndpoint, params);
+export const readEventExplorer = (
+  params: ParamsWithPagination
+): Promise<ApiJson> => postWithPagination(eventExplorerEndpoint, params);
 
-export const readROI = ({
-  params,
-}: ReadParamsWithPagination): Promise<ApiJson> =>
+export const readROI = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(ROIEndpoint, params);
-export const readROIOptions = ({ params }: ReadParams): Promise<ApiJson> =>
+export const readROIOptions = (params: Params): Promise<ApiJson> =>
   post(ROITemplatesOptionsEndpoint, params);
 
-export const readHostExplorer = ({
-  params,
-}: ReadParamsWithPagination): Promise<ApiJson> =>
-  postWithPagination(hostExplorerEndpoint, params);
-export const readOrgOptions = ({ params }: ReadParams): Promise<ApiJson> =>
+export const readHostExplorer = (
+  params: ParamsWithPagination
+): Promise<ApiJson> => postWithPagination(hostExplorerEndpoint, params);
+export const readOrgOptions = (params: Params): Promise<ApiJson> =>
   post(orgOptionsEndpoint, params);
 
-export const readPlans = ({
-  params,
-}: ReadParamsWithPagination): Promise<ApiJson> =>
+export const readPlans = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(plansEndpoint, params);
-export const createPlan = ({ params }: ReadParams): Promise<ApiJson> =>
+export const createPlan = (params: Params): Promise<ApiJson> =>
   post(planEndpoint, params);
-export const readPlan = ({ params }: ReadParams): Promise<ApiJson> =>
+export const readPlan = (params: Params): Promise<ApiJson> =>
   post(plansEndpoint, params);
 export const deletePlan = ({ id }: DeleteParams): Promise<ApiJson> =>
   deleteById(planEndpoint, id);
@@ -95,13 +87,12 @@ export const updatePlan = ({
   id,
   params = {},
 }: UpdateParams): Promise<ApiJson> => updateById(planEndpoint, id, params);
-export const readPlanOptions = (
-  { params }: ReadParams = { params: {} }
-): Promise<ApiJson> => get(planOptionsEndpoint, params);
+export const readPlanOptions = (params: Params = {}): Promise<ApiJson> =>
+  get(planOptionsEndpoint, params);
 
 export const readClusters = (): Promise<ApiJson> => get(clustersEndpoint);
-export const readClustersOptions = ({ params }: ReadParams): Promise<ApiJson> =>
+export const readClustersOptions = (params: Params): Promise<ApiJson> =>
   post(clustersOptionsEndpoint, params);
 
-export const readNotifications = ({ params }: ReadParams): Promise<ApiJson> =>
+export const readNotifications = (params: Params): Promise<ApiJson> =>
   get(notificationsEndpoint, params);

--- a/src/Components/EmptyState.js
+++ b/src/Components/EmptyState.js
@@ -9,6 +9,8 @@ import {
   EmptyStateBody,
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
+import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import { notAuthorizedParams } from '../Utilities/constants';
 
 const DefaultEmptyState = ({ preflightError: error }) => (
   <EmptyState variant={EmptyStateVariant.full}>
@@ -41,6 +43,7 @@ const DefaultEmptyState = ({ preflightError: error }) => (
         </EmptyStateBody>
       </>
     )}
+    {error.status === 403 && <NotAuthorized {...notAuthorizedParams} />}
     {!error.status && (
       <>
         <Title headingLevel="h5" size="lg">

--- a/src/Components/ModalContents.js
+++ b/src/Components/ModalContents.js
@@ -79,10 +79,7 @@ const ModalContents = ({ selectedId, isOpen, handleModal, qp, jobType }) => {
     request: fetchStats,
     ...statsApi
   } = useRequest(
-    useCallback(
-      () => readJobExplorer({ params: agreggateTemplateParams }),
-      [selectedId]
-    ),
+    useCallback(() => readJobExplorer(agreggateTemplateParams), [selectedId]),
     {}
   );
 
@@ -91,10 +88,7 @@ const ModalContents = ({ selectedId, isOpen, handleModal, qp, jobType }) => {
     request: fetchJobs,
     ...jobsApi
   } = useRequest(
-    useCallback(
-      () => readJobExplorer({ params: relatedTemplateJobsParams }),
-      [selectedId]
-    ),
+    useCallback(() => readJobExplorer(relatedTemplateJobsParams), [selectedId]),
     {}
   );
   let history = useHistory();

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -30,6 +30,8 @@ import { useQueryParams } from '../../Utilities/useQueryParams';
 import { roi as roiConst } from '../../Utilities/constants';
 import useRedirect from '../../Utilities/useRedirect';
 import { calculateDelta, convertSecondsToHours } from '../../Utilities/helpers';
+import useRequest from '../../Utilities/useRequest';
+import { getQSConfig } from '../../Utilities/qs';
 
 // Chart
 import TopTemplatesSavings from '../../Charts/ROITopTemplates';
@@ -40,8 +42,6 @@ import TotalSavings from './TotalSavings';
 import CalculationCost from './CalculationCost';
 import AutomationFormula from './AutomationFormula';
 import TopTemplates from './TopTemplates';
-import useRequest from '../../Utilities/useRequest';
-import { getQSConfig } from '../../Utilities/qs';
 
 const mapApi = ({ items = [] }) =>
   items.map((el) => ({

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -87,45 +87,27 @@ const AutomationCalculator = ({ history }) => {
   // params from toolbar/searchbar
   const { queryParams, setFromToolbar } = useQueryParams(qsConfig);
 
-  const {
-    error: preflightError,
-    isLoading: preflightIsLoading,
-    request: setPreflight,
-  } = useRequest(
-    useCallback(async () => {
-      const preflight = await preflightRequest();
-      return { preflight: preflight };
-    }, []),
-    { preflight: {}, preflightError, preflightIsLoading }
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
+  );
+
+  const { result: options, request: setOptions } = useRequest(
+    useCallback(() => readROIOptions(queryParams), [queryParams]),
+    {}
   );
 
   const {
-    result: { options },
-    error: optionsError,
-    isLoading: optionsIsLoading,
-    request: setOptions,
-  } = useRequest(
-    useCallback(async () => {
-      const options = await readROIOptions({ params: queryParams });
-      return { options: options };
-    }, [queryParams]),
-    { options: {}, optionsError, optionsIsLoading }
-  );
-
-  const {
-    result: { data: api },
+    result: api,
     error: apiError,
     isLoading: apiIsLoading,
     request: fetchEndpoint,
     setValue,
   } = useRequest(
     useCallback(async () => {
-      const response = await readROI({ params: queryParams });
-      return {
-        data: updateDeltaCost(mapApi(response), costAutomation, costManual),
-      };
+      const response = await readROI(queryParams);
+      return updateDeltaCost(mapApi(response), costAutomation, costManual);
     }, [queryParams]),
-    { data: [], apiError, apiIsLoading }
+    []
   );
 
   /**
@@ -148,13 +130,11 @@ const AutomationCalculator = ({ history }) => {
       }
     });
 
-    setValue({ data: updatedData });
+    setValue(updatedData);
   };
 
   const setEnabled = (id) => (value) => {
-    setValue({
-      data: api.map((el) => (el.id === id ? { ...el, enabled: value } : el)),
-    });
+    setValue(api.map((el) => (el.id === id ? { ...el, enabled: value } : el)));
   };
 
   useEffect(() => {
@@ -166,7 +146,7 @@ const AutomationCalculator = ({ history }) => {
    * Recalculates the delta and costs in the data after the cost is changed.
    */
   useEffect(() => {
-    setValue({ data: updateDeltaCost(api, costAutomation, costManual) });
+    setValue(updateDeltaCost(api, costAutomation, costManual));
   }, [costAutomation, costManual]);
 
   /**

--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -15,7 +14,6 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { notAuthorizedParams } from '../../Utilities/constants';
 
 // Imports from custom components
 import LoadingState from '../../Components/LoadingState';
@@ -226,10 +224,6 @@ const AutomationCalculator = ({ history }) => {
       </StackItem>
     </Stack>
   );
-
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
 
   const renderContents = () => {
     if (preflightError) return <EmptyState preflightError={preflightError} />;

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -60,6 +60,12 @@ const initialModuleParams = {
   limit: 10,
 };
 
+const initialOptionsParams = {
+  attributes: jobExplorer.attributes,
+};
+
+const optionsQueryParams = useQueryParams(initialOptionsParams);
+
 // takes json and returns
 const qsConfig = getQSConfig('clusters', { ...clusters.defaultParams }, [
   'limit',
@@ -78,7 +84,10 @@ const Clusters = () => {
     error,
     request: fetchOptions,
   } = useRequest(
-    useCallback(() => readClustersOptions(optionsQueryParams), [queryParams]),
+    useCallback(
+      () => readClustersOptions(optionsQueryParams),
+      [optionsQueryParams]
+    ),
     {}
   );
 
@@ -130,12 +139,6 @@ const Clusters = () => {
     }, [queryParams]),
     []
   );
-
-  const initialOptionsParams = {
-    attributes: jobExplorer.attributes,
-  };
-
-  const optionsQueryParams = useQueryParams(initialOptionsParams);
 
   useEffect(() => {
     setPreflight();

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -64,8 +64,6 @@ const initialOptionsParams = {
   attributes: jobExplorer.attributes,
 };
 
-const optionsQueryParams = useQueryParams(initialOptionsParams);
-
 // takes json and returns
 const qsConfig = getQSConfig('clusters', { ...clusters.defaultParams }, [
   'limit',
@@ -78,6 +76,7 @@ const Clusters = () => {
   );
 
   // params from toolbar/searchbar
+  const optionsQueryParams = useQueryParams(initialOptionsParams);
   const { queryParams, setFromToolbar } = useQueryParams(qsConfig);
   const {
     result: options,

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -74,81 +74,61 @@ const Clusters = () => {
   // params from toolbar/searchbar
   const { queryParams, setFromToolbar } = useQueryParams(qsConfig);
   const {
-    result: { options },
+    result: options,
     error,
     request: fetchOptions,
   } = useRequest(
-    useCallback(async () => {
-      const options = await readClustersOptions({ params: optionsQueryParams });
-      return { options };
-    }, [queryParams]),
-    { options: {} }
+    useCallback(() => readClustersOptions(optionsQueryParams), [queryParams]),
+    {}
   );
 
   const {
-    result: { chartData },
-    error: chartDataError,
+    result: chartData,
     isLoading: chartDataIsLoading,
     isSuccess: chartDataIsSuccess,
     request: fetchChartData,
   } = useRequest(
     useCallback(async () => {
-      const chartData = await readJobExplorer({ params: queryParams });
-      return { chartData: chartData.items };
+      const chartData = await readJobExplorer(queryParams);
+      return chartData.items;
     }, [queryParams]),
-    {
-      chartData: [],
-      chartDataError,
-      chartDataIsLoading,
-      chartDataIsSuccess,
-    }
+    []
   );
 
   const {
-    result: { modules },
-    error: modulesError,
+    result: modules,
     isLoading: modulesIsLoading,
-    isSuccess: modulesIsSuccess,
     request: fetchModules,
   } = useRequest(
     useCallback(async () => {
-      const modules = await readEventExplorer({ params: topModuleParams });
-      return { modules: modules.items };
+      const modules = await readEventExplorer(topModuleParams);
+      return modules.items;
     }, [queryParams]),
-    { modules: [], modulesError, modulesIsLoading, modulesIsSuccess }
+    []
   );
 
   const {
-    result: { templates },
-    error: templatesError,
+    result: templates,
     isLoading: templatesIsLoading,
-    isSuccess: templatesIsSuccess,
     request: fetchTemplates,
   } = useRequest(
     useCallback(async () => {
-      const templates = await readJobExplorer({ params: topTemplatesParams });
-      return { templates: templates.items };
+      const templates = await readJobExplorer(topTemplatesParams);
+      return templates.items;
     }, [queryParams]),
-    { templates: [], templatesError, templatesIsLoading, templatesIsSuccess }
+    []
   );
 
   const {
-    result: { workflows },
-    error: workflowsError,
+    result: workflows,
     isLoading: workflowsIsLoading,
-    isSuccess: workflowsIsSuccess,
     request: fetchWorkflows,
   } = useRequest(
     useCallback(async () => {
-      const workflows = await readJobExplorer({ params: topWorkflowParams });
-      return { workflows: workflows.items };
+      const workflows = await readJobExplorer(topWorkflowParams);
+      return workflows.items;
     }, [queryParams]),
-    {
-      workflows: [],
-      workflowsError,
-      workflowsIsLoading,
-      workflowsIsSuccess,
-    }
+    []
   );
 
   const initialOptionsParams = {

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
 
@@ -69,7 +69,9 @@ const qsConfig = getQSConfig('clusters', { ...clusters.defaultParams }, [
 ]);
 
 const Clusters = () => {
-  const [preflightError, setPreFlightError] = useState(null);
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
+  );
 
   // params from toolbar/searchbar
   const { queryParams, setFromToolbar } = useQueryParams(qsConfig);
@@ -138,6 +140,7 @@ const Clusters = () => {
   const optionsQueryParams = useQueryParams(initialOptionsParams);
 
   useEffect(() => {
+    setPreflight();
     fetchOptions();
     fetchChartData();
     fetchModules();
@@ -184,21 +187,11 @@ const Clusters = () => {
     ...initialModuleParams,
   };
 
-  useEffect(() => {
-    async function initializeWithPreflight() {
-      await preflightRequest().catch((error) => {
-        setPreFlightError({ preflightError: error });
-      });
-    }
-
-    initializeWithPreflight();
-  }, []);
-
-  if (preflightError?.preflightError?.status === 403) {
+  if (preflightError?.status === 403) {
     return <NotAuthorized {...notAuthorizedParams} />;
   }
 
-  if (preflightError?.preflightError) return <EmptyState {...preflightError} />;
+  if (preflightError) return <EmptyState preflightError={preflightError} />;
 
   if (error) return <ApiErrorState message={error.error} />;
 

--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -14,12 +14,10 @@ import {
 import { jobExplorer } from '../../Utilities/constants';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
   Card,
@@ -186,10 +184,6 @@ const Clusters = () => {
     end_date,
     ...initialModuleParams,
   };
-
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
 
   if (preflightError) return <EmptyState preflightError={preflightError} />;
 

--- a/src/Containers/Clusters/Clusters.test.js
+++ b/src/Containers/Clusters/Clusters.test.js
@@ -1,54 +1,57 @@
-import { act } from 'react-dom/test-utils';
-import { screen } from '@testing-library/react';
-import { renderPage } from '../../__tests__/helpers.reactTestingLib';
-import Clusters from './Clusters';
+// import { act } from 'react-dom/test-utils';
+// import { screen } from '@testing-library/react';
+// import { renderPage } from '../../__tests__/helpers.reactTestingLib';
+// import Clusters from './Clusters';
 
-import mockResponses from '../../__tests__/fixtures/';
-import * as api from '../../Api/';
-jest.mock('../../Api');
+// import mockResponses from '../../__tests__/fixtures/';
+// import * as api from '../../Api/';
+// jest.mock('../../Api');
 
 describe('<Clusters />', () => {
-  afterEach(() => {
-    api.preflightRequest.mockResolvedValue(mockResponses.preflightRequest200);
-    api.readClustersOptions.mockResolvedValue(mockResponses.readClusterOptions);
-    api.readJobExplorer.mockResolvedValue(mockResponses.readJobExplorer);
-    api.readEventExplorer.mockResolvedValue(mockResponses.readEventExplorer);
+  test('true', () => {
+    expect(true).toBe(true);
   });
+  // afterEach(() => {
+  //   api.preflightRequest.mockResolvedValue(mockResponses.preflightRequest200);
+  //   api.readClustersOptions.mockResolvedValue(mockResponses.readClusterOptions);
+  //   api.readJobExplorer.mockResolvedValue(mockResponses.readJobExplorer);
+  //   api.readEventExplorer.mockResolvedValue(mockResponses.readEventExplorer);
+  // });
 
-  test('has rendered preflight/authorization error component', async () => {
-    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest401);
-    await act(async () => {
-      renderPage(Clusters);
-    });
-    expect(screen.getByText('Not authorized'));
-  });
+  // test('has rendered preflight/authorization error component', async () => {
+  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest401);
+  //   await act(async () => {
+  //     renderPage(Clusters);
+  //   });
+  //   expect(screen.getByText('Not authorized'));
+  // });
 
-  test('has rendered Empty page component', async () => {
-    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest404);
-    await act(async () => {
-      renderPage(Clusters);
-    });
-    expect(
-      screen.getByText('Something went wrong, please try reloading the page')
-    );
-  });
+  // test('has rendered Empty page component', async () => {
+  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest404);
+  //   await act(async () => {
+  //     renderPage(Clusters);
+  //   });
+  //   expect(
+  //     screen.getByText('Something went wrong, please try reloading the page')
+  //   );
+  // });
 
-  test('has rendered RBAC Access error component', async () => {
-    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest403);
-    await act(async () => {
-      renderPage(Clusters);
-    });
-    expect(screen.queryByText(/Clusters/i)).toBeNull();
-    expect(screen.getByText('RBAC Access Denied'));
-  });
+  // test('has rendered RBAC Access error component', async () => {
+  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest403);
+  //   await act(async () => {
+  //     renderPage(Clusters);
+  //   });
+  //   expect(screen.queryByText(/Clusters/i)).toBeNull();
+  //   expect(screen.getByText('RBAC Access Denied'));
+  // });
 
-  test('has rendered Clusters component with data', async () => {
-    await act(async () => {
-      renderPage(Clusters);
-    });
-    expect(screen.getAllByText(/Clusters/i));
-    expect(screen.getByText('Jobs across all clusters'));
-    expect(screen.getByText('Top workflows'));
-    expect(screen.getByText('Job status'));
-  });
+  // test('has rendered Clusters component with data', async () => {
+  //   await act(async () => {
+  //     renderPage(Clusters);
+  //   });
+  //   expect(screen.getAllByText(/Clusters/i));
+  //   expect(screen.getByText('Jobs across all clusters'));
+  //   expect(screen.getByText('Top workflows'));
+  //   expect(screen.getByText('Job status'));
+  // });
 });

--- a/src/Containers/Clusters/Clusters.test.js
+++ b/src/Containers/Clusters/Clusters.test.js
@@ -1,57 +1,57 @@
-// import { act } from 'react-dom/test-utils';
-// import { screen } from '@testing-library/react';
-// import { renderPage } from '../../__tests__/helpers.reactTestingLib';
-// import Clusters from './Clusters';
+import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
+import { renderPage } from '../../__tests__/helpers.reactTestingLib';
+import Clusters from './Clusters';
 
-// import mockResponses from '../../__tests__/fixtures/';
-// import * as api from '../../Api/';
-// jest.mock('../../Api');
+import mockResponses from '../../__tests__/fixtures/';
+import * as api from '../../Api/';
+jest.mock('../../Api');
 
 describe('<Clusters />', () => {
   test('true', () => {
     expect(true).toBe(true);
   });
-  // afterEach(() => {
-  //   api.preflightRequest.mockResolvedValue(mockResponses.preflightRequest200);
-  //   api.readClustersOptions.mockResolvedValue(mockResponses.readClusterOptions);
-  //   api.readJobExplorer.mockResolvedValue(mockResponses.readJobExplorer);
-  //   api.readEventExplorer.mockResolvedValue(mockResponses.readEventExplorer);
-  // });
+  afterEach(() => {
+    api.preflightRequest.mockResolvedValue(mockResponses.preflightRequest200);
+    api.readClustersOptions.mockResolvedValue(mockResponses.readClusterOptions);
+    api.readJobExplorer.mockResolvedValue(mockResponses.readJobExplorer);
+    api.readEventExplorer.mockResolvedValue(mockResponses.readEventExplorer);
+  });
 
-  // test('has rendered preflight/authorization error component', async () => {
-  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest401);
-  //   await act(async () => {
-  //     renderPage(Clusters);
-  //   });
-  //   expect(screen.getByText('Not authorized'));
-  // });
+  test('has rendered preflight/authorization error component', async () => {
+    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest401);
+    await act(async () => {
+      renderPage(Clusters);
+    });
+    expect(screen.getByText('Not authorized'));
+  });
 
-  // test('has rendered Empty page component', async () => {
-  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest404);
-  //   await act(async () => {
-  //     renderPage(Clusters);
-  //   });
-  //   expect(
-  //     screen.getByText('Something went wrong, please try reloading the page')
-  //   );
-  // });
+  test('has rendered Empty page component', async () => {
+    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest404);
+    await act(async () => {
+      renderPage(Clusters);
+    });
+    expect(
+      screen.getByText('Something went wrong, please try reloading the page')
+    );
+  });
 
-  // test('has rendered RBAC Access error component', async () => {
-  //   api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest403);
-  //   await act(async () => {
-  //     renderPage(Clusters);
-  //   });
-  //   expect(screen.queryByText(/Clusters/i)).toBeNull();
-  //   expect(screen.getByText('RBAC Access Denied'));
-  // });
+  test('has rendered RBAC Access error component', async () => {
+    api.preflightRequest.mockRejectedValue(mockResponses.preflightRequest403);
+    await act(async () => {
+      renderPage(Clusters);
+    });
+    expect(screen.queryByText(/Clusters/i)).toBeNull();
+    expect(screen.getByText('RBAC Access Denied'));
+  });
 
-  // test('has rendered Clusters component with data', async () => {
-  //   await act(async () => {
-  //     renderPage(Clusters);
-  //   });
-  //   expect(screen.getAllByText(/Clusters/i));
-  //   expect(screen.getByText('Jobs across all clusters'));
-  //   expect(screen.getByText('Top workflows'));
-  //   expect(screen.getByText('Job status'));
-  // });
+  test('has rendered Clusters component with data', async () => {
+    await act(async () => {
+      renderPage(Clusters);
+    });
+    expect(screen.getAllByText(/Clusters/i));
+    expect(screen.getByText('Jobs across all clusters'));
+    expect(screen.getByText('Top workflows'));
+    expect(screen.getByText('Job status'));
+  });
 });

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -18,12 +18,10 @@ import {
 import { jobExplorer } from '../../Utilities/constants';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { notAuthorizedParams } from '../../Utilities/constants';
 
 import { Card, CardBody, PaginationVariant } from '@patternfly/react-core';
 
@@ -81,9 +79,6 @@ const JobExplorer = () => {
     fetchEndpoints();
   }, [queryParams]);
 
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
   if (preflightError) return <EmptyState preflightError={preflightError} />;
   if (error) return <ApiErrorState message={error.error} />;
 

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { useQueryParams } from '../../Utilities/useQueryParams';
@@ -41,7 +41,9 @@ const qsConfig = getQSConfig('job-explorer', { ...initialQueryParams }, [
 ]);
 
 const JobExplorer = () => {
-  const [preflightError, setPreFlightError] = useState(null);
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
+  );
 
   const {
     queryParams,
@@ -71,10 +73,7 @@ const JobExplorer = () => {
 
   useEffect(() => {
     insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
-
-    preflightRequest().catch((error) => {
-      setPreFlightError({ preflightError: error });
-    });
+    setPreflight();
   }, []);
 
   useEffect(() => {
@@ -82,10 +81,10 @@ const JobExplorer = () => {
     fetchEndpoints();
   }, [queryParams]);
 
-  if (preflightError?.preflightError?.status === 403) {
+  if (preflightError?.status === 403) {
     return <NotAuthorized {...notAuthorizedParams} />;
   }
-  if (preflightError?.preflightError) return <EmptyState {...preflightError} />;
+  if (preflightError) return <EmptyState preflightError={preflightError} />;
   if (error) return <ApiErrorState message={error.error} />;
 
   return (

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -9,8 +9,6 @@ import EmptyState from '../../Components/EmptyState';
 import NoResults from '../../Components/NoResults';
 import ApiErrorState from '../../Components/ApiErrorState';
 import Pagination from '../../Components/Pagination';
-import { Paths } from '../../paths';
-import { parse, stringify } from 'query-string';
 
 import {
   preflightRequest,
@@ -42,7 +40,7 @@ const qsConfig = getQSConfig('job-explorer', { ...initialQueryParams }, [
   'offset',
 ]);
 
-const JobExplorer = ({ location: { search }, history }) => {
+const JobExplorer = () => {
   const [preflightError, setPreFlightError] = useState(null);
 
   const {
@@ -71,31 +69,6 @@ const JobExplorer = ({ location: { search }, history }) => {
     { items: [], meta: {} }
   );
 
-  const initialSearchParams = parse(search, {
-    arrayFormat: 'bracket',
-    parseBooleans: true,
-    parseNumbers: true,
-  });
-
-  useEffect(() => {
-    history.replace({
-      pathname: jobExplorer,
-      initialSearchParams,
-    });
-  }, []);
-
-  const updateURL = () => {
-    const { jobExplorer } = Paths;
-    const search = stringify(
-      { ...initialQueryParams, ...initialSearchParams },
-      { arrayFormat: 'bracket' }
-    );
-    history.replace({
-      pathname: jobExplorer,
-      search,
-    });
-  };
-
   useEffect(() => {
     insights.chrome.appNavClick({ id: 'job-explorer', secondaryNav: true });
 
@@ -107,7 +80,6 @@ const JobExplorer = ({ location: { search }, history }) => {
   useEffect(() => {
     fetchOptions();
     fetchEndpoints();
-    updateURL();
   }, [queryParams]);
 
   if (preflightError?.preflightError?.status === 403) {

--- a/src/Containers/JobExplorer/JobExplorer.js
+++ b/src/Containers/JobExplorer/JobExplorer.js
@@ -53,33 +53,22 @@ const JobExplorer = ({ location: { search }, history }) => {
   } = useQueryParams(qsConfig);
 
   const {
-    result: { options },
+    result: options,
     error,
     request: fetchOptions,
   } = useRequest(
-    useCallback(async () => {
-      const response = await readJobExplorerOptions({ params: queryParams });
-      return { options: response };
-    }, [queryParams]),
-    {
-      options: {},
-    }
+    useCallback(() => readJobExplorerOptions(queryParams), [queryParams]),
+    {}
   );
 
   const {
-    result: { data, meta },
+    result: { items: data, meta },
     isLoading: dataIsLoading,
     isSuccess: dataIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
-    useCallback(async () => {
-      const response = await readJobExplorer({ params: queryParams });
-      return {
-        data: response.items,
-        meta: response.meta,
-      };
-    }, [queryParams]),
-    { items: [] }
+    useCallback(() => readJobExplorer(queryParams), [queryParams]),
+    { items: [], meta: {} }
   );
 
   const initialSearchParams = parse(search, {

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -155,7 +155,7 @@ const Notifications = () => {
     async function initializeWithPreflight() {
       setIsLoading(true);
       await preflightRequest().catch((error) => {
-        setPreFlightError({ preflightError: error });
+        setPreFlightError(error);
       });
       fetchEndpoints().then(
         ([

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -127,7 +127,7 @@ const Notifications = () => {
     }
 
     const getData = () => {
-      return readNotifications({ params: queryParams });
+      return readNotifications(queryParams);
     };
 
     const update = () => {
@@ -148,7 +148,7 @@ const Notifications = () => {
     let ignore = false;
     const fetchEndpoints = () => {
       return Promise.all(
-        [readClusters(), readNotifications({ params: queryParams })].map((p) =>
+        [readClusters(), readNotifications(queryParams)].map((p) =>
           p.catch(() => [])
         )
       );

--- a/src/Containers/Notifications/Notifications.js
+++ b/src/Containers/Notifications/Notifications.js
@@ -9,12 +9,10 @@ import NoData from '../../Components/NoData';
 import { preflightRequest, readClusters, readNotifications } from '../../Api/';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
   Card,
@@ -180,104 +178,95 @@ const Notifications = () => {
     return () => (ignore = true);
   }, [queryParams]);
 
-  if (preflightError?.preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
+  if (preflightError) return <EmptyState preflightError={preflightError} />;
 
   return (
     <React.Fragment>
       <PageHeader>
         <PageHeaderTitle title={'Notifications'} />
       </PageHeader>
-      {preflightError && (
+      <>
         <Main>
-          <EmptyState {...preflightError} />
-        </Main>
-      )}
-      {!preflightError && (
-        <>
-          <Main>
-            <Card>
-              <CardTitle>
-                <DropdownGroup>
-                  <FormSelect
-                    name="selectedCluster"
-                    value={selectedCluster}
-                    onChange={(value) => {
-                      setSelectedCluster(value);
-                      setId(value);
-                      setFromPagination(0);
-                    }}
-                    aria-label="Select Cluster"
-                  >
-                    {clusterOptions.map(({ value, label, disabled }, index) => (
+          <Card>
+            <CardTitle>
+              <DropdownGroup>
+                <FormSelect
+                  name="selectedCluster"
+                  value={selectedCluster}
+                  onChange={(value) => {
+                    setSelectedCluster(value);
+                    setId(value);
+                    setFromPagination(0);
+                  }}
+                  aria-label="Select Cluster"
+                >
+                  {clusterOptions.map(({ value, label, disabled }, index) => (
+                    <FormSelectOption
+                      isDisabled={disabled}
+                      key={index}
+                      value={value}
+                      label={label}
+                    />
+                  ))}
+                </FormSelect>
+                <FormSelect
+                  name="selectedNotification"
+                  value={queryParams.severity || ''}
+                  onChange={(value) => {
+                    setSeverity(value);
+                    setFromPagination(0);
+                  }}
+                  aria-label="Select Notification Type"
+                >
+                  {notificationOptions.map(
+                    ({ disabled, value, label }, index) => (
                       <FormSelectOption
                         isDisabled={disabled}
                         key={index}
                         value={value}
                         label={label}
                       />
-                    ))}
-                  </FormSelect>
-                  <FormSelect
-                    name="selectedNotification"
-                    value={queryParams.severity || ''}
-                    onChange={(value) => {
-                      setSeverity(value);
-                      setFromPagination(0);
-                    }}
-                    aria-label="Select Notification Type"
-                  >
-                    {notificationOptions.map(
-                      ({ disabled, value, label }, index) => (
-                        <FormSelectOption
-                          isDisabled={disabled}
-                          key={index}
-                          value={value}
-                          label={label}
-                        />
-                      )
-                    )}
-                  </FormSelect>
-                </DropdownGroup>
-                <Pagination
-                  count={meta?.count}
-                  qsConfig={qsConfig}
-                  params={{
-                    limit: queryParams.limit,
-                    offset: queryParams.offset,
-                  }}
-                  setPagination={setFromPagination}
-                  isCompact
-                />
-              </CardTitle>
-              <CardBody>
-                {isLoading && <LoadingState />}
-                {!isLoading && notificationsData.length <= 0 && <NoData />}
-                {!isLoading && notificationsData.length > 0 && (
-                  <NotificationDrawer>
-                    <NotificationsList
-                      filterBy={queryParams.severity || ''}
-                      options={notificationOptions}
-                      notifications={notificationsData}
-                    />
-                  </NotificationDrawer>
-                )}
-                <Pagination
-                  count={meta?.count}
-                  qsConfig={qsConfig}
-                  params={{
-                    limit: queryParams.limit,
-                    offset: queryParams.offset,
-                  }}
-                  setPagination={setFromPagination}
-                  variant={PaginationVariant.bottom}
-                />
-              </CardBody>
-            </Card>
-          </Main>
-        </>
-      )}
+                    )
+                  )}
+                </FormSelect>
+              </DropdownGroup>
+              <Pagination
+                count={meta?.count}
+                qsConfig={qsConfig}
+                params={{
+                  limit: queryParams.limit,
+                  offset: queryParams.offset,
+                }}
+                setPagination={setFromPagination}
+                isCompact
+              />
+            </CardTitle>
+            <CardBody>
+              {isLoading && <LoadingState />}
+              {!isLoading && notificationsData.length <= 0 && <NoData />}
+              {!isLoading && notificationsData.length > 0 && (
+                <NotificationDrawer>
+                  <NotificationsList
+                    filterBy={queryParams.severity || ''}
+                    options={notificationOptions}
+                    notifications={notificationsData}
+                  />
+                </NotificationDrawer>
+              )}
+              <Pagination
+                count={meta?.count}
+                qsConfig={qsConfig}
+                params={{
+                  limit: queryParams.limit,
+                  offset: queryParams.offset,
+                }}
+                setPagination={setFromPagination}
+                variant={PaginationVariant.bottom}
+              />
+            </CardBody>
+          </Card>
+        </Main>
+      </>
     </React.Fragment>
   );
 };

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -202,17 +202,6 @@ const OrganizationStatistics = ({ history }) => {
     []
   );
 
-  useEffect(() => {
-    setOrgs(activeTabKey);
-  }, [activeTabKey]);
-
-  useEffect(() => {
-    setOrgs();
-    setTasks();
-    setOptions();
-    setJobs();
-  }, [queryParams]);
-
   const jobEventsByOrgParams = {
     ...queryParams,
     attributes: ['host_task_count'],
@@ -256,6 +245,17 @@ const OrganizationStatistics = ({ history }) => {
     });
     setPreflight();
   }, []);
+
+  useEffect(() => {
+    setOrgs(activeTabKey);
+  }, [activeTabKey]);
+
+  useEffect(() => {
+    setOrgs();
+    setTasks();
+    setOptions();
+    setJobs();
+  }, [queryParams]);
 
   if (preflightError?.status === 403) {
     return <NotAuthorized {...notAuthorizedParams} />;

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -19,12 +19,10 @@ import {
 } from '../../Api/';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { notAuthorizedParams } from '../../Utilities/constants';
 
 import {
   Card,
@@ -256,10 +254,6 @@ const OrganizationStatistics = ({ history }) => {
     setOptions();
     setJobs();
   }, [queryParams]);
-
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
 
   const renderContent = () => {
     if (preflightError) return <EmptyState preflightError={preflightError} />;

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -143,35 +143,26 @@ const OrganizationStatistics = ({ history }) => {
   // params from toolbar/searchbar
   const { queryParams, setFromToolbar } = useQueryParams(qsConfig);
 
-  const {
-    error: preflightError,
-    isLoading: preflightIsLoading,
-    isSuccess: preflightIsSuccess,
-    request: setPreflight,
-  } = useRequest(
-    useCallback(async () => {
-      const preflight = await preflightRequest();
-      return { preflight: preflight };
-    }, []),
-    { preflight: {}, preflightError, preflightIsLoading, preflightIsSuccess }
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
   );
 
   const {
-    result: { jobs },
+    result: jobs,
     error: jobsError,
     isLoading: jobsIsLoading,
     isSuccess: jobsIsSuccess,
     request: setJobs,
   } = useRequest(
-    useCallback(async () => {
-      const jobs = await readJobExplorer({ params: jobRunsByOrgParams });
-      return { jobs: jobs };
-    }, [queryParams]),
-    { jobs: [], jobsError, jobsIsLoading, jobsIsSuccess }
+    useCallback(
+      async () => readJobExplorer(jobRunsByOrgParams),
+      [jobRunsByOrgParams]
+    ),
+    []
   );
 
   const {
-    result: { orgs },
+    result: orgs,
     error: orgsError,
     isLoading: orgsIsLoading,
     isSuccess: orgsIsSuccess,
@@ -181,45 +172,34 @@ const OrganizationStatistics = ({ history }) => {
       async (tabIndex = 0) => {
         let orgs;
         if (tabIndex === 0) {
-          orgs = await readJobExplorer({ params: jobsByDateAndOrgParams });
+          orgs = await readJobExplorer(jobsByDateAndOrgParams);
         } else {
-          orgs = await readHostExplorer({ params: hostAcrossOrgParams });
+          orgs = await readHostExplorer(hostAcrossOrgParams);
         }
-        return { orgs: orgs };
+        return orgs;
       },
-      [queryParams]
+      [hostAcrossOrgParams, jobsByDateAndOrgParams]
     ),
-    { orgs: [], orgsError, orgsIsLoading, orgsIsSuccess }
+    []
+  );
+
+  const { result: options, request: setOptions } = useRequest(
+    useCallback(() => readOrgOptions(queryParams), [queryParams]),
+    {}
   );
 
   const {
-    result: { options },
-    error: optionsError,
-    isLoading: optionsIsLoading,
-    isSuccess: optionsIsSuccess,
-    request: setOptions,
-  } = useRequest(
-    useCallback(async () => {
-      const options = await readOrgOptions({ params: queryParams });
-      return { options: options };
-    }, [queryParams]),
-    { options: {}, optionsError, optionsIsLoading, optionsIsSuccess }
-  );
-
-  const {
-    result: { tasks },
+    result: tasks,
     error: tasksError,
     isLoading: tasksIsLoading,
     isSuccess: tasksIsSuccess,
     request: setTasks,
   } = useRequest(
-    useCallback(async () => {
-      const tasks = await readJobExplorer({ params: jobEventsByOrgParams });
-      return {
-        tasks: tasks,
-      };
-    }, [queryParams]),
-    { tasks: [], tasksError, tasksIsLoading, tasksIsSuccess }
+    useCallback(
+      async () => readJobExplorer(jobEventsByOrgParams),
+      [jobEventsByOrgParams]
+    ),
+    []
   );
 
   useEffect(() => {

--- a/src/Containers/SavingsPlanner/Add/index.js
+++ b/src/Containers/SavingsPlanner/Add/index.js
@@ -24,15 +24,8 @@ const Add = () => {
     isSuccess,
     request: fetchPlanOptions,
   } = useRequest(
-    useCallback(async () => {
-      const response = await readPlanOptions();
-      return {
-        data: response,
-      };
-    }, []),
-    {
-      options: {},
-    }
+    useCallback(() => readPlanOptions(), []),
+    {}
   );
 
   useEffect(() => {
@@ -41,8 +34,8 @@ const Add = () => {
 
   const canWrite =
     isSuccess &&
-    (options.data?.meta?.rbac?.perms?.write === true ||
-      options.data?.meta?.rbac?.perms?.all === true);
+    (options.meta?.rbac?.perms?.write === true ||
+      options.meta?.rbac?.perms?.all === true);
   const title = 'Create new plan';
 
   const showAdd = () => (

--- a/src/Containers/SavingsPlanner/Details/Details.js
+++ b/src/Containers/SavingsPlanner/Details/Details.js
@@ -1,21 +1,18 @@
 import React, { useEffect, useCallback } from 'react';
 import { useParams, useLocation, Route, Switch } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
-import { Card } from '@patternfly/react-core';
+import { Card, EmptyState } from '@patternfly/react-core';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 
 import DetailsTab from './DetailsTab';
 import StatisticsTab from './StatisticsTab';
 import SavingsPlanner from '../List';
 import ApiErrorState from '../../../Components/ApiErrorState';
-import { notAuthorizedParams } from '../../../Utilities/constants';
 
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-
-import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 
 import Breadcrumbs from '../../../Components/Breadcrumbs';
 
@@ -98,9 +95,11 @@ const Details = () => {
         { title: plans[0].name, navigate: breadcrumbUrl },
       ]
     : [];
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
+
+  if (preflightError) {
+    return <EmptyState preflightError={preflightError} />;
   }
+
   return (
     <>
       {error && (

--- a/src/Containers/SavingsPlanner/Details/Details.js
+++ b/src/Containers/SavingsPlanner/Details/Details.js
@@ -42,42 +42,41 @@ const Details = () => {
   const queryParams = { id: [selectedId] };
 
   const {
-    result: { options },
+    result: options,
     error,
     isSuccess,
     request: fetchOptions,
   } = useRequest(
     useCallback(async () => {
+      // TODO Move this out of here
       setSelectedId(id);
       await preflightRequest().catch((error) => {
         setPreFlightError({ preflightError: error });
       });
 
-      const response = await readPlanOptions();
-      return { options: response };
+      return readPlanOptions();
     }, []),
-    { options: {} }
+    {}
   );
 
   const {
     result: { rbac, plans },
-    error: plansError,
-    isLoading: plansIsLoading,
     isSuccess: plansIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
     useCallback(async () => {
+      // TODO Move this out of here
       setSelectedId(id);
       await preflightRequest().catch((error) => {
         setPreFlightError({ preflightError: error });
       });
-      const response = await readPlan({ params: queryParams });
+      const response = await readPlan(queryParams);
       return {
         plans: response.items,
         rbac: response.rbac,
       };
     }, []),
-    { plans: [], rbac: [], plansError, plansIsLoading, plansIsSuccess }
+    { plans: [], rbac: [] }
   );
 
   useEffect(() => {

--- a/src/Containers/SavingsPlanner/Details/Details.js
+++ b/src/Containers/SavingsPlanner/Details/Details.js
@@ -46,12 +46,12 @@ const Details = () => {
   } = useRequest(() => readPlanOptions(), {});
 
   const {
-    result: { rbac, items: plans },
-    isSuccess: plansIsSuccess,
+    result: { rbac, plan },
+    isSuccess: planIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
-    useCallback(() => readPlan(queryParams), [id]),
-    { items: [], rbac: [] }
+    useCallback((id) => readPlan(id), []),
+    { plan: {}, rbac: [] }
   );
 
   useEffect(() => {
@@ -60,11 +60,11 @@ const Details = () => {
   }, []);
 
   useEffect(() => {
-    fetchEndpoints();
+    fetchEndpoints(id);
   }, [id]);
 
   const canWrite =
-    plansIsSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
+    planIsSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
 
   const tabsArray = [
     {
@@ -86,10 +86,10 @@ const Details = () => {
   ];
 
   const breadcrumbUrl = `/savings-planner/${id}`;
-  const breadcrumbsItems = plansIsSuccess
+  const breadcrumbsItems = planIsSuccess
     ? [
         { title: 'Savings Planner', navigate: '/savings-planner' },
-        { title: plans[0].name, navigate: breadcrumbUrl },
+        { title: plan.name, navigate: breadcrumbUrl },
       ]
     : [];
 
@@ -104,7 +104,7 @@ const Details = () => {
           <ApiErrorState message={error.error} />
         </>
       )}
-      {plansIsSuccess /* Todo this does not chaeck if plan is actually an array */ && (
+      {planIsSuccess /* Todo this does not chaeck if plan is actually an array */ && (
         <>
           <PageHeader>
             <Breadcrumbs items={breadcrumbsItems} />
@@ -116,14 +116,14 @@ const Details = () => {
                 <Route path="/savings-planner/:id/statistics">
                   <StatisticsTab
                     tabsArray={tabsArray}
-                    data={plans[0]}
+                    data={plan}
                     queryParams={queryParams}
                   />
                 </Route>
                 {!onEdit && (
                   <Route path="/savings-planner/:id/details">
                     <DetailsTab
-                      plans={plans}
+                      plans={[plan]}
                       tabsArray={tabsArray}
                       canWrite={canWrite}
                       options={options}
@@ -131,11 +131,11 @@ const Details = () => {
                   </Route>
                 )}
                 <Route path="/savings-planner/:id/edit">
-                  <SavingsPlanEdit data={plans[0]} />
+                  <SavingsPlanEdit data={plan} />
                 </Route>
                 <Route path="/savings-planner/:id">
                   <DetailsTab
-                    plans={plans}
+                    plans={[plan]}
                     tabsArray={tabsArray}
                     canWrite={canWrite}
                     options={options}

--- a/src/Containers/SavingsPlanner/Details/Details.js
+++ b/src/Containers/SavingsPlanner/Details/Details.js
@@ -23,29 +23,25 @@ import useRequest from '../../../Utilities/useRequest';
 
 const Details = () => {
   const { id } = useParams();
+  const location = useLocation();
+
   const queryParams = { id: [id] };
-
-  const { state: locationState } = useLocation();
-
-  const { error: preflightError, request: setPreflight } = useRequest(
-    useCallback(() => preflightRequest(), [])
-  );
+  const onEdit = !!location.state?.reload;
 
   let pageTitle = 'Details';
-  let onEdit = false;
-  if (locationState?.reload) {
-    onEdit = true;
-  }
   if (location.pathname.indexOf('/statistics') !== -1) {
     pageTitle = 'Statistics';
   } else if (location.pathname.indexOf('/edit') !== -1) {
     pageTitle = 'Edit plan';
   }
 
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
+  );
+
   const {
     result: options,
     error,
-    isSuccess,
     request: fetchOptions,
   } = useRequest(() => readPlanOptions(), {});
 
@@ -54,7 +50,7 @@ const Details = () => {
     isSuccess: plansIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
-    useCallback(() => readPlan(queryParams), [queryParams]),
+    useCallback(() => readPlan(queryParams), [id]),
     { items: [], rbac: [] }
   );
 
@@ -65,10 +61,11 @@ const Details = () => {
 
   useEffect(() => {
     fetchEndpoints();
-  }, [queryParams]);
+  }, [id]);
 
   const canWrite =
-    isSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
+    plansIsSuccess && (rbac.perms?.write === true || rbac.perms?.all === true);
+
   const tabsArray = [
     {
       id: 0,

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
@@ -48,7 +48,7 @@ const Divider = styled(PFDivider)`
   padding-top: 24px;
 `;
 
-const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
+const DetailsTab = ({ tabsArray, plan, canWrite, options }) => {
   const { pathname } = useLocation();
   const history = useHistory();
   const {
@@ -64,7 +64,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
     tasks,
     template_details,
     template_id,
-  } = plans[0];
+  } = plan;
 
   const redirectToJobExplorer = (templateId) => {
     const { jobExplorer } = Paths;
@@ -137,7 +137,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
 
   return (
     <>
-      {plans && (
+      {plan && (
         <>
           <CardBody>
             <RoutedTabs tabsArray={tabsArray} />
@@ -215,7 +215,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
 };
 
 DetailsTab.propTypes = {
-  plans: PropTypes.array,
+  plan: PropTypes.object,
   tabsArray: PropTypes.array,
   canWrite: PropTypes.bool.isRequired,
   options: PropTypes.object.isRequired,

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import styled from 'styled-components';
@@ -22,11 +22,7 @@ import {
   ListItem,
 } from '@patternfly/react-core';
 import CardActionsRow from '../../../../Components/CardActionsRow';
-import {
-  relatedResourceDeleteRequests,
-  getRelatedResourceDeleteCounts,
-} from '../../../../Utilities/getRelatedResourceDeleteDetails';
-import { deletePlan, readPlan } from '../../../../Api/';
+import { deletePlan } from '../../../../Api/';
 import useRequest, {
   useDismissableError,
 } from '../../../../Utilities/useRequest';
@@ -137,31 +133,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
     }, [id, history])
   );
 
-  const {
-    result: isDeleteDisabled,
-    error: deleteDetailsError,
-    request: fetchDeleteDetails,
-  } = useRequest(
-    useCallback(async () => {
-      const { results: deleteDetails, error } =
-        await getRelatedResourceDeleteCounts(
-          relatedResourceDeleteRequests.savingsPlan(plans[0], readPlan)
-        );
-      if (error) {
-        throw new Error(error);
-      }
-
-      return !!deleteDetails;
-    }, [plans]),
-    false
-  );
-
-  useEffect(() => {
-    fetchDeleteDetails();
-  }, [fetchDeleteDetails]);
-  const { error, dismissError } = useDismissableError(
-    deleteError || deleteDetailsError
-  );
+  const { error, dismissError } = useDismissableError(deleteError);
 
   return (
     <>
@@ -220,9 +192,6 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
                   name={name}
                   modalTitle={'Delete Plan'}
                   onConfirm={deletePlans}
-                  disabledTooltip={
-                    isDeleteDisabled && 'This plan cannot be deleted'
-                  }
                 >
                   {'Delete'}
                 </DeleteButton>

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
@@ -138,7 +138,7 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
   );
 
   const {
-    result: { isDeleteDisabled },
+    result: isDeleteDisabled,
     error: deleteDetailsError,
     request: fetchDeleteDetails,
   } = useRequest(
@@ -150,12 +150,10 @@ const DetailsTab = ({ tabsArray, plans, canWrite, options }) => {
       if (error) {
         throw new Error(error);
       }
-      if (deleteDetails) {
-        return { isDeleteDisabled: true };
-      }
-      return { isDeleteDisabled: false };
-    }, [plans[0]]),
-    { isDeleteDisabled: false }
+
+      return !!deleteDetails;
+    }, [plans]),
+    false
   );
 
   useEffect(() => {

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.test.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.test.js
@@ -37,31 +37,28 @@ const tabs = [
   { name: 'Graph', link: '/savings-planner/19/statistics', id: 2 },
 ];
 
-const dummyData = [
-  {
-    id: 1,
-    automation_status: 'successful',
-    category: 'foo',
-    description: 'foo bar',
-    frequency_period: 'monthly',
-    hosts: 20,
-    manual_time: 60,
-    modified: '2020-11-16T10:15:07.223669',
-    name: 'Foo',
-    tasks: [],
-    template_details: { id: 1, name: 'template foo' },
-    template_id: 1,
-  },
-];
+const dummyData = {
+  id: 1,
+  automation_status: { status: 'successful' },
+  category: 'foo',
+  description: 'foo bar',
+  frequency_period: 'monthly',
+  hosts: 20,
+  manual_time: 60,
+  modified: '2020-11-16T10:15:07.223669',
+  name: 'Foo',
+  tasks: [],
+  template_details: { id: 1, name: 'template foo' },
+  template_id: 1,
+};
 
-let wrapper;
 it('should render successfully', () => {
-  wrapper = mount(
+  const wrapper = mount(
     <DetailsTab
       tabsArray={tabs}
-      plans={dummyData}
+      plan={dummyData}
       canWrite={true}
-      options={{ data: {} }}
+      options={{}}
     />
   );
   wrapper.update();

--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/index.test.js
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/index.test.js
@@ -42,7 +42,7 @@ describe('SavingsPlanner/Details/StatisticsTab', () => {
   it('should render successfully', async () => {
     render(
       <MemoryRouter>
-        <StatisticsTab tabsArray={tabs} data={data} />
+        <StatisticsTab tabsArray={tabs} plan={data} />
       </MemoryRouter>
     );
     await waitFor(() => screen.getByText('Money'));

--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
@@ -59,7 +59,7 @@ interface Props {
     link: string;
     name: React.ReactNode;
   }[];
-  data: Data;
+  plan: Data;
 }
 
 const yearLabels: Record<string, string> = {
@@ -101,7 +101,7 @@ const constants = (isMoney: boolean) => ({
   },
 });
 
-const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, data }) => {
+const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, plan }) => {
   const [isMoney, setIsMoney] = useState(true);
 
   const customTooltipFormatting = (datum: Record<string, string>) =>
@@ -249,7 +249,7 @@ const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, data }) => {
       ...functions,
       fetchFnc: () =>
         new Promise((resolve) => {
-          resolve(getChartData(data));
+          resolve(getChartData(plan));
         }),
     },
   };
@@ -273,7 +273,7 @@ const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, data }) => {
             />
           </ToggleGroup>
         </CardActions>
-        <CardTitle>{data.name}</CardTitle>
+        <CardTitle>{plan.name}</CardTitle>
       </CardHeader>
       <CardBody>
         <ChartRenderer
@@ -286,7 +286,7 @@ const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, data }) => {
 
   const renderRight = () => (
     <>
-      <TotalSavings value={computeTotalSavings(data)} isMoney={isMoney} />
+      <TotalSavings value={computeTotalSavings(plan)} isMoney={isMoney} />
       <Card isPlain>
         <CardBody>
           <List isPlain>
@@ -326,7 +326,7 @@ const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, data }) => {
 StatisticsTab.propTypes = {
   /* eslint-disable-next-line */
   /* @ts-ignore: Validation error */
-  data: PropTypes.object.isRequired,
+  plan: PropTypes.object.isRequired,
   tabsArray: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -16,15 +16,8 @@ const Edit = ({ data }) => {
     isSuccess,
     request: fetchPlanOptions,
   } = useRequest(
-    useCallback(async () => {
-      const response = await readPlanOptions();
-      return {
-        data: response,
-      };
-    }, []),
-    {
-      options: {},
-    }
+    useCallback(() => readPlanOptions(), []),
+    {}
   );
 
   useEffect(() => {
@@ -33,8 +26,8 @@ const Edit = ({ data }) => {
 
   const canWrite =
     isSuccess &&
-    (options.data?.meta?.rbac?.perms?.write === true ||
-      options.data?.meta?.rbac?.perms?.all === true);
+    (options?.meta?.rbac?.perms?.write === true ||
+      options?.meta?.rbac?.perms?.all === true);
 
   const showEdit = () => (
     <>

--- a/src/Containers/SavingsPlanner/Edit/index.js
+++ b/src/Containers/SavingsPlanner/Edit/index.js
@@ -29,20 +29,17 @@ const Edit = ({ data }) => {
     (options?.meta?.rbac?.perms?.write === true ||
       options?.meta?.rbac?.perms?.all === true);
 
-  const showEdit = () => (
-    <>
-      <Form title="Edit plan" options={options} data={data} />
-    </>
-  );
+  const renderContent = () => {
+    if (!isSuccess) return null;
 
-  if (isSuccess) {
     return canWrite ? (
-      showEdit()
+      <Form title="Edit plan" options={options} data={data} />
     ) : (
       <Redirect to={`${Paths.savingsPlanner}/${id}`} />
     );
-  }
-  return null;
+  };
+
+  return renderContent();
 };
 
 Edit.propTypes = {

--- a/src/Containers/SavingsPlanner/List/List.js
+++ b/src/Containers/SavingsPlanner/List/List.js
@@ -63,30 +63,29 @@ const List = () => {
   const [preflightError, setPreFlightError] = useState(null);
 
   const {
-    result: { options },
+    result: options,
     error,
     isSuccess,
     request: fetchOptions,
   } = useRequest(
     useCallback(async () => {
+      // TODO Move this out of here
       await preflightRequest().catch((error) => {
         setPreFlightError({ preflightError: error });
       });
-      const response = await readPlanOptions();
-      return { options: response };
+      return readPlanOptions();
     }, [queryParams]),
-    { options: {} }
+    {}
   );
 
   const {
     result: { data, rbac, total_count },
-    error: itemsError,
     isLoading: itemsIsLoading,
     isSuccess: itemsIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
     useCallback(async () => {
-      const response = await readPlans({ params: queryParams });
+      const response = await readPlans(queryParams);
       return {
         data: response.items,
         rbac: response.rbac,
@@ -95,9 +94,8 @@ const List = () => {
     }, [queryParams]),
     {
       data: [],
-      itemsError,
-      itemsIsSuccess,
-      itemsIsLoading,
+      rbac: {},
+      total_count: 0,
     }
   );
 

--- a/src/Containers/SavingsPlanner/List/List.js
+++ b/src/Containers/SavingsPlanner/List/List.js
@@ -6,7 +6,6 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { Button, Gallery, PaginationVariant } from '@patternfly/react-core';
 
 import {
@@ -24,7 +23,6 @@ import Pagination from '../../../Components/Pagination';
 import PlanCard from './ListItem';
 import { useQueryParams } from '../../../Utilities/useQueryParams';
 import { savingsPlanner } from '../../../Utilities/constants';
-import { notAuthorizedParams } from '../../../Utilities/constants';
 
 import ToolbarDeleteButton from '../../../Components/Toolbar/ToolbarDeleteButton';
 import useSelected from '../../../Utilities/useSelected';
@@ -131,10 +129,6 @@ const List = () => {
     setSelected([]);
     fetchEndpoints();
   };
-
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
 
   const renderContent = () => {
     if (preflightError) return <EmptyState preflightError={preflightError} />;

--- a/src/Containers/SavingsPlanner/List/List.js
+++ b/src/Containers/SavingsPlanner/List/List.js
@@ -119,9 +119,13 @@ const List = () => {
     deleteItems: deleteItems,
     clearDeletionError,
   } = useDeleteItems(
-    useCallback(async () => {
-      return Promise.all(selected.map((plan) => deletePlan({ id: plan.id })));
-    }, [selected])
+    useCallback(() =>
+      Promise.all(
+        selected.map((plan) => deletePlan({ id: plan.id })),
+        [selected]
+      )
+    ),
+    {}
   );
 
   const handleDelete = async () => {

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
@@ -25,7 +25,7 @@ const Details = ({ options, formData, dispatch }) => {
 
   return (
     <Form>
-      {options?.data && (
+      {options && (
         <Grid hasGutter md={6}>
           <FormGroup
             label="What do you want to automate?"

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
@@ -75,39 +75,29 @@ const Templates = ({ template_id, dispatch: formDispatch }) => {
   const [preflightError, setPreFlightError] = useState(null);
 
   const {
-    result: { options },
+    result: options,
     error,
     isSuccess,
     request: fetchOptions,
   } = useRequest(
-    useCallback(async () => {
-      const response = await readJobExplorerOptions({ params: queryParams });
-      return { options: response };
-    }, [queryParams]),
-    { options: {} }
+    useCallback(() => readJobExplorerOptions(queryParams), [queryParams]),
+    {}
   );
 
   const {
     result: { templates, count },
-    error: templatesIsError,
     isLoading: templatesIsLoading,
     isSuccess: templatesIsSuccess,
     request: fetchEndpoints,
   } = useRequest(
     useCallback(async () => {
-      const response = await readJobExplorer({ params: queryParams });
+      const response = await readJobExplorer(queryParams);
       return {
         templates: response.items,
         count: response.meta.count,
       };
     }, [queryParams]),
-    {
-      templates: [],
-      count: 0,
-      templatesIsError,
-      templatesIsLoading,
-      templatesIsSuccess,
-    }
+    { templates: [], count: 0 }
   );
 
   const onSort = (_ev, _idx, dir) => {

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
@@ -19,15 +19,12 @@ import {
   Td,
 } from '@patternfly/react-table';
 
-import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
-
 import LoadingState from '../../../../../../Components/LoadingState';
 import EmptyState from '../../../../../../Components/EmptyState';
 import NoResults from '../../../../../../Components/NoResults';
 import ApiErrorState from '../../../../../../Components/ApiErrorState';
 import Pagination from '../../../../../../Components/Pagination';
 
-import { notAuthorizedParams } from '../../../../../../Utilities/constants';
 import { useQueryParams } from '../../../../../../Utilities/useQueryParams';
 import { getQSConfig } from '../../../../../../Utilities/qs';
 
@@ -145,9 +142,6 @@ const Templates = ({ template_id, dispatch: formDispatch }) => {
     fetchEndpoints();
   }, [queryParams]);
 
-  if (preflightError?.status === 403) {
-    return <NotAuthorized {...notAuthorizedParams} />;
-  }
   return (
     <>
       {preflightError && <EmptyState preflightError={preflightError} />}

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { parse, stringify } from 'query-string';
@@ -72,7 +72,9 @@ const Templates = ({ template_id, dispatch: formDispatch }) => {
     dispatch: queryParamsDispatch,
   } = useQueryParams(qsConfig);
 
-  const [preflightError, setPreFlightError] = useState(null);
+  const { error: preflightError, request: setPreflight } = useRequest(
+    useCallback(() => preflightRequest(), [])
+  );
 
   const {
     result: options,
@@ -118,10 +120,7 @@ const Templates = ({ template_id, dispatch: formDispatch }) => {
 
   useEffect(() => {
     insights.chrome.appNavClick({ id: 'savings-planner', secondaryNav: true });
-
-    preflightRequest().catch((error) => {
-      setPreFlightError({ preflightError: error });
-    });
+    setPreflight();
   }, []);
 
   const initialSearchParams = parse(search, {
@@ -146,12 +145,12 @@ const Templates = ({ template_id, dispatch: formDispatch }) => {
     fetchEndpoints();
   }, [queryParams]);
 
-  if (preflightError?.preflightError?.status === 403) {
+  if (preflightError?.status === 403) {
     return <NotAuthorized {...notAuthorizedParams} />;
   }
   return (
     <>
-      {preflightError && <EmptyState {...preflightError} />}
+      {preflightError && <EmptyState preflightError={preflightError} />}
 
       {isSuccess && (
         <Form>

--- a/src/Containers/SavingsPlanner/Shared/Form/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/index.js
@@ -46,7 +46,7 @@ const Form = ({ title, options, data = {} }) => {
         });
       }
 
-      // TODO this is very shitty should be a promise
+      // TODO this should be a promise
       return {};
     }, []),
     data

--- a/src/Containers/SavingsPlanner/Shared/Form/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/index.js
@@ -29,30 +29,27 @@ const Form = ({ title, options, data = {} }) => {
   const [startStep, setStartStep] = useState(null);
 
   const {
-    result: { data: apiResponse },
+    result: apiResponse,
     error,
     request: setData,
   } = useRequest(
-    useCallback(async (requestPayload, id) => {
-      if (typeof requestPayload !== 'undefined') {
-        if (id) {
-          data = await updatePlan({
+    useCallback((requestPayload, id) => {
+      if (requestPayload) {
+        if (id)
+          return updatePlan({
             id: id,
             params: requestPayload,
           });
-        } else {
-          data = await createPlan({
-            params: requestPayload,
-          });
-        }
+
+        return createPlan({
+          params: requestPayload,
+        });
       }
-      return {
-        data,
-      };
+
+      // TODO this is very shitty should be a promise
+      return {};
     }, []),
-    {
-      apiResponse: data,
-    }
+    data
   );
 
   const { formData, requestPayload, dispatch } = usePlanData(data);

--- a/src/Utilities/getRelatedResouceDeleteDetails.test.js
+++ b/src/Utilities/getRelatedResouceDeleteDetails.test.js
@@ -16,10 +16,6 @@ describe('delete details', () => {
     getRelatedResourceDeleteCounts(
       relatedResourceDeleteRequests.savingsPlan({ id: 1 }, plan)
     );
-    expect(plan).toBeCalledWith({
-      params: {
-        id: [1],
-      },
-    });
+    expect(plan).toBeCalledWith(1);
   });
 });

--- a/src/Utilities/getRelatedResourceDeleteDetails.js
+++ b/src/Utilities/getRelatedResourceDeleteDetails.js
@@ -26,9 +26,9 @@ export async function getRelatedResourceDeleteCounts(requests) {
 }
 
 export const relatedResourceDeleteRequests = {
-  savingsPlan: (selected, readRecordApi) => [
+  savingsPlan: (record, readRecordApi) => [
     {
-      request: async () => readRecordApi({ id: [selected.id] }),
+      request: async () => readRecordApi(record.id),
       label: 'Plan',
     },
   ],

--- a/src/Utilities/getRelatedResourceDeleteDetails.js
+++ b/src/Utilities/getRelatedResourceDeleteDetails.js
@@ -28,10 +28,7 @@ export async function getRelatedResourceDeleteCounts(requests) {
 export const relatedResourceDeleteRequests = {
   savingsPlan: (selected, readRecordApi) => [
     {
-      request: async () =>
-        readRecordApi({
-          params: { id: [selected.id] },
-        }),
+      request: async () => readRecordApi({ id: [selected.id] }),
       label: 'Plan',
     },
   ],

--- a/src/__tests__/fixtures/index.js
+++ b/src/__tests__/fixtures/index.js
@@ -6,6 +6,7 @@ import readClusterOptions from './readClusterOptions';
 import readEventExplorer from './readEventExplorer';
 import readJobExplorer from './readJobExplorer';
 import readPlans from './readPlans';
+import readPlan from './readPlan';
 import readPlansOptions from './readPlansOptions';
 import readPlansOptionsRBACFalse from './readPlansOptionsRBACFalse';
 import readTemplateJobExplorer from './readTemplateJobExplorer';
@@ -19,6 +20,7 @@ export default {
   readEventExplorer,
   readJobExplorer,
   readPlans,
+  readPlan,
   readPlansOptions,
   readPlansOptionsRBACFalse,
   readTemplateJobExplorer,

--- a/src/__tests__/fixtures/readPlan.js
+++ b/src/__tests__/fixtures/readPlan.js
@@ -1,0 +1,22 @@
+export default {
+  plan: {
+    automation_status: { status: 'None', last_known_date: '2021-04-15' },
+    last_known_date: '2021-04-15',
+    status: 'None',
+    category: 'cloud',
+    cloud: null,
+    description: null,
+    frequency_per_period: 4,
+    frequency_period: 'monthly',
+    hosts: 50,
+    hourly_rate: 60,
+    id: 7,
+    manual_time: 60,
+    modified: '2021-04-15T12:55:08.115889',
+    name: 'Manage Azure Resource Groups',
+    platform: null,
+    tasks: [],
+    template_details: {},
+    template_id: null,
+  },
+};


### PR DESCRIPTION
* Make the `readApi` params into a simple object instead of nesting, it makes TS much easier in the future
* Fixed the job explorer bookmarking (it was using duplicate bookmarking which worked weird)
* Unified the useRequest usage, removed unnecessary wrapping where was not needed.
* Corrected the default variables passed to the useRequest
* Unified the `preflight` usage
* Added the `Not authorized` to the `EmptyState` (which is handling all possible preflight errors, probably we should rename)
* **Fixed** the infinite rbac call on the details page