### PR TITLE
Fix: don't show NoData while loading the ROI calculator

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -98,6 +98,7 @@ const AutomationCalculator = ({ history }) => {
     result: api,
     error: apiError,
     isLoading: apiIsLoading,
+    isSuccess: apiIsSuccess,
     request: fetchEndpoint,
     setValue,
   } = useRequest(
@@ -173,19 +174,12 @@ const AutomationCalculator = ({ history }) => {
         <Card>
           <BorderedCardTitle>Automation savings</BorderedCardTitle>
           <CardBody>
-            {apiIsLoading && <LoadingState />}
-            {apiError && <ApiErrorState message={apiError.error} />}
-            {api.length <= 0 && <NoData />}
-            {api.length > 0 && (
-              <React.Fragment>
-                <TopTemplatesSavings
-                  margin={{ top: 20, right: 20, bottom: 20, left: 70 }}
-                  id="d3-roi-chart-root"
-                  data={filterDisabled(api)}
-                />
-                <p style={{ textAlign: 'center' }}>Templates</p>
-              </React.Fragment>
-            )}
+            <TopTemplatesSavings
+              margin={{ top: 20, right: 20, bottom: 20, left: 70 }}
+              id="d3-roi-chart-root"
+              data={filterDisabled(api)}
+            />
+            <p style={{ textAlign: 'center' }}>Templates</p>
           </CardBody>
         </Card>
       </StackItem>
@@ -227,14 +221,18 @@ const AutomationCalculator = ({ history }) => {
 
   const renderContents = () => {
     if (preflightError) return <EmptyState preflightError={preflightError} />;
-    else if (api)
+    if (apiIsLoading) return <LoadingState />;
+    if (apiError) return <ApiErrorState message={apiError.error} />;
+    if (apiIsSuccess && api.length <= 0) return <NoData />;
+    if (apiIsSuccess && api.length > 0)
       return (
         <Grid hasGutter className="automation-wrapper">
           <GridItem span={9}>{renderLeft()}</GridItem>
           <GridItem span={3}>{renderRight()}</GridItem>
         </Grid>
       );
-    else return <></>;
+
+    return null;
   };
 
   return (


### PR DESCRIPTION
Cannot make screenshots while it is a loading screen. 

**Before**: When api was loading or errored out the `No Data` screen was still showing.
**After**: The `No Data` is showed only when the request to API is successful and there is really no data returned from the API