### PR TITLE
Added granularity to the report charts

### DIFF
--- a/src/Components/Toolbar/Groups/QuickDateGroup.tsx
+++ b/src/Components/Toolbar/Groups/QuickDateGroup.tsx
@@ -4,6 +4,7 @@ import {
   ToolbarGroup,
   Split,
   SelectOptionProps,
+  ToolbarGroupVariant,
 } from '@patternfly/react-core';
 
 import ToolbarInput from './ToolbarInput';
@@ -22,7 +23,10 @@ const strToDate = (date: string): Date => {
 interface Props {
   filters: Record<string, AttributeType>;
   setFilters: SetValues;
-  values: SelectOptionProps[];
+  values: {
+    quick_date_range: SelectOptionProps[];
+    granularity: SelectOptionProps[];
+  };
 }
 
 const QuickDateGroup: FunctionComponent<Props> = ({
@@ -34,11 +38,19 @@ const QuickDateGroup: FunctionComponent<Props> = ({
   const startDate = (filters.start_date as string) || getDateByDays(-30);
 
   return (
-    <ToolbarGroup variant="filter-group">
+    <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+      {values.granularity && (
+        <ToolbarInput
+          categoryKey="granularity"
+          value={filters.granularity}
+          selectOptions={values.granularity}
+          setValue={(value) => setFilters('granularity', value)}
+        />
+      )}
       <ToolbarInput
         categoryKey="quick_date_range"
         value={filters.quick_date_range}
-        selectOptions={values}
+        selectOptions={values.quick_date_range}
         setValue={(value) => setFilters('quick_date_range', value)}
       />
       {filters.quick_date_range === 'custom' && (

--- a/src/Components/Toolbar/Toolbar.tsx
+++ b/src/Components/Toolbar/Toolbar.tsx
@@ -45,7 +45,8 @@ const FilterableToolbar: FunctionComponent<Props> = ({
   additionalControls = [],
 }) => {
   const [settingsExpanded, setSettingsExpanded] = useState(false);
-  const { quick_date_range, sort_options, ...restCategories } = categories;
+  const { quick_date_range, sort_options, granularity, ...restCategories } =
+    categories;
   const history = useHistory();
 
   // Filter out elements which are not in the option object.
@@ -83,10 +84,10 @@ const FilterableToolbar: FunctionComponent<Props> = ({
             setFilters={setFilters}
           />
         )}
-        {quick_date_range && (
+        {(quick_date_range || granularity) && (
           <QuickDateGroup
             filters={filters}
-            values={quick_date_range}
+            values={{ quick_date_range, granularity }}
             setFilters={setFilters}
           />
         )}

--- a/src/Components/Toolbar/constants.ts
+++ b/src/Components/Toolbar/constants.ts
@@ -89,4 +89,9 @@ export const optionsForCategories: OptionsForCategories = {
     name: 'Search by name',
     hasChips: true,
   },
+  granularity: {
+    type: 'select',
+    name: 'Granularity',
+    hasChips: false,
+  },
 };

--- a/src/Containers/Reports/Details/Report.tsx
+++ b/src/Containers/Reports/Details/Report.tsx
@@ -66,6 +66,13 @@ const Tr = styled(PFTr)`
 
 const customFunctions = (data: ApiReturnType) => ({
   ...functions,
+  axisFormat: {
+    ...functions.axisFormat,
+    formatAsYear: (tick: string) =>
+      Intl.DateTimeFormat('en', { year: 'numeric' }).format(new Date(tick)),
+    formatAsMonth: (tick: string) =>
+      Intl.DateTimeFormat('en', { month: 'long' }).format(new Date(tick)),
+  },
   fetchFnc: () =>
     new Promise<ApiReturnType>((resolve) => {
       resolve(data);
@@ -102,6 +109,12 @@ const getOthersStyle = (item: Record<string, string | number>, key: string) => {
     };
   }
   return {};
+};
+
+const getDateFormatByGranularity = (granularity: string): string => {
+  if (granularity === 'yearly') return 'formatAsYear';
+  if (granularity === 'monthly') return 'formatAsMonth';
+  if (granularity === 'daily') return 'formatDateAsDayMonth';
 };
 
 const renderData = (dataApi, chartSchema, attrPairs, getSorParams) => {
@@ -177,7 +190,8 @@ const Report: FunctionComponent<ReportGeneratorParams> = ({
   const chartSchema = schemaFnc(
     attrPairs.find(({ key }) => key === queryParams.sort_options)?.value ||
       'Label Y',
-    queryParams.sort_options as string
+    queryParams.sort_options as string,
+    getDateFormatByGranularity(queryParams.granularity)
   );
 
   useEffect(() => {

--- a/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
+++ b/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
@@ -6,7 +6,6 @@ import {
   ChartTopLevelType,
   ChartType,
   ChartThemeColor,
-  ChartTooltipType,
 } from 'react-json-chart-builder';
 import { readHostExplorer, readHostExplorerOptions } from '../../../../Api';
 import { CATEGORIES } from '../constants';

--- a/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
+++ b/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
@@ -25,6 +25,7 @@ const defaultParams = {
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
+  quick_date_range: 'last_6_months',
   sort_options: 'total_unique_host_count',
   sort_order: 'desc',
   cluster_id: [],

--- a/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
+++ b/src/Containers/Reports/Shared/schemas/affected_hosts_by_playbook.ts
@@ -41,7 +41,11 @@ const extraAttributes: AttributesType = [
   { key: 'name', value: 'Template name' },
 ];
 
-const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
+const schemaFnc = (
+  label: string,
+  y: string,
+  xTickFormat: string
+): ChartSchemaElement[] => [
   {
     id: 1,
     kind: ChartKind.wrapper,
@@ -60,7 +64,7 @@ const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
     },
     xAxis: {
       label: 'Date',
-      tickFormat: 'formatDateAsDayMonth',
+      tickFormat: xTickFormat,
     },
     yAxis: {
       tickFormat: 'formatNumberAsK',

--- a/src/Containers/Reports/Shared/schemas/changes_made.ts
+++ b/src/Containers/Reports/Shared/schemas/changes_made.ts
@@ -46,7 +46,11 @@ const extraAttributes: AttributesType = [
   { key: 'name', value: 'Template name' },
 ];
 
-const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
+const schemaFnc = (
+  label: string,
+  y: string,
+  xTickFormat: string
+): ChartSchemaElement[] => [
   {
     id: 1,
     kind: ChartKind.wrapper,
@@ -65,7 +69,7 @@ const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
     },
     xAxis: {
       label: 'Date',
-      tickFormat: 'formatDateAsDayMonth',
+      tickFormat: xTickFormat,
     },
     yAxis: {
       tickFormat: 'formatNumberAsK',

--- a/src/Containers/Reports/Shared/schemas/changes_made.ts
+++ b/src/Containers/Reports/Shared/schemas/changes_made.ts
@@ -30,6 +30,7 @@ const defaultParams = {
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
+  quick_date_range: 'last_6_months',
   sort_options: 'changed_host_count',
   sort_order: 'desc',
   cluster_id: [],

--- a/src/Containers/Reports/Shared/schemas/playbook_run_rate.ts
+++ b/src/Containers/Reports/Shared/schemas/playbook_run_rate.ts
@@ -45,7 +45,11 @@ const extraAttributes: AttributesType = [
   { key: 'name', value: 'Template name' },
 ];
 
-const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
+const schemaFnc = (
+  label: string,
+  y: string,
+  xTickFormat: string
+): ChartSchemaElement[] => [
   {
     id: 1,
     kind: ChartKind.wrapper,
@@ -64,7 +68,7 @@ const schemaFnc = (label: string, y: string): ChartSchemaElement[] => [
     },
     xAxis: {
       label: 'Date',
-      tickFormat: 'formatDateAsDayMonth',
+      tickFormat: xTickFormat,
     },
     yAxis: {
       tickFormat: 'formatNumberAsK',

--- a/src/Containers/Reports/Shared/schemas/playbook_run_rate.ts
+++ b/src/Containers/Reports/Shared/schemas/playbook_run_rate.ts
@@ -29,6 +29,7 @@ const defaultParams: Params = {
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
+  quick_date_range: 'last_6_months',
   sort_options: 'total_count',
   sort_order: 'desc',
   cluster_id: [],

--- a/src/Containers/Reports/Shared/types.ts
+++ b/src/Containers/Reports/Shared/types.ts
@@ -2,7 +2,11 @@ import { ChartSchemaElement } from 'react-json-chart-builder';
 import { ApiJson, Params, ParamsWithPagination } from '../../../Api';
 
 export type AttributesType = { key: string; value: string }[];
-export type SchemaFnc = (label: string, y: string) => ChartSchemaElement[];
+export type SchemaFnc = (
+  label: string,
+  y: string,
+  xTickFormat: string
+) => ChartSchemaElement[];
 
 export interface ReportGeneratorParams {
   defaultParams: Params;

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -87,7 +87,7 @@ export const useQueryParams = (initial) => {
         return { ...state, ...value };
       case 'SET_QUICK_DATE_RANGE':
         return value !== 'custom'
-          ? { ...state, start_date: null, end_date: null }
+          ? { ...state, ...value, start_date: null, end_date: null }
           : { ...state, ...value };
       case 'SET_START_DATE':
       case 'SET_END_DATE': {

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -43,6 +43,7 @@ export const useQueryParams = (initial) => {
         return isNaN(value)
           ? { ...state, offset: 0 } // Defaults back to 0
           : { ...state, offset: parseInt(value) };
+      case 'SET_GRANULARITY':
       case 'SET_ATTRIBUTES':
       case 'SET_JOB_TYPE':
       case 'SET_STATUS':
@@ -107,6 +108,7 @@ export const useQueryParams = (initial) => {
     name: 'SET_NAME',
     only_root_workflows_and_standalone_jobs: 'SET_ROOT_WORKFLOWS_AND_JOBS',
     inventory_id: 'SET_INVENTORY',
+    granularity: 'SET_GRANULARITY',
   };
 
   return {

--- a/src/Utilities/useQueryParams.js
+++ b/src/Utilities/useQueryParams.js
@@ -44,6 +44,32 @@ export const useQueryParams = (initial) => {
           ? { ...state, offset: 0 } // Defaults back to 0
           : { ...state, offset: parseInt(value) };
       case 'SET_GRANULARITY':
+        switch (value.granularity) {
+          case 'daily':
+            return {
+              ...state,
+              ...value,
+              quick_date_range: 'last_30_days',
+            };
+          case 'monthly':
+            return {
+              ...state,
+              ...value,
+              quick_date_range: 'last_6_months',
+            };
+          case 'yearly':
+            return {
+              ...state,
+              ...value,
+              quick_date_range: 'last_6_years',
+            };
+          default:
+            return {
+              ...state,
+              granularity: 'daily',
+              quick_date_range: 'last_30_days',
+            };
+        }
       case 'SET_ATTRIBUTES':
       case 'SET_JOB_TYPE':
       case 'SET_STATUS':
@@ -59,16 +85,10 @@ export const useQueryParams = (initial) => {
       case 'SET_SORT_OPTIONS':
       case 'SET_SORT_ORDER':
         return { ...state, ...value };
-      case 'SET_QUICK_DATE_RANGE': {
-        let newState = { ...state };
-        if (value !== 'custom') {
-          newState = { ...newState, start_date: null, end_date: null };
-        }
-
-        newState = { ...newState, ...value };
-        return newState;
-      }
-
+      case 'SET_QUICK_DATE_RANGE':
+        return value !== 'custom'
+          ? { ...state, start_date: null, end_date: null }
+          : { ...state, ...value };
       case 'SET_START_DATE':
       case 'SET_END_DATE': {
         let newValues = {};


### PR DESCRIPTION
### Problems:
* Chart x axis labels are not too helpful when setting to year (showing 01/01 for all ticks)
  * possible solutions: display full date always or change the date depending on the granularity (hard mode)
* Quick date range from API does not change with the granularity which is then weird
* Granularity could go next to the date selector instead to the category drop down. Waiting for the #555 PR to be merged, so we don't cause accidental bugs.

(Done) TODO: 
- Granularity to the left of the date selector
- Change the chart axis depending on the granularity