### PR TITLE
Update Savings Planner to handle new API outputs

### DIFF
--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
@@ -73,7 +73,6 @@ interface OldData {
 }
 
 const dataConversion = (data: any): Data => {
-  console.log(data);
   if ('series_stats' in data.projections) {
     return data;
   }

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.js
@@ -64,7 +64,7 @@ const Details = ({ options, formData, dispatch }) => {
               }}
               selections={category}
             >
-              {(options.data?.category || []).map(({ key, value }) => (
+              {(options?.category || []).map(({ key, value }) => (
                 <SelectOption key={key} value={key}>
                   {value}
                 </SelectOption>
@@ -109,7 +109,7 @@ const Details = ({ options, formData, dispatch }) => {
               }}
               selections={manual_time}
             >
-              {(options.data?.manual_time || []).map(({ key, value }) => (
+              {(options?.manual_time || []).map(({ key, value }) => (
                 <SelectOption key={key} value={key}>
                   {value}
                 </SelectOption>
@@ -174,7 +174,7 @@ const Details = ({ options, formData, dispatch }) => {
               }}
               selections={frequency_period}
             >
-              {(options.data?.frequency_period || []).map(({ key, value }) => (
+              {(options?.frequency_period || []).map(({ key, value }) => (
                 <SelectOption key={key} value={key}>
                   {value}
                 </SelectOption>

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.test.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Details/index.test.js
@@ -15,85 +15,83 @@ describe('SavingsPlanner/Shared/Form/Steps/Details', () => {
     template_id: -2,
   };
   const mockOptions = {
-    data: {
-      template_id: [
-        {
-          key: -2,
-          value: 'None',
-        },
-        {
-          key: 1,
-          value: 'template_name_2',
-        },
-      ],
-      automation_status: [
-        {
-          key: 'none',
-          value: 'None',
-        },
-        {
-          key: 'successful',
-          value: 'Successful',
-        },
-        {
-          key: 'failed',
-          value: 'Failed',
-        },
-      ],
-      category: [
-        {
-          key: 'system',
-          value: 'System',
-        },
-        {
-          key: 'development',
-          value: 'Development',
-        },
-      ],
-      platforms: [
-        {
-          key: 'el',
-          value: 'EL',
-        },
-        {
-          key: 'ubuntu',
-          value: 'Ubuntu',
-        },
-      ],
-      frequency_period: [
-        {
-          key: 'daily',
-          value: 'Daily',
-        },
-        {
-          key: 'weekly',
-          value: 'Weekly',
-        },
-      ],
-      manual_time: [
-        {
-          key: 60,
-          value: '1 hour (or less)',
-        },
-        {
-          key: 120,
-          value: '2 hours',
-        },
-      ],
-      sort_options: [
-        {
-          key: 'name',
-          value: 'Name',
-        },
-        {
-          key: 'hosts',
-          value: 'No. of hosts',
-        },
-      ],
-      meta: {
-        rbac: {
-          enabled: false,
-        },
+    template_id: [
+      {
+        key: -2,
+        value: 'None',
+      },
+      {
+        key: 1,
+        value: 'template_name_2',
+      },
+    ],
+    automation_status: [
+      {
+        key: 'none',
+        value: 'None',
+      },
+      {
+        key: 'successful',
+        value: 'Successful',
+      },
+      {
+        key: 'failed',
+        value: 'Failed',
+      },
+    ],
+    category: [
+      {
+        key: 'system',
+        value: 'System',
+      },
+      {
+        key: 'development',
+        value: 'Development',
+      },
+    ],
+    platforms: [
+      {
+        key: 'el',
+        value: 'EL',
+      },
+      {
+        key: 'ubuntu',
+        value: 'Ubuntu',
+      },
+    ],
+    frequency_period: [
+      {
+        key: 'daily',
+        value: 'Daily',
+      },
+      {
+        key: 'weekly',
+        value: 'Weekly',
+      },
+    ],
+    manual_time: [
+      {
+        key: 60,
+        value: '1 hour (or less)',
+      },
+      {
+        key: 120,
+        value: '2 hours',
+      },
+    ],
+    sort_options: [
+      {
+        key: 'name',
+        value: 'Name',
+      },
+      {
+        key: 'hosts',
+        value: 'No. of hosts',
+      },
+    ],
+    meta: {
+      rbac: {
+        enabled: false,
       },
     },
   };

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.js
@@ -50,6 +50,13 @@ const initialQueryParams = {
   offset: 0,
   sort_options: 'name',
   sort_order: 'asc',
+
+  cluster_id: [],
+  inventory_id: [],
+  job_type: [],
+  org_id: [],
+  status: [],
+  template_id: [],
 };
 const qsConfig = getQSConfig('job-explorer', { ...initialQueryParams }, [
   'limit',


### PR DESCRIPTION
Old Savings Planner looked for `options.data.{property_here}` but the new output is instead `options.{property_here}`. Also updated default params for Template Selection stage of Savings Planner.