### PR TITLE
AA-145 - Store Query Parameters in url

### DIFF
--- a/cypress/integration/AutomationCalculator.spec.js
+++ b/cypress/integration/AutomationCalculator.spec.js
@@ -37,4 +37,10 @@ describe('Automation Caluclator page smoketests', () => {
       expect(location.pathname).to.include(jobExplorerUrl);
     });
   });
+  it('Query parameters are stored in the URL to enable refresh', () => {
+    // Add more once fixtures are implemented - other filters are content-dependent.
+    cy.get('[data-cy="quick_date_range"]').click();
+    cy.contains('Past 2 years').click();
+    cy.url().should('include', 'quick_date_range=roi_last_2_years');
+  });
 });

--- a/cypress/integration/Dashboard.spec.js
+++ b/cypress/integration/Dashboard.spec.js
@@ -80,6 +80,13 @@ describe('Dashboard page smoketests', () => {
     );
   });
 
+  it('Query parameters are stored in the URL to enable refresh', () => {
+    // Add more once fixtures are implemented - other filters are content-dependent.
+    cy.get('[data-cy="quick_date_range"]').click();
+    cy.contains('Past 2 weeks').click();
+    cy.url().should('include', 'quick_date_range=last_2_weeks');
+  });
+
   // it('Can filter by organization', () => {
   //     cy.get(toolBarCatSelector).first().contains('Filter by').click();
   //     cy.get('button[class="pf-c-select__menu-item"]').contains('Organization').click();

--- a/cypress/integration/JobExplorer.spec.js
+++ b/cypress/integration/JobExplorer.spec.js
@@ -1,0 +1,17 @@
+import { jobExplorerUrl } from '../support/constants';
+
+const appid = Cypress.env('appid');
+
+describe('Job Explorer page smoketests', () => {
+  beforeEach(() => {
+    cy.loginFlow();
+    cy.visit(jobExplorerUrl);
+  });
+
+  it('Query parameters are stored in the URL to enable refresh', () => {
+    // Add more once fixtures are implemented - other filters are content-dependent.
+    cy.get('[data-cy="quick_date_range"]').click();
+    cy.contains('Past 2 weeks').click();
+    cy.url().should('include', 'quick_date_range=last_2_weeks');
+  });
+});

--- a/cypress/integration/OrganizationStatistics.spec.js
+++ b/cypress/integration/OrganizationStatistics.spec.js
@@ -62,6 +62,13 @@ describe('Organization statistics page smoketests', () => {
     cy.visit(orgsUrl);
   });
 
+  it('Query parameters are stored in the URL to enable refresh', () => {
+    // Add more once fixtures are implemented - other filters are content-dependent.
+    cy.get('[data-cy="quick_date_range"]').click();
+    cy.contains('Past 2 weeks').click();
+    cy.url().should('include', 'quick_date_range=last_2_weeks');
+  });
+
   it('can interact with the org stats page without breaking the UI', () => {
     fuzzOrgStatsPage();
   });

--- a/cypress/integration/SavingsPlanner.spec.js
+++ b/cypress/integration/SavingsPlanner.spec.js
@@ -1,0 +1,19 @@
+import { savingsPlannerUrl } from '../support/constants';
+
+const appid = Cypress.env('appid');
+
+describe('Savings Planner page smoketests', () => {
+  beforeEach(() => {
+    cy.loginFlow();
+    cy.intercept('**/plans/*').as('getPlans')
+    cy.visit(savingsPlannerUrl);
+    cy.wait('@getPlans');
+  });
+  it('Query parameters are stored in the URL to enable refresh', () => {
+    // Add more once fixtures are implemented - other filters are content-dependent.
+    cy.get('[data-cy="sort_options"]').click();
+    cy.contains('Manual Time').click();
+    cy.url().should('include', 'savings-planner.sort_options=manual_time');
+  });
+});
+


### PR DESCRIPTION
This PR adds some basic tests for query parameter storage in the URL. There is one outstanding issue at the moment, which is whether or not jobtype should be retained there since it currently is not.