### PR TITLE
Fix: the default params were never in the URL, now they are always

### DIFF
--- a/src/Utilities/qs.js
+++ b/src/Utilities/qs.js
@@ -134,9 +134,8 @@ export const encodeNonDefaultQueryString = (
   nonNamespacedParams = {}
 ) => {
   if (!params) return '';
-  const paramsWithoutDefaults = removeParams({}, params, config.defaultParams);
   return encodeQueryString({
-    ...namespaceParams(config.namespace, paramsWithoutDefaults),
+    ...namespaceParams(config.namespace, params),
     ...nonNamespacedParams,
   });
 };

--- a/src/Utilities/qs.test.js
+++ b/src/Utilities/qs.test.js
@@ -58,8 +58,14 @@ describe('qs (qs.js)', () => {
       [
         [null, ''],
         [{}, ''],
-        [{ order_by: 'name', offset: 1, limit: 5 }, ''],
-        [{ order_by: '-name', offset: 1, limit: 5 }, 'order_by=-name'],
+        [
+          { order_by: 'name', offset: 1, limit: 5 },
+          'limit=5&offset=1&order_by=name',
+        ],
+        [
+          { order_by: '-name', offset: 1, limit: 5 },
+          'limit=5&offset=1&order_by=-name',
+        ],
         [
           { order_by: '-name', offset: 3, limit: 10 },
           'limit=10&offset=3&order_by=-name',
@@ -91,7 +97,9 @@ describe('qs (qs.js)', () => {
         offset: 1,
         foo: 'bar',
       };
-      expect(encodeNonDefaultQueryString(conf, params)).toEqual('item.foo=bar');
+      expect(encodeNonDefaultQueryString(conf, params)).toEqual(
+        'item.foo=bar&item.offset=1'
+      );
     });
 
     test('should handle array values', () => {
@@ -105,7 +113,7 @@ describe('qs (qs.js)', () => {
         },
       };
       expect(encodeNonDefaultQueryString(conf, vals)).toEqual(
-        'bar=alpha&bar=beta'
+        'bar=alpha&bar=beta&foo=one&foo=two'
       );
     });
   });


### PR DESCRIPTION
Fixes: AA-667
In addition it fixes also AA-678

**Before:**
- The default params never got into the url, even if only a subset was selected. This prevented bookmarking combinations which were using the default params, but weren't the same. 
- Error when changing pagination in the console

**After:**
- Default params still not added to the url, as long as the filter is not changed. After any change the params will be saved into the URL
- No errors when changing pagination