### PR TITLE
[Waiting for PR-570] Add slugs to reports in url instead of IDs

### DIFF
--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -253,12 +253,12 @@ const OrganizationStatistics = ({ history }) => {
       actionLinks={
         <>
           <AlertActionLink>
-            <Link to={reportPaths.getDetails(4)}>
+            <Link to={reportPaths.getDetails('hosts_by_organization')}>
               Host by organization report
             </Link>
           </AlertActionLink>
           <AlertActionLink>
-            <Link to={reportPaths.getDetails(5)}>
+            <Link to={reportPaths.getDetails('jobs_and_tasks_by_organization')}>
               Jobs/Tasks by organization report
             </Link>
           </AlertActionLink>

--- a/src/Containers/Reports/Details/Details.tsx
+++ b/src/Containers/Reports/Details/Details.tsx
@@ -21,8 +21,8 @@ const Description = styled.p`
 `;
 
 const Details: FunctionComponent<Record<string, never>> = () => {
-  const { id } = useParams<{ id: string }>();
-  const { name, description, report } = getReport(+id);
+  const { slug } = useParams<{ slug: string }>();
+  const { name, description, report } = getReport(slug);
 
   const breadcrumbsItems = [{ title: 'Reports', navigate: paths.get }];
 

--- a/src/Containers/Reports/List/List.js
+++ b/src/Containers/Reports/List/List.js
@@ -38,7 +38,7 @@ const List = () => {
           }}
         >
           {reports.map((report) => (
-            <ListItem key={report.id} report={report} />
+            <ListItem key={report.slug} report={report} />
           ))}
         </Gallery>
       </FlexMain>

--- a/src/Containers/Reports/List/ListItem/index.js
+++ b/src/Containers/Reports/List/ListItem/index.js
@@ -30,12 +30,12 @@ const Label = styled(PFLabel)`
   margin-right: 10px;
 `;
 
-const ListItem = ({ report: { id, description, name, categories } }) => (
+const ListItem = ({ report: { slug, description, name, categories } }) => (
   <Card>
     <CardHeader>
       <CardHeaderMain>
         <CardTitle>
-          <Link to={paths.getDetails(id)}>{name}</Link>
+          <Link to={paths.getDetails(slug)}>{name}</Link>
         </CardTitle>
       </CardHeaderMain>
     </CardHeader>

--- a/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
+++ b/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
@@ -11,6 +11,8 @@ import { readHostExplorer, readHostExplorerOptions } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
+const slug = 'hosts_changed_by_job_template';
+
 const name = 'Hosts changed by job template';
 
 const description =
@@ -111,6 +113,7 @@ const schemaFnc = (
 ];
 
 const reportParams: ReportPageParams = {
+  slug,
   name,
   description,
   categories,

--- a/src/Containers/Reports/Shared/schemas/changesMade.ts
+++ b/src/Containers/Reports/Shared/schemas/changesMade.ts
@@ -11,6 +11,8 @@ import { readJobExplorer, readJobExplorerOptions } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
+const slug = 'changes_made_by_job_template';
+
 const name = 'Changes made by job template';
 
 const description =
@@ -116,6 +118,7 @@ const schemaFnc = (
 ];
 
 const reportParams: ReportPageParams = {
+  slug,
   name,
   description,
   categories,

--- a/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
+++ b/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
@@ -11,6 +11,8 @@ import { readHostExplorer, readHostExplorerOptions } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
+const slug = 'hosts_by_organization';
+
 const name = 'Hosts by Organization';
 
 const description =
@@ -111,6 +113,7 @@ const schemaFnc = (
 ];
 
 const reportParams: ReportPageParams = {
+  slug,
   name,
   description,
   categories,

--- a/src/Containers/Reports/Shared/schemas/index.ts
+++ b/src/Containers/Reports/Shared/schemas/index.ts
@@ -11,15 +11,16 @@ const reports = [
   playbookRunRate,
   hostsByOrganization,
   jobsTasksByOrganization,
-].map((report, id) => ({ id: id + 1, ...report }));
+];
 
 const defaultReport: ReportPageParams = {
+  slug: 'unknown',
   name: 'Unknown',
   description: 'Unknown',
   categories: [] as string[],
 };
 
-export const getReport = (searchId: number): ReportPageParams =>
-  reports.find(({ id }) => id === searchId) ?? defaultReport;
+export const getReport = (searchSlug: string): ReportPageParams =>
+  reports.find(({ slug }) => slug === searchSlug) ?? defaultReport;
 
 export default reports;

--- a/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
@@ -11,6 +11,8 @@ import { readJobExplorer, readJobExplorerOptions } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
+const slug = 'jobs_and_tasks_by_organization';
+
 const name = 'Jobs/Tasks by Organization';
 
 const description =
@@ -111,6 +113,7 @@ const schemaFnc = (
 ];
 
 const reportParams: ReportPageParams = {
+  slug,
   name,
   description,
   categories,

--- a/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
+++ b/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
@@ -15,6 +15,8 @@ import {
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
+const slug = 'job_template_run_rate';
+
 const name = 'Job template run rate';
 
 const description =
@@ -115,6 +117,7 @@ const schemaFnc = (
 ];
 
 const reportParams: ReportPageParams = {
+  slug,
   name,
   description,
   categories,

--- a/src/Containers/Reports/Shared/types.ts
+++ b/src/Containers/Reports/Shared/types.ts
@@ -17,6 +17,7 @@ export interface ReportGeneratorParams {
 }
 
 export interface ReportPageParams {
+  slug: string;
   name: string;
   description: string;
   categories: string[];

--- a/src/Containers/Reports/index.tsx
+++ b/src/Containers/Reports/index.tsx
@@ -7,8 +7,8 @@ import List from './List';
 
 export const paths = {
   get: `${Paths.reports}`,
-  details: `${Paths.reports}/:id`,
-  getDetails: (id: number): string => `${Paths.reports}/${id}`,
+  details: `${Paths.reports}/:slug`,
+  getDetails: (slug: string): string => `${Paths.reports}/${slug}`,
 };
 
 const ReportsRouter: FunctionComponent<Record<string, never>> = () => {


### PR DESCRIPTION
**Before**:
- Opening a report put a number into the url:
- for example: `.../reports/4`

**After**:
- Reports have unique slugs for displaying in the URL
- example: `.../reports/hosts_by_organization`