### PR TITLE
Make tooltip into popover in the settings toolbar for Job Explorer page

### DIFF
--- a/src/Components/Toolbar/Groups/SettingsPanel.tsx
+++ b/src/Components/Toolbar/Groups/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Button, Tooltip, Switch } from '@patternfly/react-core';
+import { Button, Switch, Popover } from '@patternfly/react-core';
 import {
   Card,
   CardTitle,
@@ -7,8 +7,20 @@ import {
   CardActions,
   CardHeader,
 } from '@patternfly/react-core';
-import { QuestionCircleIcon, TimesIcon } from '@patternfly/react-icons';
+import {
+  OutlinedQuestionCircleIcon as PFOutlinedQuestionCircleIcon,
+  TimesIcon,
+} from '@patternfly/react-icons';
 import { SetValues, AttributeType } from '../types';
+import styled from 'styled-components';
+
+const OutlinedQuestionCircleIcon = styled(PFOutlinedQuestionCircleIcon)`
+  color: #151515;
+`;
+
+const PopoverButton = styled(Button)`
+  vertical-align: middle;
+`;
 
 interface Props {
   filters: Record<string, AttributeType>;
@@ -46,18 +58,21 @@ const SettingsPanel: FunctionComponent<Props> = ({
           setFilters('only_root_workflows_and_standalone_jobs', value)
         }
       />
-      <Tooltip
-        position={'top'}
-        content={
-          <div>
-            {' '}
-            If enabled, nested workflows and jobs will not be included in the
-            overall totals. Enable this option to filter out duplicate entries.
-          </div>
-        }
-      >
-        <QuestionCircleIcon />
-      </Tooltip>
+      <PopoverButton variant="plain">
+        <Popover
+          aria-label="ignore nested workflow popover"
+          position={'top'}
+          bodyContent={
+            <div>
+              If enabled, nested workflows and jobs will not be included in the
+              overall totals. Enable this option to filter out duplicate
+              entries.
+            </div>
+          }
+        >
+          <OutlinedQuestionCircleIcon />
+        </Popover>
+      </PopoverButton>
     </CardBody>
   </Card>
 );


### PR DESCRIPTION
Changed the tooltip to a popover in the settings toolbar on the Job Explorer page.

Before:
![image](https://user-images.githubusercontent.com/89094075/131919359-f9cd074e-c920-421e-b168-2891ccdcecb0.png)

After:
![Screen Shot 2021-09-02 at 5 34 00 PM](https://user-images.githubusercontent.com/89094075/131919287-a588947a-89e4-4bf4-8480-1bd224a59a35.png)