### PR TITLE
404 page for root urls

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,4 @@
 import App from './App.js';
-import { Router } from 'react-router-dom';
 import { mountPage } from './__tests__/helpers';
 import packageJson from '../package.json';
 
@@ -9,28 +8,7 @@ describe('App', () => {
   });
 
   it('should return a div with a version attribute', () => {
-    const history = {
-      listen() {
-        return { unlisten() {} };
-      },
-      replace() {},
-      push() {},
-      length: 1,
-      action: 'PUSH',
-      location: {
-        pathname: '/somewhere',
-        search: '',
-        hash: '#howdy',
-      },
-    };
-
-    const Component = () => (
-      <Router history={history}>
-        <App />
-      </Router>
-    );
-
-    const wrapper = mountPage(Component);
+    const wrapper = mountPage(App);
 
     let componentVersion = wrapper
       .find('#automation-analytics-application')

--- a/src/Components/Error404.tsx
+++ b/src/Components/Error404.tsx
@@ -19,8 +19,8 @@ interface Props {
 }
 
 const Error404: FunctionComponent<Props> = ({
-  title = "404: We've lost it.",
-  body = "Let's find you a new one.Try a new search or return home.",
+  title = '404: Page does not exist.',
+  body = "Let's find you a new one.",
   buttonText = 'Return to home page',
   link = Paths.clusters,
 }) => (

--- a/src/Components/Error404.tsx
+++ b/src/Components/Error404.tsx
@@ -7,7 +7,7 @@ import {
   EmptyStateBody,
   TitleSizes,
 } from '@patternfly/react-core';
-import { PathMissingIcon } from '@patternfly/react-icons';
+import PathMissingIcon from '@patternfly/react-icons/dist/js/icons/pathMissing-icon';
 import { Paths } from '../paths';
 import { Link } from 'react-router-dom';
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import asyncComponent from './Utilities/asyncComponent';
 import { Paths } from './paths';
+import Error404 from './Components/Error404';
 
 const components = {
   clusters: asyncComponent(() => import('./Containers/Clusters/Clusters')),
@@ -59,9 +60,9 @@ export const Routes = () => {
           rootClass={key}
         />
       ))}
-      {/* Finally, catch all unmatched routes and redirect to Clusters page */}
+      {/* Finally, catch all unmatched routes and render 404 */}
       <Route>
-        <Redirect to={Paths.clusters} />
+        <Error404 body="Sorry, we could not find what you were looking for. The page you requested may have been changed or moved." />
       </Route>
     </Switch>
   );


### PR DESCRIPTION
> Currently we are redirecting to the clusters page if a top level link is not found in our routes. We should display the 404 page instead as this will be confusing to users especially if we remove a page (for example the orgs page)

![Screenshot from 2021-09-08 16-56-33](https://user-images.githubusercontent.com/8531681/132533824-89a0c515-fec8-41ba-828b-3e56d73a7d2b.png)
