### PR TITLE
Extended condition to also check if value is not 0

### DIFF
--- a/src/Utilities/qs.js
+++ b/src/Utilities/qs.js
@@ -216,7 +216,7 @@ export function mergeParams(oldParams, newParams) {
 }
 
 function mergeParam(oldVal, newVal) {
-  if (!newVal && newVal !== '') {
+  if (!newVal && newVal !== '' && newVal !== 0) {
     return oldVal;
   }
   if (!oldVal && oldVal !== '') {


### PR DESCRIPTION
`if (!newVal && newVal !== '')` was evaluating as true when offset value was 0 in the querystring and in return was setting offset value to 'undefined' causing pagination to show NaN on the screen.

before
![Screen Shot 2021-09-09 at 10 17 29 AM](https://user-images.githubusercontent.com/3450808/132711499-389cd942-b415-4c26-a257-8df1cc807e3b.png)


after
![Screen Shot 2021-09-09 at 10 59 58 AM](https://user-images.githubusercontent.com/3450808/132711523-d1e24a92-8615-4bd7-9f78-51a37ad28504.png)

This issue only happened when offset value was 0 in url