### PR TITLE
Make Filterable Toolbar Responsive

### DIFF
--- a/src/Components/Toolbar/Toolbar.tsx
+++ b/src/Components/Toolbar/Toolbar.tsx
@@ -7,6 +7,7 @@ import {
   ToolbarItem,
   ToolbarItemVariant,
   ButtonVariant,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon, CogIcon } from '@patternfly/react-icons';
 
@@ -69,47 +70,54 @@ const FilterableToolbar: FunctionComponent<Props> = ({
 
   return (
     <Toolbar
+      className="pf-m-toggle-group-container"
       id={`${qsConfig.namespace}-filterable-toolbar-with-chip-groups`}
       clearAllFilters={() => setFilters(undefined, undefined)}
       collapseListedFiltersBreakpoint="xl"
     >
       <ToolbarContent>
-        <Button variant={ButtonVariant.control}>
-          <FilterIcon />
-        </Button>
-        {Object.keys(filterCategories).length > 0 && (
-          <FilterCategoriesGroup
-            filterCategories={filterCategories}
-            filters={filters}
-            setFilters={setFilters}
-          />
-        )}
-        {(quick_date_range || granularity) && (
-          <QuickDateGroup
-            filters={filters}
-            values={{ quick_date_range, granularity }}
-            setFilters={setFilters}
-          />
-        )}
-        {sort_options && (
-          <SortByGroup
-            filters={filters}
-            setFilters={setFilters}
-            sort_options={sort_options}
-          />
-        )}
-        {hasSettings && (
-          <ToolbarItem>
-            <Button
-              variant={ButtonVariant.plain}
-              onClick={() => setSettingsExpanded(!settingsExpanded)}
-              aria-label="settings"
-              isActive={settingsExpanded}
-            >
-              <CogIcon />
+        <ToolbarToggleGroup
+          toggleIcon={
+            <Button variant={ButtonVariant.control}>
+              <FilterIcon />
             </Button>
-          </ToolbarItem>
-        )}
+          }
+          breakpoint="xl"
+        >
+          {Object.keys(filterCategories).length > 0 && (
+            <FilterCategoriesGroup
+              filterCategories={filterCategories}
+              filters={filters}
+              setFilters={setFilters}
+            />
+          )}
+          {(quick_date_range || granularity) && (
+            <QuickDateGroup
+              filters={filters}
+              values={{ quick_date_range, granularity }}
+              setFilters={setFilters}
+            />
+          )}
+          {sort_options && (
+            <SortByGroup
+              filters={filters}
+              setFilters={setFilters}
+              sort_options={sort_options}
+            />
+          )}
+          {hasSettings && (
+            <ToolbarItem>
+              <Button
+                variant={ButtonVariant.plain}
+                onClick={() => setSettingsExpanded(!settingsExpanded)}
+                aria-label="settings"
+                isActive={settingsExpanded}
+              >
+                <CogIcon />
+              </Button>
+            </ToolbarItem>
+          )}
+        </ToolbarToggleGroup>
         {additionalControls.length > 0 && (
           <ToolbarGroup>
             {additionalControls.map((control, idx) => (


### PR DESCRIPTION
Made the filterable toolbar responsive. The filter icon now only appears when window is minimized to a specific width (previously, it served no function). 

Before:
![Screen Shot 2021-09-15 at 2 35 45 PM](https://user-images.githubusercontent.com/89094075/133490458-6851c4d2-c45a-4c7d-a64c-9f6907c66dea.png)

After:
![Screen Shot 2021-09-15 at 2 36 00 PM](https://user-images.githubusercontent.com/89094075/133490522-b28f6faf-9fc0-43fd-975c-d36d1424ad80.png)

After (when filter icon is clicked):
![Screen Shot 2021-09-15 at 2 36 13 PM](https://user-images.githubusercontent.com/89094075/133490580-fd1316dc-cc97-4aff-b086-fdaba1ffb40a.png)
