### PR TITLE
Fixes typo in deprecation warning on Organization Statistics page

### DIFF
--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -251,7 +251,7 @@ const OrganizationStatistics = ({ history }) => {
   const renderDeprecationWarning = () => (
     <Alert
       variant={AlertVariant.warning}
-      title="The Organization statistic page will be deprecated in the future release."
+      title="The Organization statistics page will be deprecated in the future release."
       actionLinks={
         <>
           <AlertActionLink>


### PR DESCRIPTION
Before:
![Screen Shot 2021-09-16 at 11 05 29 AM](https://user-images.githubusercontent.com/89094075/133640556-de00d2d3-9bb7-46fd-9424-10f762a1d3d1.png)

After:
![Screen Shot 2021-09-16 at 11 25 33 AM](https://user-images.githubusercontent.com/89094075/133640594-be461e72-68f9-4ad1-a210-b2a31345aad5.png)
