### PR TITLE
Fix date selector

### DIFF
--- a/src/Components/Toolbar/Groups/QuickDateGroup.tsx
+++ b/src/Components/Toolbar/Groups/QuickDateGroup.tsx
@@ -53,7 +53,9 @@ const QuickDateGroup: FunctionComponent<Props> = ({
         selectOptions={values.quick_date_range}
         setValue={(value) => setFilters('quick_date_range', value)}
       />
-      {filters.quick_date_range === 'custom' && (
+      {['custom', 'roi_custom'].includes(
+        filters.quick_date_range as string
+      ) && (
         <Split hasGutter>
           <SplitItem>
             <ToolbarInput


### PR DESCRIPTION
The date selectors were not displaying when "Custom" was selected in Automation Calculator.

Before: 
![image](https://user-images.githubusercontent.com/89094075/134563182-9c8ad381-c069-405a-8a8a-fd7ddfc3b801.png)

After:
![Screen Shot 2021-09-23 at 2 16 31 PM](https://user-images.githubusercontent.com/89094075/134565911-dad95160-eb9b-4254-b5d6-cdbe45d7fe17.png)