### PR TITLE
Fixed to display the error message

### DIFF
--- a/src/Containers/SavingsPlanner/Shared/Form/index.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/index.js
@@ -200,7 +200,7 @@ const Form = ({ title, options, data = {} }) => {
           variant="error"
         >
           {'There was an error saving the plan.'}
-          <ErrorDetail error={error.detail} />
+          <ErrorDetail error={error?.error?.detail.name} />
         </AlertModal>
       )}
     </>


### PR DESCRIPTION
- Display an error message when trying to save a Savings Plan with the name that exists.

https://issues.redhat.com/browse/AA-607

before
<img width="1013" alt="Screen Shot 2021-09-24 at 5 05 23 PM" src="https://user-images.githubusercontent.com/3450808/134739627-97eeff64-095e-4817-965b-3bcf2f0cc72e.png">


after
<img width="1119" alt="Screen Shot 2021-09-24 at 5 02 00 PM" src="https://user-images.githubusercontent.com/3450808/134739556-61b03edd-f87e-48c8-980a-96dcbcfe27c6.png">


