### PR TITLE
Fixed tooltip activation space

### DIFF
--- a/src/Components/Toolbar/DownloadPdfButton.js
+++ b/src/Components/Toolbar/DownloadPdfButton.js
@@ -30,23 +30,21 @@ const DownloadPdfButton = ({ slug, data, y, label, xTickFormat }) => {
   const getPdfButtonText = (error) => error || 'Download PDF version of report';
 
   return (
-    <>
-      <Tooltip
-        position={TooltipPosition.top}
-        content={<div>{getPdfButtonText(error)}</div>}
+    <Tooltip
+      position={TooltipPosition.top}
+      content={<div>{getPdfButtonText(error)}</div>}
+    >
+      <Button
+        variant={error ? ButtonVariant.link : ButtonVariant.plain}
+        aria-label={getPdfButtonText(error)}
+        onClick={() => request(data)}
+        isDanger={error}
       >
-        <Button
-          variant={error ? ButtonVariant.link : ButtonVariant.plain}
-          aria-label={getPdfButtonText(error)}
-          onClick={() => request(data)}
-          isDanger={error}
-        >
-          {isLoading && <Spinner isSVG size="md" />}
-          {error && <ExclamationCircleIcon />}
-          {!isLoading && !error && <DownloadIcon />}
-        </Button>
-      </Tooltip>
-    </>
+        {isLoading && <Spinner isSVG size="md" />}
+        {error && <ExclamationCircleIcon />}
+        {!isLoading && !error && <DownloadIcon />}
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/src/Components/Toolbar/DownloadPdfButton.js
+++ b/src/Components/Toolbar/DownloadPdfButton.js
@@ -30,21 +30,23 @@ const DownloadPdfButton = ({ slug, data, y, label, xTickFormat }) => {
   const getPdfButtonText = (error) => error || 'Download PDF version of report';
 
   return (
-    <Button
-      variant={error ? ButtonVariant.link : ButtonVariant.plain}
-      aria-label={getPdfButtonText(error)}
-      onClick={() => request(data)}
-      isDanger={error}
-    >
+    <>
       <Tooltip
         position={TooltipPosition.top}
         content={<div>{getPdfButtonText(error)}</div>}
       >
-        {isLoading && <Spinner isSVG size="md" />}
-        {error && <ExclamationCircleIcon />}
-        {!isLoading && !error && <DownloadIcon />}
+        <Button
+          variant={error ? ButtonVariant.link : ButtonVariant.plain}
+          aria-label={getPdfButtonText(error)}
+          onClick={() => request(data)}
+          isDanger={error}
+        >
+          {isLoading && <Spinner isSVG size="md" />}
+          {error && <ExclamationCircleIcon />}
+          {!isLoading && !error && <DownloadIcon />}
+        </Button>
       </Tooltip>
-    </Button>
+    </>
   );
 };
 


### PR DESCRIPTION
Fixed the small activation space on the download PDF button.

Before (only activated tooltip in the middle of the icon):
![before activation space](https://user-images.githubusercontent.com/89094075/135880958-b7bd25ad-59ae-41c4-a701-2d6c6c1cca2f.jpg)

After (now activates in the entire button area):
![activation space](https://user-images.githubusercontent.com/89094075/135881028-daf3d870-7915-41ec-802d-fcd4ddafc62c.jpg)


