### PR TITLE
[Example] Added basic unrolled table

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -7,6 +7,9 @@ export type OptionsReturnType = Record<
   string,
   { key: string; value: string }[]
 >;
+
+export type TempApiErrorType = { error: string; [key: string]: string } | null;
+
 export type ApiJson = Record<string, unknown> | OptionsReturnType;
 
 export interface ParamsWithPagination {

--- a/src/Components/ApiStatus/ApiStatusWrapper.tsx
+++ b/src/Components/ApiStatus/ApiStatusWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { TempApiErrorType } from '../../Api';
 import ApiErrorState from './ApiErrorState';
 import LoadingState from './LoadingState';
 import NoData from './NoData';
@@ -6,7 +7,7 @@ import NoData from './NoData';
 interface Props {
   api: {
     result: unknown;
-    error: { error: string; [key: string]: string } | null;
+    error: TempApiErrorType;
     isSuccess: boolean;
     isLoading: boolean;
   };

--- a/src/Containers/Reports/Details/Components/ReportCard.tsx
+++ b/src/Containers/Reports/Details/Components/ReportCard.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import React, { FunctionComponent, useCallback, useEffect } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import styled from 'styled-components';
 
 import {
@@ -66,7 +66,7 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
     useQueryParams(defaultParams);
 
   const { request: setData, ...dataApi } = useRequest(
-    useCallback(() => readData(queryParams), [queryParams]),
+    () => readData(queryParams),
     { meta: { count: 0, legend: [] } }
   );
 

--- a/src/Containers/Reports/Details/Components/UnrolledTableCard.tsx
+++ b/src/Containers/Reports/Details/Components/UnrolledTableCard.tsx
@@ -1,0 +1,117 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+import { Table } from './';
+import {
+  ApiJson,
+  OptionsReturnType,
+  Params,
+  ParamsWithPagination,
+} from '../../../../Api';
+import useRequest from '../../../../Utilities/useRequest';
+import { AttributesType } from '../../Shared/types';
+import { LegendEntry } from './types';
+import ApiStatusWrapper from '../../../../Components/ApiStatus/ApiStatusWrapper';
+import { useQueryParams } from '../../../../QueryParams';
+
+// TODO: To the types file and sync up with the repport types
+interface Props {
+  defaultParams: Params;
+  defaultTableHeaders: AttributesType;
+  tableAttributes?: string[];
+  readData: (options: ParamsWithPagination) => Promise<ApiJson>;
+  readOptions: (options: Params) => Promise<ApiJson>;
+}
+
+interface ApiReturnType {
+  meta: {
+    count: number;
+    legend: LegendEntry[];
+  };
+  links: {
+    next: string | null;
+  };
+}
+
+const UnrolledTableCard: FunctionComponent<Props> = ({
+  defaultParams,
+  defaultTableHeaders,
+  tableAttributes,
+  readData,
+  readOptions,
+}) => {
+  const { queryParams } = useQueryParams(defaultParams) as {
+    queryParams: Params;
+  };
+
+  const { request: setData, ...dataApi } = useRequest(
+    (params) =>
+      readData(
+        params as ParamsWithPagination
+      ) as unknown as Promise<ApiReturnType>,
+    { meta: { count: 0, legend: [] }, links: { next: null } }
+  );
+
+  const { result: options, request: setOptions } =
+    useRequest<OptionsReturnType>(
+      () => readOptions(queryParams) as Promise<OptionsReturnType>,
+      { sort_options: [] }
+    );
+
+  const [legend, setLegend] = useState<LegendEntry[]>([]);
+
+  const getNextPage = () =>
+    setData({
+      ...queryParams,
+      limit: '25',
+      offset: `${legend.length}`,
+    });
+
+  useEffect(() => {
+    setOptions();
+  }, []);
+
+  useEffect(() => {
+    setLegend([]);
+    getNextPage();
+  }, [queryParams]);
+
+  useEffect(() => {
+    setLegend([
+      ...legend,
+      ...dataApi.result.meta.legend.filter((item) => +item.id !== -1),
+    ]);
+  }, [dataApi.result]);
+
+  useEffect(() => {
+    if (legend.length < 100 && dataApi.result.links.next) {
+      getNextPage();
+    }
+  }, [legend]);
+
+  const tableHeaders = [
+    ...defaultTableHeaders,
+    ...(tableAttributes
+      ? options.sort_options.filter(({ key }) => tableAttributes.includes(key))
+      : options.sort_options),
+  ];
+
+  const sortedBy = options.sort_options.find(
+    ({ key }) => key === queryParams.sort_options
+  )?.value;
+
+  const pagination = legend.length < 100 ? 'all data' : 'first 4 pages';
+
+  return (
+    <Card>
+      <CardTitle>
+        Top {legend.length} results ({pagination}, sorted by {sortedBy})
+      </CardTitle>
+      <CardBody>
+        <Table legend={legend} headers={tableHeaders} />
+        <ApiStatusWrapper api={dataApi}> </ApiStatusWrapper>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default UnrolledTableCard;

--- a/src/Containers/Reports/Details/Details.tsx
+++ b/src/Containers/Reports/Details/Details.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Main from '@redhat-cloud-services/frontend-components/Main';
@@ -14,6 +14,13 @@ import Breadcrumbs from '../../../Components/Breadcrumbs';
 import { ReportCard } from './Components/';
 import { getReport } from '../Shared/schemas';
 import paths from '../paths';
+import UnrolledTableCard from './Components/UnrolledTableCard';
+import {
+  Button,
+  ButtonVariant,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 
 const Description = styled.p`
   max-width: 70em;
@@ -23,6 +30,7 @@ const Description = styled.p`
 const Details: FunctionComponent<Record<string, never>> = () => {
   const { slug } = useParams<{ slug: string }>();
   const { name, description, report } = getReport(slug);
+  const [unrolledVisible, setUnrolledVisible] = useState(false);
 
   const breadcrumbsItems = [{ title: 'Reports', navigate: paths.get }];
 
@@ -36,7 +44,31 @@ const Details: FunctionComponent<Record<string, never>> = () => {
             <Description>{description}</Description>
           </PageHeader>
           <Main>
-            <ReportCard {...report} />
+            <Stack hasGutter>
+              <StackItem>
+                <ReportCard {...report} />
+              </StackItem>
+              <StackItem>
+                {/* TODO Own component */}
+                <Button
+                  variant={ButtonVariant.link}
+                  onClick={() => setUnrolledVisible(!unrolledVisible)}
+                >
+                  {unrolledVisible ? 'Hide' : 'Show'} the top 100 rows
+                </Button>
+              </StackItem>
+              {unrolledVisible && (
+                <StackItem>
+                  <UnrolledTableCard
+                    defaultParams={report.defaultParams}
+                    defaultTableHeaders={report.defaultTableHeaders}
+                    tableAttributes={report.tableAttributes}
+                    readData={report.readData}
+                    readOptions={report.readOptions}
+                  />
+                </StackItem>
+              )}
+            </Stack>
           </Main>
         </>
       );

--- a/src/Utilities/useRequest.ts
+++ b/src/Utilities/useRequest.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback } from 'react';
+import { TempApiErrorType } from '../Api';
 import useIsMounted from './useIsMounted';
 
-type ErrorType = unknown; // TODO: When the error format is evident, use that instead of `unknown`
+type ErrorType = TempApiErrorType; // TODO: When the error format is evident, use that instead of `unknown`
 
 /*
  * The useRequest hook accepts a request function and returns an object with
@@ -24,12 +25,12 @@ interface UseRequestVariables<T> {
 }
 
 interface UseRequestReturn<T> extends UseRequestVariables<T> {
-  request: () => void;
+  request: (...args: unknown[]) => void;
   setValue: (value: T) => void;
 }
 
 export const useRequest = <T>(
-  makeRequest: () => Promise<T>,
+  makeRequest: (...args: unknown[]) => Promise<T>,
   initialValue: T
 ): UseRequestReturn<T> => {
   const [variables, setVariables] = useState<UseRequestVariables<T>>({
@@ -64,7 +65,7 @@ export const useRequest = <T>(
             setVariables({
               isSuccess: false,
               isLoading: false,
-              error,
+              error: error as ErrorType,
               result: initialValue,
             });
           }


### PR DESCRIPTION
* Loads the first 4 pages (max 100 elements) on open
* On queryParam change reloads the data rather than closing
* In the header has some info about sorting and how much data is there
* Pagination of the first card has no effect on the unrolled card (always showing the first 4 pages with limit 25)
* Not super polish, just a rough draft how could it work
* Has a handy dandy loading component for every request so the user can see when the data is loaded/reloaded request by request

![Screenshot from 2021-10-08 11-45-49](https://user-images.githubusercontent.com/8531681/136535332-b7af00b9-5302-4a14-9160-899cfbbb67c8.png)
