### PR TITLE
AA-802 passing params to fastapi to generate data for PDF

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -3,14 +3,6 @@ export type Params = Record<
   string | number | string[] | number[] | boolean
 >;
 
-export interface PDFParams {
-  slug: string;
-  data: Record<string, unknown>;
-  y: string;
-  label: string;
-  x_tick_format: string;
-}
-
 export type OptionsReturnType = Record<
   string,
   { key: string; value: string }[]
@@ -23,6 +15,15 @@ export interface ParamsWithPagination {
   sort_options?: string;
   sort_order?: 'asc' | 'desc';
   [x: string]: string | number | string[] | number[] | boolean | undefined;
+}
+
+export interface PDFParams {
+  slug: string;
+  endpointUrl: string;
+  queryParams: Params;
+  y: string;
+  label: string;
+  x_tick_format: string;
 }
 
 export type ReadParams = { params: Params };

--- a/src/Components/Toolbar/DownloadPdfButton.js
+++ b/src/Components/Toolbar/DownloadPdfButton.js
@@ -14,14 +14,22 @@ import { generatePdf } from '../../Api';
 import AlertModal from '../AlertModal';
 import ErrorDetail from '../ErrorDetail';
 
-const DownloadPdfButton = ({ slug, data, y, label, xTickFormat }) => {
+const DownloadPdfButton = ({
+  slug,
+  endpointUrl,
+  queryParams,
+  y,
+  label,
+  xTickFormat,
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { error, isLoading, request } = useRequest(
-    (data) =>
+    () =>
       generatePdf({
         slug,
-        data,
+        endpointUrl,
+        queryParams,
         y,
         label,
         x_tick_format: xTickFormat,
@@ -46,7 +54,7 @@ const DownloadPdfButton = ({ slug, data, y, label, xTickFormat }) => {
         <Button
           variant={error ? ButtonVariant.link : ButtonVariant.plain}
           aria-label={getPdfButtonText}
-          onClick={() => request(data)}
+          onClick={() => request()}
           isDanger={!!error}
         >
           {isLoading && <Spinner isSVG size="md" />}
@@ -69,7 +77,8 @@ const DownloadPdfButton = ({ slug, data, y, label, xTickFormat }) => {
 
 DownloadPdfButton.propTypes = {
   slug: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired,
+  endpointUrl: PropTypes.string.isRequired,
+  queryParams: PropTypes.object.isRequired,
   y: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   xTickFormat: PropTypes.string.isRequired,

--- a/src/Containers/Reports/Details/Components/ReportCard.tsx
+++ b/src/Containers/Reports/Details/Components/ReportCard.tsx
@@ -63,6 +63,7 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
   tableAttributes,
   expandedAttributes,
   availableChartTypes,
+  dataEndpointUrl,
   readData,
   readOptions,
   schemaFnc,
@@ -158,7 +159,8 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
       <DownloadPdfButton
         key="download-button"
         slug={slug}
-        data={dataApi.result}
+        endpointUrl={dataEndpointUrl}
+        queryParams={queryParams}
         y={chartParams.y}
         label={chartParams.label}
         xTickFormat={chartParams.xTickFormat}

--- a/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
+++ b/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readHostExplorer, readHostExplorerOptions } from '../../../../Api';
+import {
+  hostExplorerEndpoint,
+  readHostExplorer,
+  readHostExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -147,6 +151,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: hostExplorerEndpoint,
     readData: readHostExplorer,
     readOptions: readHostExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/changesMade.ts
+++ b/src/Containers/Reports/Shared/schemas/changesMade.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readJobExplorer, readJobExplorerOptions } from '../../../../Api';
+import {
+  jobExplorerEndpoint,
+  readJobExplorer,
+  readJobExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -149,6 +153,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: jobExplorerEndpoint,
     readData: readJobExplorer,
     readOptions: readJobExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
+++ b/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readHostExplorer, readHostExplorerOptions } from '../../../../Api';
+import {
+  hostExplorerEndpoint,
+  readHostExplorer,
+  readHostExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -147,6 +151,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: hostExplorerEndpoint,
     readData: readHostExplorer,
     readOptions: readHostExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readJobExplorer, readJobExplorerOptions } from '../../../../Api';
+import {
+  jobExplorerEndpoint,
+  readJobExplorer,
+  readJobExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -144,6 +148,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: jobExplorerEndpoint,
     readData: readJobExplorer,
     readOptions: readJobExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/moduleUsageByJobTemplate.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsageByJobTemplate.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readEventExplorer, readEventExplorerOptions } from '../../../../Api';
+import {
+  eventExplorerEndpoint,
+  readEventExplorer,
+  readEventExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -150,6 +154,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: eventExplorerEndpoint,
     readData: readEventExplorer,
     readOptions: readEventExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/moduleUsageByTask.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsageByTask.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readEventExplorer, readEventExplorerOptions } from '../../../../Api';
+import {
+  eventExplorerEndpoint,
+  readEventExplorer,
+  readEventExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -150,6 +154,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: eventExplorerEndpoint,
     readData: readEventExplorer,
     readOptions: readEventExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/moduleUsagebyOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsagebyOrganization.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readEventExplorer, readEventExplorerOptions } from '../../../../Api';
+import {
+  eventExplorerEndpoint,
+  readEventExplorer,
+  readEventExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -150,6 +154,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: eventExplorerEndpoint,
     readData: readEventExplorer,
     readOptions: readEventExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/mostUsedModules.ts
+++ b/src/Containers/Reports/Shared/schemas/mostUsedModules.ts
@@ -7,7 +7,11 @@ import {
   ChartType,
   ChartThemeColor,
 } from 'react-json-chart-builder';
-import { readEventExplorer, readEventExplorerOptions } from '../../../../Api';
+import {
+  eventExplorerEndpoint,
+  readEventExplorer,
+  readEventExplorerOptions,
+} from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
 
@@ -148,6 +152,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: eventExplorerEndpoint,
     readData: readEventExplorer,
     readOptions: readEventExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
+++ b/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
@@ -11,6 +11,7 @@ import {
   readJobExplorer,
   readJobExplorerOptions,
   Params,
+  jobExplorerEndpoint,
 } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
@@ -148,6 +149,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: jobExplorerEndpoint,
     readData: readJobExplorer,
     readOptions: readJobExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
+++ b/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
@@ -9,6 +9,7 @@ import {
   readJobExplorer,
   readJobExplorerOptions,
   Params,
+  jobExplorerEndpoint,
 } from '../../../../Api';
 import { CATEGORIES } from '../constants';
 import { AttributesType, ReportPageParams } from '../types';
@@ -161,6 +162,7 @@ const reportParams: ReportPageParams = {
     tableAttributes,
     expandedAttributes,
     availableChartTypes,
+    dataEndpointUrl: jobExplorerEndpoint,
     readData: readJobExplorer,
     readOptions: readJobExplorerOptions,
     schemaFnc,

--- a/src/Containers/Reports/Shared/types.ts
+++ b/src/Containers/Reports/Shared/types.ts
@@ -16,6 +16,7 @@ export interface ReportGeneratorParams {
   tableAttributes: string[];
   expandedAttributes: string[];
   availableChartTypes: string[];
+  dataEndpointUrl: string;
   readData: (options: ParamsWithPagination) => Promise<ApiJson>;
   readOptions: (options: Params) => Promise<ApiJson>;
   schemaFnc: SchemaFnc;


### PR DESCRIPTION
Passing qsparams and other params to pdf generation & fastapi endpoint which queries data directly, rather than passing the data itself

goes with:
https://gitlab.cee.redhat.com/automation-analytics/automation-analytics-backend/-/merge_requests/268
https://gitlab.cee.redhat.com/automation-analytics/pdf-generator/-/merge_requests/15