### PR TITLE
AA-752 Removed extra space above failed task bars

### DIFF
--- a/src/Containers/Reports/Details/Components/Table/TableExpandedRow.tsx
+++ b/src/Containers/Reports/Details/Components/Table/TableExpandedRow.tsx
@@ -103,7 +103,7 @@ const TableExpandedRow: FunctionComponent<Props> = ({ isExpanded, item }) => {
             <strong>Most failed tasks</strong>
           </p>
           <br />
-          <Grid>
+          <Grid hasGutter>
             {failed_tasks
               .slice(0, failed_tasks.length)
               .map((task: any, idx: number) => {


### PR DESCRIPTION
Removed the additional space above the most failed task bars

Jira Issue: https://issues.redhat.com/browse/AA-752 

Before: 
![Screen Shot 2021-10-26 at 4 40 36 PM](https://user-images.githubusercontent.com/89094075/138957560-7c34afd9-7d3f-4d2e-8385-3bf2a77a6d72.png)

After:
![Screen Shot 2021-10-26 at 4 39 55 PM](https://user-images.githubusercontent.com/89094075/138957478-4fa0c2c7-ef08-4081-9820-747b072ef9e8.png)
 