### PR TITLE
Tooltip fix to match dropdown label

### DIFF
--- a/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
+++ b/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
@@ -145,6 +145,7 @@ const schemaFnc = (
       },
       tooltip: {
         standalone: true,
+        labelName: label,
       },
     },
   },


### PR DESCRIPTION
Matched the wording in the chart tooltips to the wording in the sort category dropdown.

Jira issue: https://issues.redhat.com/browse/AA-854 

Before:
![Screen Shot 2021-11-01 at 4 25 00 PM](https://user-images.githubusercontent.com/89094075/139913862-7fb84e86-6d08-4ee6-8750-2ec0ca5936f2.png)

After: 
![Screen Shot 2021-11-02 at 1 17 12 PM](https://user-images.githubusercontent.com/89094075/139913914-872384b8-d0ab-4e0c-a98a-a9afca50b8e4.png)
 