### PR TITLE
Fixed boolean in showExtraRows for PDF download

### DIFF
--- a/src/Components/Toolbar/DownloadPdfButton.js
+++ b/src/Components/Toolbar/DownloadPdfButton.js
@@ -41,7 +41,7 @@ const DownloadPdfButton = ({
         y,
         label,
         x_tick_format: xTickFormat,
-        showExtraRows: isCurrent,
+        showExtraRows: isCurrent ? false : true,
       }),
     null
   );

--- a/src/Components/Toolbar/DownloadPdfButton.js
+++ b/src/Components/Toolbar/DownloadPdfButton.js
@@ -41,7 +41,7 @@ const DownloadPdfButton = ({
         y,
         label,
         x_tick_format: xTickFormat,
-        showExtraRows: isCurrent ? false : true,
+        showExtraRows: !isCurrent,
       }),
     null
   );


### PR DESCRIPTION
showExtraRows was passing the opposite value to the back end, causing the wrong pdf report to download from UI.