### PR TITLE
[AA-910] Updated the roi report table displayed values

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/ExplandedRowContents.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/ExplandedRowContents.tsx
@@ -23,7 +23,7 @@ const ExpandedRowContents: FunctionComponent<Props> = ({ template }) => (
         <DescriptionListGroup>
           <DescriptionListTerm>Elapsed</DescriptionListTerm>
           <DescriptionListDescription>
-            {template.elapsed}
+            {template.elapsed} seconds
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -53,7 +53,7 @@ const Row: FunctionComponent<Props> = ({
             </Button>
           </Tooltip>
         </Td>
-        <Td>{template[variableRow.key]}</Td>
+        <Td>{(+template[variableRow.key]).toFixed(2)}</Td>
         <Td>
           <InputGroup>
             <TextInput


### PR DESCRIPTION
Note the 2 decimal places in the Template productivity column and the `s` in the expanded row elasped data field.
![Screenshot from 2021-11-30 10-49-33](https://user-images.githubusercontent.com/8531681/144024602-3f511577-66bc-428b-82eb-088ddb5aeafe.png)
