### PR TITLE
Removed radio options in PDF download modal

### DIFF
--- a/src/Components/Toolbar/DownloadPdfButton.tsx
+++ b/src/Components/Toolbar/DownloadPdfButton.tsx
@@ -27,6 +27,7 @@ interface Props {
   label: string;
   xTickFormat: string;
   totalCount: number;
+  onPageCount: number;
 }
 
 const DownloadPdfButton: FC<Props> = ({
@@ -37,6 +38,7 @@ const DownloadPdfButton: FC<Props> = ({
   label,
   xTickFormat,
   totalCount,
+  onPageCount,
 }) => {
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [isCurrent, setIsCurrent] = useState(true);
@@ -117,30 +119,36 @@ const DownloadPdfButton: FC<Props> = ({
         ]}
       >
         <Grid md={4}>
-          <GridItem>
-            <Radio
-              onChange={() => setIsCurrent(true)}
-              isChecked={isCurrent}
-              name="optionSelected"
-              label="Current page"
-              id="current-page-radio"
-              aria-label="current-page-radio"
-            />
-          </GridItem>
-          <GridItem>
-            <Radio
-              onChange={() => setIsCurrent(false)}
-              isChecked={!isCurrent}
-              name="optionSelected"
-              label={
-                totalCount <= 100
-                  ? `All ${totalCount} items`
-                  : `Top 100 of ${totalCount} items`
-              }
-              id="total-count-radio"
-              aria-label="total-count-radio"
-            />
-          </GridItem>
+          {totalCount <= onPageCount ? (
+            <GridItem>All {totalCount} items</GridItem>
+          ) : (
+            <>
+              <GridItem>
+                <Radio
+                  onChange={() => setIsCurrent(true)}
+                  isChecked={isCurrent}
+                  name="optionSelected"
+                  label="Current page"
+                  id="current-page-radio"
+                  aria-label="current-page-radio"
+                />
+              </GridItem>
+              <GridItem>
+                <Radio
+                  onChange={() => setIsCurrent(false)}
+                  isChecked={!isCurrent}
+                  name="optionSelected"
+                  label={
+                    totalCount <= 100
+                      ? `All ${totalCount} items`
+                      : `Top 100 of ${totalCount} items`
+                  }
+                  id="total-count-radio"
+                  aria-label="total-count-radio"
+                />
+              </GridItem>
+            </>
+          )}
         </Grid>
       </Modal>
     </>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.js
@@ -271,6 +271,7 @@ const AutomationCalculator = ({
               label={''}
               xTickFormat={''}
               totalCount={api.result.meta.count}
+              onPageCount={queryParams.limit}
             />,
           ]}
         />

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -183,6 +183,7 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
       label={chartParams.label}
       xTickFormat={chartParams.xTickFormat}
       totalCount={dataApi.result.meta.count}
+      onPageCount={queryParams.limit}
     />,
   ];
   return (


### PR DESCRIPTION
Removed all radio options in pdf download modal when the total number of items is less than or equal to currently displayed items. Instead, text will be displayed reflecting that this report would show all available data.

Jira issue: https://issues.redhat.com/browse/AA-913

![Screen Shot 2021-12-07 at 5 37 36 PM](https://user-images.githubusercontent.com/89094075/145484380-6e7cb4bf-89a8-45a6-93ed-56aa631f1a29.png)

