### PR TITLE
[AA-926] Make report tables reorder-able

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.js
@@ -84,8 +84,7 @@ const computeTotalSavings = (data) =>
 const AutomationCalculator = ({
   slug,
   defaultParams,
-  defaultTableHeaders: _ignored2,
-  tableAttributes: _ignored3,
+  tableHeaders: _ignored2,
   expandedAttributes: _ignored4,
   availableChartTypes: _ignored5,
   dataEndpoint,
@@ -314,8 +313,7 @@ const AutomationCalculator = ({
 AutomationCalculator.propTypes = {
   slug: PropTypes.string.isRequired,
   defaultParams: PropTypes.object.isRequired,
-  defaultTableHeaders: PropTypes.array.isRequired,
-  tableAttributes: PropTypes.array.isRequired,
+  tableHeaders: PropTypes.array.isRequired,
   expandedAttributes: PropTypes.array.isRequired,
   availableChartTypes: PropTypes.array.isRequired,
   dataEndpoint: PropTypes.string.isRequired,

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -71,26 +71,35 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
     fetchOptions(queryParams);
   }, [queryParams]);
 
-  const updateFilter = () => {
+  /**
+   * The function is used because the API is not returning the value.
+   * When API gets support, this function should be removed.
+   */
+  const addTaskActionId = (
+    qp: Record<string, string | string[]>
+  ): Record<string, string | string[]> => {
     if (
-      queryParams.task_action_name &&
-      queryParams.task_action_id.length === 0 &&
+      qp.task_action_name &&
+      qp.task_action_id.length === 0 &&
       options?.task_action_id &&
-      Array.isArray(queryParams.task_action_name)
+      Array.isArray(qp.task_action_name)
     ) {
-      const task_action_name = queryParams.task_action_name as Array<T>;
+      const task_action_name = qp.task_action_name;
       const modules = options.task_action_id.filter((obj) =>
         task_action_name.includes(obj.value)
       );
-      queryParams.task_action_id = modules.map((module) =>
-        module.key?.toString()
-      );
+      qp.task_action_id = modules.map((module) => module.key?.toString());
     }
+
+    return qp;
   };
 
+  /**
+   * When API gets support, this effect should be removed.
+   */
   useEffect(() => {
-    updateFilter();
-    setData(queryParams);
+    // Pass the queryParams to the function making a copy so it is not mutated.
+    setData(addTaskActionId(queryParams));
   }, [options?.task_action_id]);
 
   const tableHeaders = [

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -40,8 +40,7 @@ const getDateFormatByGranularity = (granularity: string): string => {
 const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
   slug,
   defaultParams,
-  defaultTableHeaders,
-  tableAttributes,
+  tableHeaders,
   expandedAttributes,
   availableChartTypes,
   dataEndpoint,
@@ -62,12 +61,12 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
   const { result: options, request: fetchOptions } =
     useRequest<OptionsReturnType>(readOptions, { sort_options: [] });
 
-  const { request: setData, ...dataApi } = useRequest(readData, {
+  const { request: fetchData, ...dataApi } = useRequest(readData, {
     meta: { count: 0, legend: [] },
   });
 
   useEffect(() => {
-    setData(queryParams);
+    fetchData(queryParams);
     fetchOptions(queryParams);
   }, [queryParams]);
 
@@ -99,15 +98,8 @@ const ReportCard: FunctionComponent<ReportGeneratorParams> = ({
    */
   useEffect(() => {
     // Pass the queryParams to the function making a copy so it is not mutated.
-    setData(addTaskActionId(queryParams));
+    fetchData(addTaskActionId(queryParams));
   }, [options?.task_action_id]);
-
-  const tableHeaders = [
-    ...defaultTableHeaders,
-    ...(tableAttributes
-      ? options.sort_options.filter(({ key }) => tableAttributes.includes(key))
-      : options.sort_options),
-  ];
 
   const chartParams = {
     y: queryParams.sort_options as string,

--- a/src/Containers/Reports/Shared/schemas/aa21OnboardingReport.ts
+++ b/src/Containers/Reports/Shared/schemas/aa21OnboardingReport.ts
@@ -27,19 +27,18 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
+  { key: 'host_task_count', value: 'Tasks count' },
 ];
-
-const tableAttributes = ['host_task_count'];
 
 const expandedAttributes = [] as string[];
 
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: ['host_task_count', ...expandedAttributes],
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
@@ -189,8 +188,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.eventExplorer,

--- a/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
+++ b/src/Containers/Reports/Shared/schemas/affectedHostsByPlaybook.ts
@@ -25,14 +25,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
-];
-
-const tableAttributes = [
-  'total_unique_host_count',
-  'total_unique_host_changed_count',
+  { key: 'total_unique_host_count', value: 'Total unique hosts' },
+  {
+    key: 'total_unique_host_changed_count',
+    value: 'Total unique hosts changed',
+  },
 ];
 
 const expandedAttributes = [] as string[];
@@ -40,7 +40,11 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'total_unique_host_count',
+    'total_unique_host_changed_count',
+    ...expandedAttributes,
+  ],
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
@@ -136,8 +140,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.hostExplorer,

--- a/src/Containers/Reports/Shared/schemas/automationCalculator.ts
+++ b/src/Containers/Reports/Shared/schemas/automationCalculator.ts
@@ -91,8 +91,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders: [],
-    tableAttributes: [],
+    tableHeaders: [],
     expandedAttributes: [],
     availableChartTypes: [],
     dataEndpoint: Endpoint.ROI,

--- a/src/Containers/Reports/Shared/schemas/changesMade.ts
+++ b/src/Containers/Reports/Shared/schemas/changesMade.ts
@@ -25,16 +25,13 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
-];
-
-const tableAttributes = [
-  'host_count',
-  'changed_host_count',
-  'host_task_count',
-  'host_task_changed_count',
+  { key: 'host_count', value: 'Host count' },
+  { key: 'changed_host_count', value: 'Changed host count' },
+  { key: 'host_task_count', value: 'Task count' },
+  { key: 'host_task_changed_count', value: 'Changed task count' },
 ];
 
 const expandedAttributes = [] as string[];
@@ -42,7 +39,13 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'host_count',
+    'changed_host_count',
+    'host_task_count',
+    'host_task_changed_count',
+    ...expandedAttributes,
+  ],
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
@@ -138,8 +141,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.jobExplorer,

--- a/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
+++ b/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
@@ -25,14 +25,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Organization name' },
-];
-
-const tableAttributes = [
-  'total_unique_host_count',
-  'total_unique_host_changed_count',
+  { key: 'total_unique_host_count', value: 'Unique host count' },
+  {
+    key: 'total_unique_host_changed_count',
+    value: 'Unique changed host count',
+  },
 ];
 
 const expandedAttributes = [] as string[];
@@ -48,7 +48,11 @@ const defaultParams = {
   cluster_id: [],
   template_id: [],
   inventory_id: [],
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'total_unique_host_count',
+    'total_unique_host_changed_count',
+    ...expandedAttributes,
+  ],
   group_by: 'org',
   group_by_time: true,
   sort_options: 'total_unique_host_count',
@@ -136,8 +140,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.hostExplorer,

--- a/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
@@ -26,12 +26,12 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Organization name' },
+  { key: 'total_count', value: 'Total jobs count' },
+  { key: 'host_task_count', value: 'Tasks count' },
 ];
-
-const tableAttributes = ['total_count', 'host_task_count'];
 
 const expandedAttributes = [] as string[];
 
@@ -46,7 +46,7 @@ const defaultParams = {
   cluster_id: [],
   template_id: [],
   inventory_id: [],
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: ['total_count', 'host_task_count', ...expandedAttributes],
   group_by: 'org',
   group_by_time: true,
   sort_options: 'total_count',
@@ -134,8 +134,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.jobExplorer,

--- a/src/Containers/Reports/Shared/schemas/moduleUsageByJobTemplate.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsageByJobTemplate.ts
@@ -26,17 +26,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
-];
-
-const tableAttributes = [
-  'host_task_count',
-  'host_task_changed_count',
-  'host_task_ok_count',
-  'host_task_failed_count',
-  'host_task_unreachable_count',
+  { key: 'host_task_count', value: 'Tasks count' },
+  { key: 'host_task_changed_count', value: 'Changed tasks count' },
+  { key: 'host_task_ok_count', value: 'Successful tasks count' },
+  { key: 'host_task_failed_count', value: 'Failed tasks count' },
+  { key: 'host_task_unreachable_count', value: 'Unreachable tasks count' },
 ];
 
 const expandedAttributes = [] as string[];
@@ -44,7 +41,14 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'host_task_count',
+    'host_task_changed_count',
+    'host_task_ok_count',
+    'host_task_failed_count',
+    'host_task_unreachable_count',
+    ...expandedAttributes,
+  ],
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
@@ -140,8 +144,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.eventExplorer,

--- a/src/Containers/Reports/Shared/schemas/moduleUsageByOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsageByOrganization.ts
@@ -27,17 +27,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Organization name' },
-];
-
-const tableAttributes = [
-  'host_task_count',
-  'host_task_changed_count',
-  'host_task_ok_count',
-  'host_task_failed_count',
-  'host_task_unreachable_count',
+  { key: 'host_task_count', value: 'Tasks count' },
+  { key: 'host_task_changed_count', value: 'Changed tasks count' },
+  { key: 'host_task_ok_count', value: 'Successful tasks count' },
+  { key: 'host_task_failed_count', value: 'Failed tasks count' },
+  { key: 'host_task_unreachable_count', value: 'Unreachable tasks count' },
 ];
 
 const expandedAttributes = [] as string[];
@@ -45,7 +42,14 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'host_task_count',
+    'host_task_changed_count',
+    'host_task_ok_count',
+    'host_task_failed_count',
+    'host_task_unreachable_count',
+    ...expandedAttributes,
+  ],
   group_by: 'org',
   group_by_time: true,
   granularity: 'monthly',
@@ -141,8 +145,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.eventExplorer,

--- a/src/Containers/Reports/Shared/schemas/moduleUsageByTask.ts
+++ b/src/Containers/Reports/Shared/schemas/moduleUsageByTask.ts
@@ -26,17 +26,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Task name' },
-];
-
-const tableAttributes = [
-  'host_task_count',
-  'host_task_changed_count',
-  'host_task_ok_count',
-  'host_task_failed_count',
-  'host_task_unreachable_count',
+  { key: 'host_task_count', value: 'Tasks count' },
+  { key: 'host_task_changed_count', value: 'Changed tasks count' },
+  { key: 'host_task_ok_count', value: 'Successful tasks count' },
+  { key: 'host_task_failed_count', value: 'Failed tasks count' },
+  { key: 'host_task_unreachable_count', value: 'Unreachable tasks count' },
 ];
 
 const expandedAttributes = [] as string[];
@@ -44,7 +41,14 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'host_task_count',
+    'host_task_changed_count',
+    'host_task_ok_count',
+    'host_task_failed_count',
+    'host_task_unreachable_count',
+    ...expandedAttributes,
+  ],
   group_by: 'task',
   group_by_time: true,
   granularity: 'monthly',
@@ -140,8 +144,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.eventExplorer,

--- a/src/Containers/Reports/Shared/schemas/mostUsedModules.ts
+++ b/src/Containers/Reports/Shared/schemas/mostUsedModules.ts
@@ -26,17 +26,14 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Module name' },
-];
-
-const tableAttributes = [
-  'host_task_count',
-  'host_task_changed_count',
-  'host_task_ok_count',
-  'host_task_failed_count',
-  'host_task_unreachable_count',
+  { key: 'host_task_count', value: 'Tasks count' },
+  { key: 'host_task_changed_count', value: 'Changed tasks count' },
+  { key: 'host_task_ok_count', value: 'Successful tasks count' },
+  { key: 'host_task_failed_count', value: 'Failed tasks count' },
+  { key: 'host_task_unreachable_count', value: 'Unreachable tasks count' },
 ];
 
 const expandedAttributes = [] as string[];
@@ -44,7 +41,14 @@ const expandedAttributes = [] as string[];
 const defaultParams = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'host_task_count',
+    'host_task_changed_count',
+    'host_task_ok_count',
+    'host_task_failed_count',
+    'host_task_unreachable_count',
+    ...expandedAttributes,
+  ],
   group_by: 'module',
   group_by_time: true,
   granularity: 'monthly',
@@ -139,8 +143,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.eventExplorer,

--- a/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
+++ b/src/Containers/Reports/Shared/schemas/playbookRunRate.ts
@@ -25,19 +25,25 @@ const tags = [
   TagName.timeSeries,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
+  { key: 'total_count', value: 'Total jobs count' },
+  { key: 'successful_count', value: 'Successful jobs count' },
+  { key: 'failed_count', value: 'Failed jobs count' },
 ];
-
-const tableAttributes = ['failed_count', 'successful_count', 'total_count'];
 
 const expandedAttributes = [] as string[];
 
 const defaultParams: Params = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'failed_count',
+    'successful_count',
+    'total_count',
+    ...expandedAttributes,
+  ],
   group_by: 'template',
   group_by_time: true,
   granularity: 'monthly',
@@ -133,8 +139,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.jobExplorer,

--- a/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
+++ b/src/Containers/Reports/Shared/schemas/templatesExplorer.ts
@@ -24,12 +24,13 @@ const tags = [
   TagName.performanceAnomalyDetection,
 ];
 
-const defaultTableHeaders: AttributesType = [
+const tableHeaders: AttributesType = [
   { key: 'id', value: 'ID' },
   { key: 'name', value: 'Template name' },
+  { key: 'total_count', value: 'Total jobs count' },
+  { key: 'successful_count', value: 'Successful jobs count' },
+  { key: 'failed_count', value: 'Failed jobs count' },
 ];
-
-const tableAttributes = ['failed_count', 'successful_count', 'total_count'];
 
 const expandedAttributes = [
   'average_host_task_count_per_host',
@@ -65,7 +66,12 @@ const expandedAttributes = [
 const defaultParams: Params = {
   limit: 6,
   offset: 0,
-  attributes: [...tableAttributes, ...expandedAttributes],
+  attributes: [
+    'total_count',
+    'successful_count',
+    'failed_count',
+    ...expandedAttributes,
+  ],
   group_by: 'template',
   group_by_time: false,
   granularity: 'monthly',
@@ -147,8 +153,7 @@ const reportParams: ReportPageParams = {
   reportParams: {
     slug,
     defaultParams,
-    defaultTableHeaders,
-    tableAttributes,
+    tableHeaders,
     expandedAttributes,
     availableChartTypes,
     dataEndpoint: Endpoint.jobExplorer,

--- a/src/Containers/Reports/Shared/types.ts
+++ b/src/Containers/Reports/Shared/types.ts
@@ -14,8 +14,7 @@ export type SchemaFnc = (props: {
 export interface ReportGeneratorParams {
   slug: string;
   defaultParams: Params;
-  defaultTableHeaders: AttributesType;
-  tableAttributes: string[];
+  tableHeaders: AttributesType;
   expandedAttributes: string[];
   availableChartTypes: string[];
   dataEndpoint: Endpoint;


### PR DESCRIPTION
*  Fix the types and mutation in the reports card 
*  Updated the schema to allow reorder-able columns in the table 

No UI/behavioural changes