### PR TITLE
Transcende legend

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -27,6 +27,7 @@ export interface PDFParams {
     endpointUrl: string;
     queryParams: Params;
     showExtraRows: boolean;
+    chartSeriesHiddenProps: boolean[];
   };
 }
 

--- a/src/Components/Chart/index.tsx
+++ b/src/Components/Chart/index.tsx
@@ -47,7 +47,7 @@ const Chart: FC<Props> = ({
   schema,
   data,
   specificFunctions,
-  namespace = 'chart-settings',
+  namespace = 'settings',
 }) => {
   const {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/Components/Chart/index.tsx
+++ b/src/Components/Chart/index.tsx
@@ -39,7 +39,7 @@ const applyHiddenFilter = (
   ...chartData,
   series: chartData.series.map((series, index) => ({
     ...series,
-    hidden: !!chartSeriesHidden.at(index),
+    hidden: !!chartSeriesHidden[index],
   })),
 });
 
@@ -76,7 +76,10 @@ const Chart: FC<Props> = ({
 
   useEffect(() => {
     setChartData(
-      applyHiddenFilter(convertApiToData(data), chartSeriesHiddenProps)
+      applyHiddenFilter(
+        convertApiToData(data),
+        chartSeriesHiddenProps as boolean[]
+      )
     );
   }, [data]);
 

--- a/src/Components/Toolbar/DownloadPdfButton.tsx
+++ b/src/Components/Toolbar/DownloadPdfButton.tsx
@@ -17,8 +17,10 @@ import { downloadPdf as downloadPdfAction } from '../../store/pdfDownloadButton/
 import { DownloadState } from '../../store/pdfDownloadButton/types';
 import { Endpoint, Params } from '../../Api';
 import { useAppDispatch, useAppSelector } from '../../store';
+import { useReadQueryParams } from '../../QueryParams';
 
 interface Props {
+  settingsNamespace: string;
   slug: string;
   endpointUrl: Endpoint;
   queryParams: Params;
@@ -31,6 +33,7 @@ interface Props {
 }
 
 const DownloadPdfButton: FC<Props> = ({
+  settingsNamespace = 'settings',
   slug,
   endpointUrl,
   queryParams,
@@ -44,6 +47,12 @@ const DownloadPdfButton: FC<Props> = ({
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [isCurrent, setIsCurrent] = useState(true);
   const dispatch = useAppDispatch();
+  const { chartSeriesHiddenProps } = useReadQueryParams(
+    {
+      chartSeriesHiddenProps: [],
+    },
+    settingsNamespace
+  );
 
   const status = useAppSelector((state) => state?.pdfDownloadButton[slug]);
   const isLoading = status === DownloadState.pending;
@@ -71,6 +80,7 @@ const DownloadPdfButton: FC<Props> = ({
             showExtraRows: !isCurrent,
             endpointUrl,
             queryParams,
+            chartSeriesHiddenProps,
           },
         },
         dispatch,

--- a/src/Containers/Clusters/Clusters.test.js
+++ b/src/Containers/Clusters/Clusters.test.js
@@ -23,9 +23,9 @@ describe('Containers/Clusters', () => {
     renderPage(Clusters);
 
     await waitFor(() => {
-      expect(api.readJobExplorer).toHaveBeenCalledTimes(3);
-      expect(api.readClustersOptions).toHaveBeenCalledTimes(1);
-      expect(api.readEventExplorer).toHaveBeenCalledTimes(1);
+      expect(api.readJobExplorer).toHaveBeenCalledTimes(6);
+      expect(api.readClustersOptions).toHaveBeenCalledTimes(2);
+      expect(api.readEventExplorer).toHaveBeenCalledTimes(2);
     });
 
     expect(screen.getAllByText(/Clusters/i));

--- a/src/Containers/Notifications/Notifications.tsx
+++ b/src/Containers/Notifications/Notifications.tsx
@@ -5,7 +5,7 @@ import { useQueryParams } from '../../QueryParams/';
 import styled from 'styled-components';
 import LoadingState from '../../Components/ApiStatus/LoadingState';
 import NoData from '../../Components/ApiStatus/NoData';
-import { readClusters, readNotifications } from '../../Api/';
+import { Params, readClusters, readNotifications } from '../../Api/';
 import useRequest from '../../Utilities/useRequest';
 
 import Main from '@redhat-cloud-services/frontend-components/Main';
@@ -130,7 +130,7 @@ const Notifications: FC<Record<string, never>> = () => {
     useCallback(
       () =>
         readNotifications(
-          queryParams
+          queryParams as Params
         ) as unknown as Promise<NotificationDataType>,
       [queryParams]
     ),

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.test.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.test.js
@@ -31,7 +31,7 @@ describe('SavingsPlanner/Shared/Form/Templates', () => {
     });
     renderPage(Templates, undefined, defaultProps);
 
-    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(2));
 
     expect(screen.getByText('No results found')).toBeTruthy();
   });
@@ -39,7 +39,7 @@ describe('SavingsPlanner/Shared/Form/Templates', () => {
   test('has rendered Templates component with data and is clickable', async () => {
     renderPage(Templates, undefined, defaultProps);
 
-    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(2));
 
     expect(screen.getByText('Link a template to this plan:')).toBeTruthy();
 

--- a/src/QueryParams/Context.js
+++ b/src/QueryParams/Context.js
@@ -1,4 +1,0 @@
-import { createContext } from 'react';
-
-export const QueryParamsContext = createContext({});
-export const QueryParamsProvider = QueryParamsContext.Provider;

--- a/src/QueryParams/Context.ts
+++ b/src/QueryParams/Context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import { ContextProps } from './types';
+
+export const QueryParamsContext = createContext<ContextProps>({
+  queryParams: {},
+  update: () => null,
+  redirectWithQueryParams: () => null,
+});
+export const QueryParamsProvider = QueryParamsContext.Provider;

--- a/src/QueryParams/Context.ts
+++ b/src/QueryParams/Context.ts
@@ -3,7 +3,10 @@ import { ContextProps } from './types';
 
 export const QueryParamsContext = createContext<ContextProps>({
   queryParams: {},
+  initialParams: {},
   update: () => null,
+  addInitialParams: () => null,
+  removeInitialParams: () => null,
   redirectWithQueryParams: () => null,
 });
 export const QueryParamsProvider = QueryParamsContext.Provider;

--- a/src/QueryParams/Provider.tsx
+++ b/src/QueryParams/Provider.tsx
@@ -7,7 +7,11 @@ import {
   DEFAULT_NAMESPACE,
 } from './helpers';
 import redirectWithQueryParams from './redirectWithQueryParams';
-import { UpdateFunction } from './types';
+import {
+  InitialParamsFunction,
+  NamespacedQueryParams,
+  UpdateFunction,
+} from './types';
 
 interface Props {
   children: React.ReactNode;
@@ -15,7 +19,8 @@ interface Props {
 
 const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
   const history = useHistory();
-  const [queryParams, setQueryParams] = useState({});
+  const [queryParams, setQueryParams] = useState<NamespacedQueryParams>({});
+  const [initialParams, setInitialParams] = useState<NamespacedQueryParams>({});
 
   useEffect(() => {
     if (history.location.search.length > 0) {
@@ -43,11 +48,40 @@ const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
     setQsInUrl(q, history);
   };
 
+  const addInitialParams: InitialParamsFunction = ({
+    params,
+    namespace = DEFAULT_NAMESPACE,
+  }) => {
+    setInitialParams({
+      ...initialParams,
+      [namespace]: {
+        ...initialParams[namespace],
+        ...params,
+      },
+    });
+  };
+
+  const removeInitialParams: InitialParamsFunction = ({
+    params,
+    namespace = DEFAULT_NAMESPACE,
+  }) => {
+    const newParams = { ...initialParams[namespace] };
+    Object.keys(params).forEach((e) => delete newParams[e]);
+
+    setInitialParams({
+      ...initialParams,
+      [namespace]: newParams,
+    });
+  };
+
   return (
     <Provider
       value={{
         queryParams,
+        initialParams,
         update,
+        addInitialParams,
+        removeInitialParams,
         redirectWithQueryParams: redirectWithQueryParams(history),
       }}
     >

--- a/src/QueryParams/Provider.tsx
+++ b/src/QueryParams/Provider.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
+import React, { useState, useEffect, FunctionComponent } from 'react';
 import { useHistory } from 'react-router-dom';
 import { QueryParamsProvider as Provider } from './Context';
 import {
@@ -8,8 +7,13 @@ import {
   DEFAULT_NAMESPACE,
 } from './helpers';
 import redirectWithQueryParams from './redirectWithQueryParams';
+import { UpdateFunction } from './types';
 
-const QueryParamsProvider = ({ children }) => {
+interface Props {
+  children: React.ReactNode;
+}
+
+const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
   const history = useHistory();
   const [queryParams, setQueryParams] = useState({});
 
@@ -27,7 +31,10 @@ const QueryParamsProvider = ({ children }) => {
     };
   }, []);
 
-  const update = ({ newQueryParams, namespace = DEFAULT_NAMESPACE }) => {
+  const update: UpdateFunction = ({
+    newQueryParams,
+    namespace = DEFAULT_NAMESPACE,
+  }) => {
     const q = {
       ...queryParams,
       [namespace]: newQueryParams,
@@ -47,10 +54,6 @@ const QueryParamsProvider = ({ children }) => {
       {children}
     </Provider>
   );
-};
-
-QueryParamsProvider.propTypes = {
-  children: PropTypes.node.isRequired,
 };
 
 export default QueryParamsProvider;

--- a/src/QueryParams/__tests__/Context.test.js
+++ b/src/QueryParams/__tests__/Context.test.js
@@ -1,4 +1,4 @@
-import { QueryParamsContext, QueryParamsProvider } from './Context';
+import { QueryParamsContext, QueryParamsProvider } from '../Context';
 
 describe('QueryParams/Context', () => {
   it('should have exported members', () => {

--- a/src/QueryParams/__tests__/Provider.test.js
+++ b/src/QueryParams/__tests__/Provider.test.js
@@ -1,4 +1,4 @@
-import QueryParamsProvider from './Provider';
+import QueryParamsProvider from '../Provider';
 
 describe('QueryParams/Provider', () => {
   // All the other testing is done trough consumers of the context

--- a/src/QueryParams/__tests__/helpers.test.js
+++ b/src/QueryParams/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { parseQueryParams, stringifyQueryParams } from './helpers';
+import { parseQueryParams, stringifyQueryParams } from '../helpers';
 
 describe('QueryParams/helpers', () => {
   it('should encode null and empty query params correctly', () => {

--- a/src/QueryParams/__tests__/index.test.js
+++ b/src/QueryParams/__tests__/index.test.js
@@ -3,7 +3,7 @@ import {
   useRedirect,
   QueryParamsProvider,
   DEFAULT_NAMESPACE,
-} from './';
+} from '../';
 
 describe('QueryParams/index', () => {
   it('should have exported members', () => {

--- a/src/QueryParams/__tests__/redirectWithQueryParams.test.js
+++ b/src/QueryParams/__tests__/redirectWithQueryParams.test.js
@@ -1,6 +1,6 @@
-import { Paths } from '../paths';
+import { Paths } from '../../paths';
 import { createMemoryHistory } from 'history';
-import useRedirect from './redirectWithQueryParams';
+import useRedirect from '../redirectWithQueryParams';
 
 describe('QueryParams/redirect', () => {
   // All the other testing is done in the helpers tests

--- a/src/QueryParams/__tests__/useQueryParams.test.js
+++ b/src/QueryParams/__tests__/useQueryParams.test.js
@@ -2,8 +2,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 
-import Provider from './Provider';
-import useQueryParams from './useQueryParams';
+import Provider from '../Provider';
+import useQueryParams from '../useQueryParams';
 
 // TODO Have a feeling that the useQueryParams reducer will change a bit
 // when converting to ts, so the test are going to be expanded then.

--- a/src/QueryParams/__tests__/useRedirect.test.js
+++ b/src/QueryParams/__tests__/useRedirect.test.js
@@ -2,9 +2,9 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 
-import Provider from './Provider';
-import useRedirect from './useRedirect';
-import { Paths } from '../paths';
+import Provider from '../Provider';
+import useRedirect from '../useRedirect';
+import { Paths } from '../../paths';
 
 describe('QueryParams/useRedirect', () => {
   const history = createMemoryHistory();

--- a/src/QueryParams/helpers.ts
+++ b/src/QueryParams/helpers.ts
@@ -1,9 +1,13 @@
-import { parse, stringify } from 'query-string';
+import { History } from 'history';
+import { parse, ParsedQuery, stringify } from 'query-string';
+import { NamespacedQueryParams, QueryParams } from './types';
 
 export const DEFAULT_NAMESPACE = 'default';
 
-const parseNamespace = (obj) => {
-  const retObj = {};
+const parseNamespace = (
+  obj: ParsedQuery<string | boolean>
+): NamespacedQueryParams => {
+  const retObj = {} as NamespacedQueryParams;
   Object.keys(obj).map((key) => {
     const namespace = key.split('.')[0];
     const attributes = key.split('.')[1];
@@ -16,14 +20,18 @@ const parseNamespace = (obj) => {
   return retObj;
 };
 
-const stringifyNamespace = (obj, namespace) => {
+const stringifyNamespace = (
+  obj: QueryParams,
+  namespace: string
+): QueryParams => {
   const keyValues = Object.keys(obj).map((key) => ({
     [`${namespace}.${key}`]: obj[key],
   }));
-  return Object.assign({}, ...keyValues);
+
+  return Object.assign({}, ...keyValues) as QueryParams;
 };
 
-export const parseQueryParams = (search) => {
+export const parseQueryParams = (search: string): NamespacedQueryParams => {
   const parsed = parse(search, {
     parseNumbers: false,
     parseBooleans: true,
@@ -33,7 +41,9 @@ export const parseQueryParams = (search) => {
   return parseNamespace(parsed);
 };
 
-export const stringifyQueryParams = (queryParams) => {
+export const stringifyQueryParams = (
+  queryParams: NamespacedQueryParams
+): string => {
   const namespacedObject = Object.keys(queryParams).reduce(
     (acc, key) => ({ ...acc, ...stringifyNamespace(queryParams[key], key) }),
     {}
@@ -42,7 +52,10 @@ export const stringifyQueryParams = (queryParams) => {
   return stringify(namespacedObject, { arrayFormat: 'bracket-separator' });
 };
 
-export const setQueryParams = (queryParams, history) => {
+export const setQueryParams = (
+  queryParams: NamespacedQueryParams,
+  history: History
+): void => {
   history.push({
     pathname: history.location.pathname,
     search: stringifyQueryParams(queryParams),

--- a/src/QueryParams/index.ts
+++ b/src/QueryParams/index.ts
@@ -1,4 +1,5 @@
 export { default as useQueryParams } from './useQueryParams';
+export { default as useReadQueryParams } from './useReadQueryParams';
 export { default as useRedirect } from './useRedirect';
 export { default as QueryParamsProvider } from './Provider';
 export { DEFAULT_NAMESPACE } from './helpers';

--- a/src/QueryParams/redirectWithQueryParams.ts
+++ b/src/QueryParams/redirectWithQueryParams.ts
@@ -1,18 +1,9 @@
-import { RouteComponentProps } from 'react-router-dom';
+import { History } from 'history';
 import { stringifyQueryParams } from './helpers';
-
-// TODO move it elsewhere when doing qp --> ts
-interface NamespacedQueryParams {
-  [key: string]: Record<string, any>;
-}
-
-export type RedirectWithQueryParamsProps = (
-  path: string,
-  queryParams: NamespacedQueryParams | undefined
-) => void;
+import { RedirectWithQueryParamsProps } from './types';
 
 type TopLevelRedirectParams = (
-  history: RouteComponentProps['history']
+  history: History
 ) => RedirectWithQueryParamsProps;
 
 /**

--- a/src/QueryParams/types.ts
+++ b/src/QueryParams/types.ts
@@ -12,6 +12,14 @@ export type UpdateFunction = ({
   namespace: string;
 }) => void;
 
+export type InitialParamsFunction = ({
+  params,
+  namespace,
+}: {
+  params: QueryParams;
+  namespace: string;
+}) => void;
+
 export type RedirectWithQueryParamsProps = (
   path: string,
   queryParams: NamespacedQueryParams | undefined
@@ -19,6 +27,9 @@ export type RedirectWithQueryParamsProps = (
 
 export interface ContextProps {
   queryParams: NamespacedQueryParams;
+  initialParams: NamespacedQueryParams;
   update: UpdateFunction;
+  addInitialParams: InitialParamsFunction;
+  removeInitialParams: InitialParamsFunction;
   redirectWithQueryParams: RedirectWithQueryParamsProps;
 }

--- a/src/QueryParams/types.ts
+++ b/src/QueryParams/types.ts
@@ -1,0 +1,24 @@
+export type QueryParams = Record<
+  string,
+  (string | boolean)[] | string | boolean | null
+>;
+export type NamespacedQueryParams = Record<string, QueryParams>;
+
+export type UpdateFunction = ({
+  newQueryParams,
+  namespace,
+}: {
+  newQueryParams: QueryParams;
+  namespace: string;
+}) => void;
+
+export type RedirectWithQueryParamsProps = (
+  path: string,
+  queryParams: NamespacedQueryParams | undefined
+) => void;
+
+export interface ContextProps {
+  queryParams: NamespacedQueryParams;
+  update: UpdateFunction;
+  redirectWithQueryParams: RedirectWithQueryParamsProps;
+}

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -145,7 +145,7 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
 
   const { push: dispatch } = useAsyncActionQueue({
     executeAction,
-    waitFor: params,
+    waitFor: [params],
   });
 
   return {

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -13,8 +13,6 @@ const paramsReducer = (state, { type, value }) => {
       return { ...state, startDate: value };
     case 'SET_ENDDATE':
       return { ...state, endDate: value };
-    case 'SET_CHART_TYPE':
-      return { ...state, chartType: value };
     case 'SET_ID':
       if (isNaN(value)) {
         const { id: ignored, ...rest } = state;
@@ -31,6 +29,13 @@ const paramsReducer = (state, { type, value }) => {
       return { ...state, ...value };
 
     /* v1 api reducers */
+    /* Settings reducers START */
+    /* TODO: If possible somehow rip these two types of reducers apart */
+    case 'SET_CHART_TYPE':
+      return { ...state, chartType: value };
+    case 'SET_CHART_SERIES_HIDDEN_PROPS':
+      return { ...state, chartSeriesHiddenProps: value };
+    /* Settings reducers END */
     case 'SET_LIMIT':
       return isNaN(value)
         ? { ...state, limit: '5' } // Defaults back to 5
@@ -120,6 +125,11 @@ const actionMapper = {
   granularity: 'SET_GRANULARITY',
 };
 
+// TODO: This should be a singleton
+// (since the action queue should wait for ALL changes across namespaces and functions)
+// or we can move the action queue and the `params` constant inside the context,
+// and leave this hook as a boarder stuff, and maybe make more of it depending the
+// reducer it can use.hmmmmm.
 const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
   const { queryParams, update } = useContext(QueryParamsContext);
   const params = queryParams[namespace] || initial;

--- a/src/QueryParams/useReadQueryParams.ts
+++ b/src/QueryParams/useReadQueryParams.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { QueryParamsContext } from './Context';
+import { DEFAULT_NAMESPACE } from './helpers';
+import { QueryParams } from './types';
+
+const useReadQueryParams = <T extends QueryParams>(
+  initial: T,
+  namespace = DEFAULT_NAMESPACE
+): T => {
+  const { queryParams, initialParams } = useContext(QueryParamsContext);
+
+  return (
+    (queryParams[namespace] as T) || (initialParams[namespace] as T) || initial
+  );
+};
+
+export default useReadQueryParams;

--- a/src/QueryParams/useRedirect.ts
+++ b/src/QueryParams/useRedirect.ts
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
 import { QueryParamsContext } from './Context';
+import { RedirectWithQueryParamsProps } from './types';
 
-const useRedirect = () => {
+const useRedirect = (): RedirectWithQueryParamsProps => {
   const { redirectWithQueryParams } = useContext(QueryParamsContext);
 
   return redirectWithQueryParams;

--- a/src/Utilities/useAsyncActionQueue.ts
+++ b/src/Utilities/useAsyncActionQueue.ts
@@ -1,7 +1,19 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
-const useAsyncActionQueue = ({ executeAction, waitFor }) => {
-  const [actionQueue, setActionQueue] = useState([]);
+interface Props<T> {
+  executeAction: (args: T) => void;
+  waitFor: React.DependencyList;
+}
+
+interface Return<T> {
+  push: (action: T) => void;
+}
+
+const useAsyncActionQueue = <T>({
+  executeAction,
+  waitFor,
+}: Props<T>): Return<T> => {
+  const [actionQueue, setActionQueue] = useState<T[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const processNext = () => {
@@ -21,7 +33,7 @@ const useAsyncActionQueue = ({ executeAction, waitFor }) => {
 
   useEffect(() => {
     setIsProcessing(false);
-  }, [waitFor]);
+  }, waitFor);
 
   return {
     push: (action) => {


### PR DESCRIPTION
* Make all charts toggles (hide show in legend) to be present in the URL in the `settings` namespace by default, allowing to override it with a prop.
* To make it work I had to:
  * make the useQueryParam hook to work with mutliple components for the same namespace. 
  * that needed and update to the QueryParam context, saving the initial values (and removing them) in the global state so all the different hooks can add and remove them
  * While doing it I applied to the changed files a minimal TS update.
  
@jlmitch5 @h-kataria 
I consider this PR done, I won't have time to do the PDF generator part of the transcending legend before Christmas, but it will be relatively fast and easy after this, to do in January.