### PR TITLE
Changed item limit

### DIFF
--- a/src/Utilities/constants.ts
+++ b/src/Utilities/constants.ts
@@ -55,7 +55,7 @@ export const roi = {
     sort_order: 'desc',
     start_date: undefined,
     end_date: undefined,
-    limit: '25',
+    limit: '6',
     offset: '0',
     only_root_workflows_and_standalone_jobs: true,
     attributes: [


### PR DESCRIPTION
Changed the item limit on the automation calculator report from 25 to 6 (the standard number of items displayed on all other reports).

Jira issue: https://issues.redhat.com/browse/AA-931

Before: 
![Screen Shot 2021-12-20 at 12 03 59 PM](https://user-images.githubusercontent.com/89094075/146804821-fc0047a9-0b60-4d1b-8273-6fbb9eebab25.png)

After:
![Screen Shot 2021-12-20 at 12 02 14 PM](https://user-images.githubusercontent.com/89094075/146804862-9113b244-65f1-4877-a0eb-df8bca8f1394.png)