### PR TITLE
removing duplicated lint and test in deploy stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:container": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js --host 0.0.0.0",
     "build:prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "deploy": "npm-run-all build:prod lint test",
+    "deploy": "npm-run-all build:prod",
     "verify": "npm-run-all build:prod lint test"
   },
   "insights": {


### PR DESCRIPTION
Currently, the travis ci already have lint and test stages. The third stage `Deploy` is running again the lint and test. That is duplicating the work and slowing down the PR ci turn around time.

https://github.com/RedHatInsights/tower-analytics-frontend/blob/main/.travis.yml#L18-L23

```  
include:
  - stage: Lint
    script: npm run lint
  - stage: Test
    script: npm run test
  - stage: Deploy
    script: npm run deploy && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
```