### PR TITLE
Visualization updates to ROI chart

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -207,30 +207,44 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     redirect(Paths.jobExplorer, initialQueryParams);
   };
 
-  const getDateFormatByGranularity = (granularity) => {
-    if (granularity === 'yearly') return 'formatAsYear';
-    if (granularity === 'monthly') return 'formatAsMonth';
-    if (granularity === 'daily') return 'formatDateAsDayMonth';
-    return '';
-  };
-
   const chartParams = {
     y: queryParams.sort_options,
     tooltip: 'Savings for',
+    field: queryParams.sort_options,
     label:
       options.sort_options?.find(({ key }) => key === queryParams.sort_options)
         ?.value || 'Label Y',
   };
 
+  const formattedValue = (key: string, value: number) => {
+    let val;
+    switch (key) {
+      case 'elapsed':
+        val = value.toFixed(2) + ' seconds';
+        break;
+      case 'template_automation_percentage':
+        val = value.toFixed(2) + '%';
+        break;
+      case 'successful_hosts_savings':
+      case 'failed_hosts_costs':
+      case 'monetary_gain':
+        val = currencyFormatter(value);
+        break;
+      default:
+        val = value.toFixed(2);
+    }
+    return val;
+  };
+
   const customTooltipFormatting = ({ datum }) => {
     const tooltip =
-      'Savings for ' + datum.name + ': ' + currencyFormatter(+datum.y);
+      'Savings for ' +
+      datum.name +
+      ': ' +
+      formattedValue(queryParams.sort_options, datum.y);
     return tooltip;
   };
-  console.log(
-    'api.result.itemsapi.result.itemsapi.result.itemsapi.result.items',
-    api.result.items
-  );
+
   const renderLeft = () => (
     <Card isPlain>
       <CardHeader>
@@ -241,6 +255,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           schema={hydrateSchema(schema)({
             label: chartParams.label,
             tooltip: chartParams.tooltip,
+            field: chartParams.field,
           })}
           data={{
             items: filterDisabled(api.result.items),

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -50,6 +50,8 @@ import { perPageOptions as defaultPerPageOptions } from '../../Shared/constants'
 import DownloadPdfButton from '../../../../Components/Toolbar/DownloadPdfButton';
 import { endpointFunctionMap } from '../../../../Api';
 import { AutmationCalculatorProps } from '../types';
+import hydrateSchema from '../../Shared/hydrateSchema';
+import currencyFormatter from '../../../../Utilities/currencyFormatter';
 
 const perPageOptions = [
   ...defaultPerPageOptions,
@@ -205,6 +207,30 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     redirect(Paths.jobExplorer, initialQueryParams);
   };
 
+  const getDateFormatByGranularity = (granularity) => {
+    if (granularity === 'yearly') return 'formatAsYear';
+    if (granularity === 'monthly') return 'formatAsMonth';
+    if (granularity === 'daily') return 'formatDateAsDayMonth';
+    return '';
+  };
+
+  const chartParams = {
+    y: queryParams.sort_options,
+    tooltip: 'Savings for',
+    label:
+      options.sort_options?.find(({ key }) => key === queryParams.sort_options)
+        ?.value || 'Label Y',
+  };
+
+  const customTooltipFormatting = ({ datum }) => {
+    const tooltip =
+      'Savings for ' + datum.name + ': ' + currencyFormatter(+datum.y);
+    return tooltip;
+  };
+  console.log(
+    'api.result.itemsapi.result.itemsapi.result.itemsapi.result.items',
+    api.result.items
+  );
   const renderLeft = () => (
     <Card isPlain>
       <CardHeader>
@@ -212,9 +238,17 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       </CardHeader>
       <CardBody>
         <Chart
-          schema={schema}
+          schema={hydrateSchema(schema)({
+            label: chartParams.label,
+            tooltip: chartParams.tooltip,
+          })}
           data={{
             items: filterDisabled(api.result.items),
+          }}
+          specificFunctions={{
+            labelFormat: {
+              customTooltipFormatting,
+            },
           }}
         />
       </CardBody>

--- a/src/Containers/Reports/Shared/schemas/automationCalculator.ts
+++ b/src/Containers/Reports/Shared/schemas/automationCalculator.ts
@@ -81,7 +81,7 @@ const schema = [
     parent: 0,
     props: {
       x: 'name',
-      y: 'delta',
+      y: 'VAR_field',
     },
   },
 ];

--- a/src/Containers/Reports/Shared/schemas/automationCalculator.ts
+++ b/src/Containers/Reports/Shared/schemas/automationCalculator.ts
@@ -34,11 +34,19 @@ const schema = [
         left: 90,
       },
     },
+    tooltip: {
+      cursor: true,
+      stickToAxis: 'x',
+      mouseFollow: true,
+      labelFormat: 'customTooltipFormatting',
+      labelName: 'VAR_tooltip',
+    },
     xAxis: {
       label: 'Templates',
       style: {
         axisLabel: {
           padding: 130,
+          title: 'test',
         },
       },
       labelProps: {
@@ -52,7 +60,7 @@ const schema = [
     yAxis: {
       tickFormat: 'formatNumberAsK',
       showGrid: true,
-      label: 'Savings per template',
+      label: 'VAR_label',
       style: {
         axisLabel: {
           padding: 60,
@@ -74,10 +82,6 @@ const schema = [
     props: {
       x: 'name',
       y: 'delta',
-    },
-    tooltip: {
-      standalone: true,
-      labelName: 'Saving',
     },
   },
 ];


### PR DESCRIPTION
Fixed to update label on Y axis to match the sort by field in toolbar. Tooltip labels are updated to show "Savings for X: $123,00.00" instead of “Savings per template”. amount value is formatted as currency, with the correct currency symbol and number of decimal places.

https://issues.redhat.com/browse/AA-932

before
![Screen Shot 2022-01-12 at 12 46 09 PM](https://user-images.githubusercontent.com/3450808/149194013-50bd5312-b221-4b4d-b9b0-437c30378a3a.png)


after
![Screen Shot 2022-01-12 at 12 00 06 PM](https://user-images.githubusercontent.com/3450808/149193997-ac466a43-8b69-4c9e-b8b5-efbeab7ee608.png)

![Screen Shot 2022-01-17 at 2 56 11 PM](https://user-images.githubusercontent.com/3450808/149830342-36cff796-8195-4aba-b943-9be2456f723f.png)


