### PR TITLE
AA986 - Reset pagination when setting filter 

### DIFF
--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -179,6 +179,8 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
     queryParams: params,
     dispatch,
     setFromToolbar: (varName, value = null) => {
+      //reset pagination when filter is set
+      dispatch({ type: 'SET_OFFSET', value: 0 });
       if (!varName) {
         dispatch({ type: 'RESET_FILTER' });
       } else {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AA-968

Go to Automation Calculator report -> click on last page in pagination -> set some filters

Before:
<img width="1323" alt="Screenshot 2022-01-14 at 14 17 48" src="https://user-images.githubusercontent.com/9210860/149529517-86933927-a93b-489e-9626-b6e91dc6311f.png">

After:
<img width="1302" alt="Screenshot 2022-01-14 at 14 26 57" src="https://user-images.githubusercontent.com/9210860/149529542-61b48d54-a812-4b7d-90f4-0a3f2a67c240.png">

