### PR TITLE
AA935 ROI report table fixes

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -7,8 +7,12 @@
 // @ts-nocheck
 import React, { useState, useEffect, FC } from 'react';
 import {
+  Button,
   Card,
   CardBody,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
   Grid,
   GridItem,
   Stack,
@@ -17,8 +21,9 @@ import {
   CardTitle,
   CardFooter,
   PaginationVariant,
+  Title,
 } from '@patternfly/react-core';
-
+import { ExclamationTriangleIcon as ExclamationTriangleIcon } from '@patternfly/react-icons';
 // Imports from custom components
 import FilterableToolbar from '../../../../Components/Toolbar';
 import Pagination from '../../../../Components/Pagination';
@@ -274,21 +279,32 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         <CardTitle>Automation savings</CardTitle>
       </CardHeader>
       <CardBody>
-        <Chart
-          schema={hydrateSchema(schema)({
-            label: chartParams.label,
-            tooltip: chartParams.tooltip,
-            field: chartParams.field,
-          })}
-          data={{
-            items: filterDisabled(api.result.items),
-          }}
-          specificFunctions={{
-            labelFormat: {
-              customTooltipFormatting,
-            },
-          }}
-        />
+        {filterDisabled(api.result.items).length > 0 ? <Chart
+            schema={hydrateSchema(schema)({
+                label: chartParams.label,
+                tooltip: chartParams.tooltip,
+                field: chartParams.field,
+            })}
+            data={{
+                items: filterDisabled(api.result.items),
+            }}
+            specificFunctions={{
+                labelFormat: {
+                    customTooltipFormatting,
+                },
+            }}
+        />  : <EmptyState>
+          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <Title headingLevel="h4" size="lg">
+            You have disabled all views
+          </Title>
+          <EmptyStateBody>
+            Enable individual views in the table below or press Show all button.
+          </EmptyStateBody>
+          <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
+            Show all
+          </Button>
+        </EmptyState>}
       </CardBody>
     </Card>
   );

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -185,12 +185,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     }
   };
   const getSortParams = () => {
-    const onSort = (
-        _event,
-        index,
-        direction
-    ) => {
-      setFromToolbar('sort_order', direction)
+    const onSort = (_event, index, direction) => {
+      setFromToolbar('sort_order', direction);
     };
     return {
       sort: {
@@ -279,32 +275,40 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         <CardTitle>Automation savings</CardTitle>
       </CardHeader>
       <CardBody>
-        {filterDisabled(api.result.items).length > 0 ? <Chart
+        {filterDisabled(api.result.items).length > 0 ? (
+          <Chart
             schema={hydrateSchema(schema)({
-                label: chartParams.label,
-                tooltip: chartParams.tooltip,
-                field: chartParams.field,
+              label: chartParams.label,
+              tooltip: chartParams.tooltip,
+              field: chartParams.field,
             })}
             data={{
-                items: filterDisabled(api.result.items),
+              items: filterDisabled(api.result.items),
             }}
             specificFunctions={{
-                labelFormat: {
-                    customTooltipFormatting,
-                },
+              labelFormat: {
+                customTooltipFormatting,
+              },
             }}
-        />  : <EmptyState>
-          <EmptyStateIcon icon={ExclamationTriangleIcon} />
-          <Title headingLevel="h4" size="lg">
-            You have disabled all views
-          </Title>
-          <EmptyStateBody>
-            Enable individual views in the table below or press Show all button.
-          </EmptyStateBody>
-          <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
-            Show all
-          </Button>
-        </EmptyState>}
+          />
+        ) : (
+          <EmptyState>
+            <EmptyStateIcon icon={ExclamationTriangleIcon} />
+            <Title headingLevel="h4" size="lg">
+              You have disabled all views
+            </Title>
+            <EmptyStateBody>
+              Enable individual views in the table below or press Show all
+              button.
+            </EmptyStateBody>
+            <Button
+              variant="primary"
+              onClick={() => setEnabled(undefined)(true)}
+            >
+              Show all
+            </Button>
+          </EmptyState>
+        )}
       </CardBody>
     </Card>
   );

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -101,7 +101,6 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
 
   const [costManual, setCostManual] = useState('50');
   const [costAutomation, setCostAutomation] = useState('20');
-
   const redirect = useRedirect();
   const { queryParams, setFromToolbar, setFromPagination } =
     useQueryParams(defaultParams);
@@ -179,6 +178,25 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         )
       );
     }
+  };
+  const getSortParams = () => {
+    const onSort = (
+        _event,
+        index,
+        direction
+    ) => {
+      setFromToolbar('sort_order', direction)
+    };
+    return {
+      sort: {
+        sortBy: {
+          index: 2,
+          direction: queryParams.sort_order || 'none',
+        },
+        onSort,
+        columnIndex: 2,
+      },
+    };
   };
 
   /**
@@ -345,6 +363,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
               )}
               setDataRunTime={setDataRunTime}
               setEnabled={setEnabled}
+              getSortParams={getSortParams}
             />
           </GridItem>
         </Grid>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 const setLabeledValue = (key: string, value: number) => {
   let label;
-  switch(key) {
+  switch (key) {
     case 'elapsed':
       label = timeFormatter(value) + ' seconds';
       break;
@@ -70,7 +70,7 @@ const Row: FunctionComponent<Props> = ({
             <Button
               onClick={() => redirectToJobExplorer(template.id)}
               variant={ButtonVariant.link}
-              style={{ padding: "0px" }}
+              style={{ padding: '0px' }}
             >
               {template.name}
             </Button>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -13,6 +13,8 @@ import { Tr, Td } from '@patternfly/react-table';
 import { global_success_color_200 as globalSuccessColor200 } from '@patternfly/react-tokens';
 
 import currencyFormatter from '../../../../../Utilities/currencyFormatter';
+import timeFormatter from '../../../../../Utilities/timeFormatter';
+import percentageFormatter from '../../../../../Utilities/percentageFormatter';
 import { Template } from './types';
 import ExpandedRowContents from './ExplandedRowContents';
 
@@ -23,6 +25,26 @@ interface Props {
   setEnabled: (enabled: boolean) => void;
   redirectToJobExplorer: (id: number) => void;
 }
+
+const setLabeledValue = (key: string, value: number) => {
+  let label;
+  switch(key) {
+    case 'elapsed':
+      label = timeFormatter(value) + ' seconds';
+      break;
+    case 'template_automation_percentage':
+      label = percentageFormatter(value) + '%';
+      break;
+    case 'successful_hosts_savings':
+    case 'failed_hosts_costs':
+    case 'monetary_gain':
+      label = currencyFormatter(value);
+      break;
+    default:
+      label = value;
+  }
+  return label;
+};
 
 const Row: FunctionComponent<Props> = ({
   template,
@@ -54,7 +76,7 @@ const Row: FunctionComponent<Props> = ({
             </Button>
           </Tooltip>
         </Td>
-        <Td>{(+template[variableRow.key]).toFixed(2)}</Td>
+        <Td>{setLabeledValue(variableRow.key, +template[variableRow.key])}</Td>
         <Td>
           <InputGroup>
             <TextInput

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -48,6 +48,7 @@ const Row: FunctionComponent<Props> = ({
             <Button
               onClick={() => redirectToJobExplorer(template.id)}
               variant={ButtonVariant.link}
+              style={{ padding: "0px" }}
             >
               {template.name}
             </Button>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-table';
 import { Template } from './types';
 import Row from './Row';
-import {TableSortParams} from "../../Standard/types";
+import { TableSortParams } from '../../Standard/types';
 
 interface Props {
   data: Template[];

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -35,7 +35,7 @@ const TopTemplates: FunctionComponent<Props> = ({
           <Th />
           <Th>Name</Th>
           <Th>{variableRow.value}</Th>
-          <Th>Time</Th>
+          <Th>Manual time</Th>
           <Th>Savings</Th>
           <Th>
             <Switch

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-table';
 import { Template } from './types';
 import Row from './Row';
+import {TableSortParams} from "../../Standard/types";
 
 interface Props {
   data: Template[];
@@ -18,6 +19,7 @@ interface Props {
   setDataRunTime: (delta: number, id: number) => void;
   setEnabled: (id: number | undefined) => (enabled: boolean) => void;
   redirectToJobExplorer: (id: number) => void;
+  getSortParams?: () => TableSortParams;
 }
 
 const TopTemplates: FunctionComponent<Props> = ({
@@ -26,6 +28,7 @@ const TopTemplates: FunctionComponent<Props> = ({
   setDataRunTime = () => ({}),
   setEnabled = () => () => ({}),
   redirectToJobExplorer = () => ({}),
+  getSortParams = () => ({}),
 }) => (
   <>
     <p>Enter the time it takes to run the following templates manually.</p>
@@ -34,7 +37,7 @@ const TopTemplates: FunctionComponent<Props> = ({
         <Tr>
           <Th />
           <Th>Name</Th>
-          <Th>{variableRow.value}</Th>
+          <Th {...getSortParams()}>{variableRow.value}</Th>
           <Th>Manual time</Th>
           <Th>Savings</Th>
           <Th>

--- a/src/Containers/Reports/Layouts/Standard/Table/index.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/index.tsx
@@ -26,31 +26,30 @@ const ReportTable: FunctionComponent<Props> = ({
   getSortParams = () => ({}),
   expandedRowName,
 }) => {
-      headers.map(({ key, value }) => {
-      });
-  return <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
-    <Thead>
-      <Tr>
-        {expandedRowName && <Th />}
-        {headers.map(({ key, value }) => (
-          <Th key={key} {...getSortParams(key)} data-testid={key}>
-            {value}
-          </Th>
+  headers.map(({ key, value }) => {});
+  return (
+    <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
+      <Thead>
+        <Tr>
+          {expandedRowName && <Th />}
+          {headers.map(({ key, value }) => (
+            <Th key={key} {...getSortParams(key)} data-testid={key}>
+              {value}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {legend.map((entry) => (
+          <TableRow
+            key={entry.id}
+            legendEntry={entry}
+            headers={headers}
+            expandedRowName={expandedRowName}
+          />
         ))}
-      </Tr>
-    </Thead>
-    <Tbody>
-      {legend.map((entry) => (
-        <TableRow
-          key={entry.id}
-          legendEntry={entry}
-          headers={headers}
-          expandedRowName={expandedRowName}
-        />
-      ))}
-    </Tbody>
-  </TableComposable>
-}
-;
-
+      </Tbody>
+    </TableComposable>
+  );
+};
 export default ReportTable;

--- a/src/Containers/Reports/Layouts/Standard/Table/index.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/index.tsx
@@ -26,7 +26,6 @@ const ReportTable: FunctionComponent<Props> = ({
   getSortParams = () => ({}),
   expandedRowName,
 }) => {
-  headers.map(({ key, value }) => {});
   return (
     <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
       <Thead>

--- a/src/Containers/Reports/Layouts/Standard/Table/index.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/index.tsx
@@ -25,8 +25,13 @@ const ReportTable: FunctionComponent<Props> = ({
   headers,
   getSortParams = () => ({}),
   expandedRowName,
-}) => (
-  <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
+}) => {
+      headers.map(({ key, value }) => {
+        console.log(key);
+        console.log(value);
+        console.log({...getSortParams(key)});
+      });
+  return <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
     <Thead>
       <Tr>
         {expandedRowName && <Th />}
@@ -48,6 +53,7 @@ const ReportTable: FunctionComponent<Props> = ({
       ))}
     </Tbody>
   </TableComposable>
-);
+}
+;
 
 export default ReportTable;

--- a/src/Containers/Reports/Layouts/Standard/Table/index.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/index.tsx
@@ -27,9 +27,6 @@ const ReportTable: FunctionComponent<Props> = ({
   expandedRowName,
 }) => {
       headers.map(({ key, value }) => {
-        console.log(key);
-        console.log(value);
-        console.log({...getSortParams(key)});
       });
   return <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
     <Thead>

--- a/src/Utilities/percentageFormatter.ts
+++ b/src/Utilities/percentageFormatter.ts
@@ -1,5 +1,7 @@
 const percentageFormatter = (n: number): string => {
-  const formatter = new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 });
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumSignificantDigits: 2,
+  });
 
   return formatter.format(n);
 };

--- a/src/Utilities/percentageFormatter.ts
+++ b/src/Utilities/percentageFormatter.ts
@@ -1,0 +1,6 @@
+const percentageFormatter = (n: number): string => {
+  const formatter = new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 });
+
+  return formatter.format(n);
+};
+export default percentageFormatter;

--- a/src/Utilities/timeFormatter.ts
+++ b/src/Utilities/timeFormatter.ts
@@ -1,0 +1,5 @@
+const timeFormatter = (n: number): string => {
+  const formatter = new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 });
+  return formatter.format(n);
+};
+export default timeFormatter;

--- a/src/Utilities/timeFormatter.ts
+++ b/src/Utilities/timeFormatter.ts
@@ -1,5 +1,7 @@
 const timeFormatter = (n: number): string => {
-  const formatter = new Intl.NumberFormat('en-US', { maximumSignificantDigits: 2 });
+  const formatter = new Intl.NumberFormat('en-US', {
+    maximumSignificantDigits: 2,
+  });
   return formatter.format(n);
 };
 export default timeFormatter;


### PR DESCRIPTION
Replaces https://github.com/RedHatInsights/tower-analytics-frontend/pull/720

Fixes: https://issues.redhat.com/browse/AA-935

- Adding units to sortable column

After:
<img width="1306" alt="Screenshot 2022-01-07 at 14 56 05" src="https://user-images.githubusercontent.com/9210860/148554281-b54d9a74-9738-4d0d-b9a8-70936b2c2508.png">
<img width="1302" alt="Screenshot 2022-01-07 at 14 56 25" src="https://user-images.githubusercontent.com/9210860/148554296-7561df18-b78c-486a-aa6e-2f3b60ba17b7.png">
<img width="1299" alt="Screenshot 2022-01-07 at 14 56 37" src="https://user-images.githubusercontent.com/9210860/148554316-bee66468-414f-44a4-be91-b4d44de058d2.png">

- Adding empty state when all data is hidden
Before:
<img width="1283" alt="Screenshot 2022-01-14 at 16 00 29" src="https://user-images.githubusercontent.com/9210860/149536842-243842cf-bdc3-4c62-844d-cff9c8c8bed6.png">

After:
<img width="1295" alt="Screenshot 2022-01-14 at 12 02 58" src="https://user-images.githubusercontent.com/9210860/149531204-e3ed5d02-a621-4c92-8c36-804845176fa0.png">

- Adding sort to sortable column
Before:
<img width="1308" alt="Screenshot 2022-01-14 at 16 00 15" src="https://user-images.githubusercontent.com/9210860/149536771-f7a636a3-2935-4a55-aff0-7e2b154867cb.png">

After:
<img width="1303" alt="Screenshot 2022-01-14 at 15 54 10" src="https://user-images.githubusercontent.com/9210860/149536195-b659ce4b-a5f8-4600-84a9-2dfba58b24be.png">



