### PR TITLE
Add test that offset is reset when a filter in toolbar is set

### DIFF
--- a/src/QueryParams/__tests__/useQueryParams.test.js
+++ b/src/QueryParams/__tests__/useQueryParams.test.js
@@ -64,4 +64,15 @@ describe('QueryParams/useQueryParams', () => {
 
     expect(result.current.queryParams).toEqual({ attributes: [] });
   });
+  it('should reset the offset when a filter is set via toolbar', () => {
+    const { result } = renderHook(() => useQueryParams({ offset: 10 }), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.setFromToolbar('org_id', 1);
+    });
+
+    expect(result.current.queryParams).toEqual({ offset: '0', org_id: '1' });
+  });
 });


### PR DESCRIPTION
Follow-up to https://github.com/RedHatInsights/tower-analytics-frontend/pull/723 change