### PR TITLE
Used data in meta['legend'] instead of items from API response

### DIFF
--- a/src/Containers/AutomationCalculator/AutomationCalculator.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.js
@@ -44,8 +44,8 @@ import AutomationFormula from './AutomationFormula';
 import TopTemplates from './TopTemplates';
 import { Paths } from '../../paths';
 
-const mapApi = ({ items = [] }) =>
-  items.map((el) => ({
+const mapApi = ({ legend = [] }) =>
+  legend.map((el) => ({
     ...el,
     delta: 0,
     avgRunTime: 3600,
@@ -96,7 +96,7 @@ const AutomationCalculator = () => {
     setValue,
   } = useRequest(async (params) => {
     const response = await readROI(params);
-    return updateDeltaCost(mapApi(response), costAutomation, costManual);
+    return updateDeltaCost(mapApi(response.meta), costAutomation, costManual);
   }, []);
 
   /**

--- a/src/Containers/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/AutomationCalculator/AutomationCalculator.test.js
@@ -13,35 +13,37 @@ fetchMock.config.overwriteRoutes = true;
 
 const jobExplorerUrl = 'path:/api/tower-analytics/v1/roi_templates/';
 const dummyRoiData = {
-  items: [
-    {
-      id: 1,
-      name: 'a',
-      successful_elapsed_total: 3600,
-      host_cluster_count: 10,
-      total_org_count: 2,
-      successful_hosts_total: 10,
-      total_cluster_count: 20,
-    },
-    {
-      id: 2,
-      name: 'b',
-      successful_elapsed_total: 3600,
-      host_cluster_count: 10,
-      total_org_count: 2,
-      successful_hosts_total: 10,
-      total_cluster_count: 20,
-    },
-    {
-      id: 3,
-      name: 'c',
-      successful_elapsed_total: 0,
-      host_cluster_count: 10,
-      total_org_count: 2,
-      successful_hosts_total: 10,
-      total_cluster_count: 20,
-    },
-  ],
+  meta: {
+    legend: [
+      {
+        id: 1,
+        name: 'a',
+        successful_elapsed_total: 3600,
+        host_cluster_count: 10,
+        total_org_count: 2,
+        successful_hosts_total: 10,
+        total_cluster_count: 20,
+      },
+      {
+        id: 2,
+        name: 'b',
+        successful_elapsed_total: 3600,
+        host_cluster_count: 10,
+        total_org_count: 2,
+        successful_hosts_total: 10,
+        total_cluster_count: 20,
+      },
+      {
+        id: 3,
+        name: 'c',
+        successful_elapsed_total: 0,
+        host_cluster_count: 10,
+        total_org_count: 2,
+        successful_hosts_total: 10,
+        total_cluster_count: 20,
+      },
+    ],
+  },
 };
 const defaultTotalSaving = '1,460.00';
 const jobExplorerOptionsUrl =
@@ -108,7 +110,7 @@ describe('Containers/AutomationCalculator', () => {
   });
 
   it('should render no data', async () => {
-    fetchMock.post({ url: jobExplorerUrl }, { items: [] });
+    fetchMock.post({ url: jobExplorerUrl }, { meta: { legend: [] } });
 
     await act(async () => {
       wrapper = mountPage(AutomationCalculator);

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -263,7 +263,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
 
   const customTooltipFormatting = ({ datum }) => {
     const tooltip =
-      'Savings for ' +
+      chartParams.label +
+      ' for ' +
       datum.name +
       ': ' +
       formattedValue(queryParams.sort_options, datum.y);


### PR DESCRIPTION
UI changes to adjust old Automation Calculator screen.
Fixed tooltips on new ROI report page, that somehow got lost with maybe Zita's PR merge with ROI visual changes

https://issues.redhat.com/browse/AA-958

![Screen Shot 2022-01-20 at 5 06 18 PM](https://user-images.githubusercontent.com/3450808/150429864-17a5f4ef-255d-4321-9434-6bf820c5acc5.png)


![Screen Shot 2022-01-20 at 5 06 37 PM](https://user-images.githubusercontent.com/3450808/150429871-d657c681-1cdd-42e0-a662-891e7a532b29.png)

