### PR TITLE
ROI report loading fixes

### DIFF
--- a/src/Components/ApiStatus/ApiStatusWrapper.tsx
+++ b/src/Components/ApiStatus/ApiStatusWrapper.tsx
@@ -11,9 +11,17 @@ interface Props {
     isLoading: boolean;
   };
   children: React.ReactNode;
+  customLoading: boolean;
 }
 
-const ApiStatusWrapper: FunctionComponent<Props> = ({ api, children }) => {
+const ApiStatusWrapper: FunctionComponent<Props> = ({
+  api,
+  children,
+  customLoading = false,
+}) => {
+  if (customLoading && api.isLoading) {
+    return <>{children}</>;
+  }
   if (!api || api.isLoading) return <LoadingState />;
   if (api.error) return <ApiErrorState message={api.error.error} />;
 

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -58,7 +58,13 @@ import { endpointFunctionMap } from '../../../../Api';
 import { AutmationCalculatorProps } from '../types';
 import hydrateSchema from '../../Shared/hydrateSchema';
 import currencyFormatter from '../../../../Utilities/currencyFormatter';
+import styled from 'styled-components';
 
+const SpinnerDiv = styled.div`
+  height: 400px;
+  padding-top: 200px;
+  padding-left: 400px;
+`;
 const perPageOptions = [
   ...defaultPerPageOptions,
   { title: '15', value: 15 },
@@ -297,15 +303,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       </CardHeader>
       <CardBody>
         {api.isLoading ? (
-          <div
-            style={{
-              height: '400px',
-              paddingTop: '200px',
-              paddingLeft: '400px',
-            }}
-          >
+          <SpinnerDiv>
             <Spinner isSVG />
-          </div>
+          </SpinnerDiv>
         ) : filterDisabled(api.result.items).length > 0 ? (
           <Chart
             schema={hydrateSchema(schema)({

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -306,7 +306,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           <SpinnerDiv>
             <Spinner isSVG />
           </SpinnerDiv>
-        ) : filterDisabled(api.result.items).length > 0 ? (
+        ) : filterDisabled(api?.result?.items).length > 0 ? (
           <Chart
             schema={hydrateSchema(schema)({
               label: chartParams.label,

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -22,6 +22,7 @@ import {
   CardFooter,
   PaginationVariant,
   Title,
+  Spinner,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon as ExclamationTriangleIcon } from '@patternfly/react-icons';
 // Imports from custom components
@@ -295,7 +296,17 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         <CardTitle>Automation savings</CardTitle>
       </CardHeader>
       <CardBody>
-        {filterDisabled(api.result.items).length > 0 ? (
+        {api.isLoading ? (
+          <div
+            style={{
+              height: '400px',
+              paddingTop: '200px',
+              paddingLeft: '400px',
+            }}
+          >
+            <Spinner isSVG />
+          </div>
+        ) : filterDisabled(api.result.items).length > 0 ? (
           <Chart
             schema={hydrateSchema(schema)({
               label: chartParams.label,
@@ -338,6 +349,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       <StackItem>
         <TotalSavings
           totalSavings={computeTotalSavings(filterDisabled(api.result.items))}
+          isLoading={api.isLoading}
         />
       </StackItem>
       <StackItem>
@@ -395,16 +407,23 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           <GridItem span={9}>{renderLeft()}</GridItem>
           <GridItem span={3}>{renderRight()}</GridItem>
           <GridItem span={12}>
-            <TemplatesTable
-              redirectToJobExplorer={redirectToJobExplorer}
-              data={api.result.items}
-              variableRow={options.sort_options.find(
-                ({ key }) => key === queryParams.sort_options
-              )}
-              setDataRunTime={setDataRunTime}
-              setEnabled={setEnabled}
-              getSortParams={getSortParams}
-            />
+            <p>
+              Enter the time it takes to run the following templates manually.
+            </p>
+            {api.isLoading ? (
+              <Spinner isSVG />
+            ) : (
+              <TemplatesTable
+                redirectToJobExplorer={redirectToJobExplorer}
+                data={api.result.items}
+                variableRow={options.sort_options.find(
+                  ({ key }) => key === queryParams.sort_options
+                )}
+                setDataRunTime={setDataRunTime}
+                setEnabled={setEnabled}
+                getSortParams={getSortParams}
+              />
+            )}
           </GridItem>
         </Grid>
       </CardBody>
@@ -422,8 +441,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       </CardFooter>
     </Card>
   );
-
-  return <ApiStatusWrapper api={api}>{renderContents()}</ApiStatusWrapper>;
+  return (
+    <ApiStatusWrapper api={api} customLoading={true}>
+      {renderContents()}
+    </ApiStatusWrapper>
+  );
 };
 
 export default AutomationCalculator;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -48,6 +48,7 @@ const CalculationCost: FunctionComponent<Props> = ({
         </InputGroupText>
         <TextInput
           id="manual-cost"
+          key="manual-cost"
           type="number"
           aria-label="manual-cost"
           value={isNaN(costManual) ? '' : costManual.toString()}
@@ -62,6 +63,7 @@ const CalculationCost: FunctionComponent<Props> = ({
         </InputGroupText>
         <TextInput
           id="automation-cost"
+          key="automation-cost"
           type="number"
           aria-label="automation-cost"
           value={isNaN(costAutomation) ? '' : costAutomation.toString()}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -53,7 +53,13 @@ const Row: FunctionComponent<Props> = ({
   setEnabled,
   redirectToJobExplorer,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(
+    window.localStorage.getItem(template.id.toString()) === 'true' || false
+  );
+  const expandedRow = (value: boolean, id: number) => {
+    window.localStorage.setItem(id.toString(), value ? 'true' : 'false');
+    setIsExpanded(value);
+  };
 
   return (
     <>
@@ -62,7 +68,7 @@ const Row: FunctionComponent<Props> = ({
           expand={{
             rowIndex: template.id,
             isExpanded: isExpanded,
-            onToggle: () => setIsExpanded(!isExpanded),
+            onToggle: () => expandedRow(!isExpanded, template.id),
           }}
         />
         <Td>
@@ -80,11 +86,23 @@ const Row: FunctionComponent<Props> = ({
         <Td>
           <InputGroup>
             <TextInput
+              autoFocus={
+                window.localStorage.getItem('focused') ===
+                'manual-time-' + template.id.toString()
+              }
+              id={'manual-time-' + template.id.toString()}
               style={{ maxWidth: '150px' }}
               type="number"
               aria-label="time run manually"
               value={template.avgRunTime / 60}
-              onChange={(minutes) => setDataRunTime(+minutes * 60, template.id)}
+              onBlur={() => window.localStorage.setItem('focused', '')}
+              onChange={(minutes) => {
+                window.localStorage.setItem(
+                  'focused',
+                  'manual-time-' + template.id.toString()
+                );
+                setDataRunTime(+minutes * 60, template.id);
+              }}
             />
             <InputGroupText>min</InputGroupText>
             <InputGroupText variant={InputGroupTextVariant.plain}>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -30,40 +30,37 @@ const TopTemplates: FunctionComponent<Props> = ({
   redirectToJobExplorer = () => ({}),
   getSortParams = () => ({}),
 }) => (
-  <>
-    <p>Enter the time it takes to run the following templates manually.</p>
-    <TableComposable aria-label="ROI Table" variant={TableVariant.compact}>
-      <Thead>
-        <Tr>
-          <Th />
-          <Th>Name</Th>
-          <Th {...getSortParams()}>{variableRow.value}</Th>
-          <Th>Manual time</Th>
-          <Th>Savings</Th>
-          <Th>
-            <Switch
-              label="Show all"
-              labelOff="Show all"
-              isChecked={!data.find((d) => !d.enabled)}
-              onChange={(checked) => setEnabled(undefined)(checked)}
-            />
-          </Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        {data.map((template) => (
-          <Row
-            key={template.id}
-            template={template}
-            variableRow={variableRow}
-            setDataRunTime={setDataRunTime}
-            redirectToJobExplorer={redirectToJobExplorer}
-            setEnabled={setEnabled(template.id)}
+  <TableComposable aria-label="ROI Table" variant={TableVariant.compact}>
+    <Thead>
+      <Tr>
+        <Th />
+        <Th>Name</Th>
+        <Th {...getSortParams()}>{variableRow.value}</Th>
+        <Th>Manual time</Th>
+        <Th>Savings</Th>
+        <Th>
+          <Switch
+            label="Show all"
+            labelOff="Show all"
+            isChecked={!data.find((d) => !d.enabled)}
+            onChange={(checked) => setEnabled(undefined)(checked)}
           />
-        ))}
-      </Tbody>
-    </TableComposable>
-  </>
+        </Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      {data.map((template) => (
+        <Row
+          key={template.id}
+          template={template}
+          variableRow={variableRow}
+          setDataRunTime={setDataRunTime}
+          redirectToJobExplorer={redirectToJobExplorer}
+          setEnabled={setEnabled(template.id)}
+        />
+      ))}
+    </Tbody>
+  </TableComposable>
 );
 
 export default TopTemplates;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
@@ -7,11 +7,16 @@ import {
   Title,
 } from '@patternfly/react-core';
 import currencyFormatter from '../../../../Utilities/currencyFormatter';
+import styled from 'styled-components';
 
 interface Props {
   totalSavings: number;
   isLoading: boolean;
 }
+const SpinnerDiv = styled.div`
+  height: 46.8px;
+  padding-left: 100px;
+`;
 
 const TotalSavings: FunctionComponent<Props> = ({
   totalSavings = 0,
@@ -26,9 +31,9 @@ const TotalSavings: FunctionComponent<Props> = ({
         style={{ color: 'var(--pf-global--success-color--200)' }}
       >
         {isLoading ? (
-          <div style={{ height: '46.8px', paddingLeft: '100px' }}>
+          <SpinnerDiv>
             <Spinner isSVG size="lg" />
-          </div>
+          </SpinnerDiv>
         ) : (
           currencyFormatter(totalSavings)
         )}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
@@ -1,12 +1,22 @@
 import React, { FunctionComponent } from 'react';
-import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
 import currencyFormatter from '../../../../Utilities/currencyFormatter';
 
 interface Props {
   totalSavings: number;
+  isLoading: boolean;
 }
 
-const TotalSavings: FunctionComponent<Props> = ({ totalSavings = 0 }) => (
+const TotalSavings: FunctionComponent<Props> = ({
+  totalSavings = 0,
+  isLoading = false,
+}) => (
   <Card isPlain isCompact>
     <CardTitle>Total savings</CardTitle>
     <CardBody>
@@ -15,7 +25,13 @@ const TotalSavings: FunctionComponent<Props> = ({ totalSavings = 0 }) => (
         size="4xl"
         style={{ color: 'var(--pf-global--success-color--200)' }}
       >
-        {currencyFormatter(totalSavings)}
+        {isLoading ? (
+          <div style={{ height: '46.8px', paddingLeft: '100px' }}>
+            <Spinner isSVG size="lg" />
+          </div>
+        ) : (
+          currencyFormatter(totalSavings)
+        )}
       </Title>
     </CardBody>
   </Card>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-986

- use spinner for components that are rerendred
- inputs have focus when used
- spinners are the same size as chart and $ sum - not posssible to do for the table

Before:
<img width="1383" alt="Screenshot 2022-01-28 at 13 29 32" src="https://user-images.githubusercontent.com/9210860/151547115-40dec768-5b6d-4280-8ea4-a035fd4af7c4.png">


After:
<img width="1324" alt="Screenshot 2022-01-28 at 13 25 25" src="https://user-images.githubusercontent.com/9210860/151546832-0a65eee1-2fc2-4517-b51e-1585df3551e7.png">

