### PR TITLE
ROI report has default manual time per item when pagination changes

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -111,9 +111,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     legend.map((el, index) => ({
       ...el,
       delta: 0,
-      avgRunTime: queryParams.time_per_item
-        ? queryParams.time_per_item[index]
-        : 3600,
+      avgRunTime:
+        queryParams.time_per_item && !!queryParams.time_per_item[index]
+          ? queryParams.time_per_item[index]
+          : 3600,
       manualCost: 0,
       automatedCost: 0,
       enabled: queryParams.enabled_per_item


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-997

Introduced by me in https://github.com/RedHatInsights/tower-analytics-frontend/pull/726 😿 

Before:
<img width="1303" alt="Screenshot 2022-01-28 at 15 50 20" src="https://user-images.githubusercontent.com/9210860/151570057-9432d9bb-c994-4eb2-a139-0471e1b44198.png">

After:
<img width="1309" alt="Screenshot 2022-01-28 at 16 02 39" src="https://user-images.githubusercontent.com/9210860/151570035-992f6d6a-1427-4c77-b0e3-01975c46ff43.png">


