### PR TITLE
Preserve ROI report params in DB

### DIFF
--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -3,7 +3,7 @@ import {
   get,
   post,
   postWithPagination,
-  save,
+  saveROIData,
   deleteById,
   updateById,
   authenticatedFetch,
@@ -80,7 +80,7 @@ export const readROI = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(Endpoint.ROI, params);
 
 export const saveROI = (params: saveROIParams): Promise<ApiJson> => {
-  return save(Endpoint.costEffortROI, params);
+  return saveROIData(Endpoint.costEffortROI, params);
 };
 
 export const readROIOptions = (params: Params): Promise<ApiJson> =>

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -79,7 +79,7 @@ export const readEventExplorerOptions = (params: Params): Promise<ApiJson> =>
 export const readROI = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(Endpoint.ROI, params);
 
-export const saveROI = (params: saveROIParams): Promise<ApiJson> =>{
+export const saveROI = (params: saveROIParams): Promise<ApiJson> => {
   return save(Endpoint.costEffortROI, params);
 };
 

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -3,6 +3,7 @@ import {
   get,
   post,
   postWithPagination,
+  save,
   deleteById,
   updateById,
   authenticatedFetch,
@@ -16,6 +17,7 @@ import {
   ApiJson,
   PDFParams,
   NotificationParams,
+  saveROIParams,
 } from './types';
 
 export enum Endpoint {
@@ -30,6 +32,7 @@ export enum Endpoint {
   hostExplorer = '/api/tower-analytics/v1/host_explorer/',
   eventExplorer = '/api/tower-analytics/v1/event_explorer/',
   ROI = '/api/tower-analytics/v1/roi_templates/',
+  costEffortROI = '/api/tower-analytics/v1/roi_cost_effort_data/',
   plans = '/api/tower-analytics/v1/plans/',
   plan = '/api/tower-analytics/v1/plan/',
 
@@ -75,6 +78,10 @@ export const readEventExplorerOptions = (params: Params): Promise<ApiJson> =>
 
 export const readROI = (params: ParamsWithPagination): Promise<ApiJson> =>
   postWithPagination(Endpoint.ROI, params);
+
+export const saveROI = (params: saveROIParams): Promise<ApiJson> =>{
+  return save(Endpoint.costEffortROI, params);
+};
 
 export const readROIOptions = (params: Params): Promise<ApiJson> =>
   post(Endpoint.ROIOptions, params);

--- a/src/Api/methods.ts
+++ b/src/Api/methods.ts
@@ -6,6 +6,7 @@ import {
   ParamsWithPagination,
   PDFParams,
   NotificationParams,
+  saveROIParams,
 } from './types';
 import { createWriteStream } from 'streamsaver';
 import {
@@ -111,6 +112,17 @@ export const get = (
 export const post = (
   endpoint: string,
   params: Params = {}
+): Promise<ApiJson> => {
+  const url = new URL(endpoint, window.location.origin);
+  return authenticatedFetch(url.toString(), {
+    method: 'POST',
+    body: JSON.stringify(params),
+  }).then(handleResponse);
+};
+
+export const save = (
+  endpoint: string,
+  params: saveROIParams = {}
 ): Promise<ApiJson> => {
   const url = new URL(endpoint, window.location.origin);
   return authenticatedFetch(url.toString(), {

--- a/src/Api/methods.ts
+++ b/src/Api/methods.ts
@@ -120,7 +120,7 @@ export const post = (
   }).then(handleResponse);
 };
 
-export const save = (
+export const saveROIData = (
   endpoint: string,
   params: saveROIParams
 ): Promise<ApiJson> => {

--- a/src/Api/methods.ts
+++ b/src/Api/methods.ts
@@ -122,7 +122,7 @@ export const post = (
 
 export const save = (
   endpoint: string,
-  params: saveROIParams = {}
+  params: saveROIParams
 ): Promise<ApiJson> => {
   const url = new URL(endpoint, window.location.origin);
   return authenticatedFetch(url.toString(), {

--- a/src/Api/methods.ts
+++ b/src/Api/methods.ts
@@ -2,10 +2,10 @@ import { stringify } from 'query-string';
 import { saveStream } from './streamSaver';
 import {
   ApiJson,
+  NotificationParams,
   Params,
   ParamsWithPagination,
   PDFParams,
-  NotificationParams,
   saveROIParams,
 } from './types';
 import { createWriteStream } from 'streamsaver';

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -32,6 +32,13 @@ export interface PDFParams {
   };
 }
 
+export interface saveROIParams {
+  currency?: string;
+  hourly_manual_labor_cost?: number;
+  hourly_automation_cost?: number;
+  templates_manual_equivalent?: {template_is: number, effort_minutes: number, template_weigh_in: boolean}[];
+}
+
 export type NotificationAsyncFunction = (
   id: string,
   message?: string

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -33,11 +33,11 @@ export interface PDFParams {
 }
 
 export interface saveROIParams {
-  currency?: string;
-  hourly_manual_labor_cost?: number;
-  hourly_automation_cost?: number;
-  templates_manual_equivalent?: {
-    template_is: number;
+  currency: string;
+  hourly_manual_labor_cost: number;
+  hourly_automation_cost: number;
+  templates_manual_equivalent: {
+    template_id: number;
     effort_minutes: number;
     template_weigh_in: boolean;
   }[];

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -36,7 +36,11 @@ export interface saveROIParams {
   currency?: string;
   hourly_manual_labor_cost?: number;
   hourly_automation_cost?: number;
-  templates_manual_equivalent?: {template_is: number, effort_minutes: number, template_weigh_in: boolean}[];
+  templates_manual_equivalent?: {
+    template_is: number;
+    effort_minutes: number;
+    template_weigh_in: boolean;
+  }[];
 }
 
 export type NotificationAsyncFunction = (

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -18,6 +18,7 @@ const dummyRoiData = {
   response_type: '',
   meta: {
     count: 3,
+    cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50},
     legend: [
       {
         id: 1,

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -16,7 +16,7 @@ fetchMock.config.overwriteRoutes = true;
 const jobExplorerUrl = 'path:/api/tower-analytics/v1/roi_templates/';
 const dummyRoiData = {
   response_type: '',
-  cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50 },
+  cost: { hourly_automation_cost: 20, hourly_manual_labor_cost: 50 },
   meta: {
     count: 3,
     legend: [

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -28,6 +28,8 @@ const dummyRoiData = {
         total_org_count: 2,
         successful_hosts_total: 10,
         total_cluster_count: 20,
+        template_weigh_in: true,
+        manual_effort_minutes: 60,
       },
       {
         id: 2,
@@ -37,6 +39,8 @@ const dummyRoiData = {
         total_org_count: 2,
         successful_hosts_total: 10,
         total_cluster_count: 20,
+        template_weigh_in: true,
+        manual_effort_minutes: 60,
       },
       {
         id: 3,
@@ -46,6 +50,8 @@ const dummyRoiData = {
         total_org_count: 2,
         successful_hosts_total: 10,
         total_cluster_count: 20,
+        template_weigh_in: true,
+        manual_effort_minutes: 60,
       },
     ],
   },

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -18,7 +18,7 @@ const dummyRoiData = {
   response_type: '',
   meta: {
     count: 3,
-    cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50},
+    cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50 },
     legend: [
       {
         id: 1,
@@ -68,6 +68,13 @@ const jobExplorerOptions = {
       value: 'Template productivity score',
     },
   ],
+  meta: {
+    rbac: {
+      perms: {
+        all: true,
+      },
+    },
+  },
 };
 
 const inputManCost = (wrapper) => wrapper.find('input').at(0);
@@ -193,7 +200,14 @@ describe('Containers/CustomReports/AutomationCalculator', () => {
   });
 
   it('should render no data', async () => {
-    fetchMock.post({ url: jobExplorerUrl }, { items: [], meta: { count: 0 } });
+    fetchMock.post(
+      { url: jobExplorerUrl },
+      {
+        items: [],
+        meta: { count: 0 },
+        cost: { hourly_automation_cost: 50, hourly_manual_labor_cost: 25 },
+      }
+    );
 
     await act(async () => {
       wrapper = mountPage(AutomationCalculator, pageParams);

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -16,9 +16,9 @@ fetchMock.config.overwriteRoutes = true;
 const jobExplorerUrl = 'path:/api/tower-analytics/v1/roi_templates/';
 const dummyRoiData = {
   response_type: '',
+  cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50 },
   meta: {
     count: 3,
-    cost: { hourly_automation_cost: 25, hourly_manual_labor_cost: 50 },
     legend: [
       {
         id: 1,

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -173,25 +173,23 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     };
   };
 
-  const updateCalculationValues = (varName: string, value: number) => {
+  const updateCalculationValues = async (varName: string, value: number) => {
     const hourly_automation_cost =
       varName === 'automation_cost' ? value : costAutomation;
     const hourly_manual_labor_cost =
       varName === 'manual_cost' ? value : costManual;
-    const prom = saveROI(
-      getROISaveData(
-        api.result.items,
-        hourly_manual_labor_cost,
-        hourly_automation_cost
-      )
-    );
-    prom
-      .then(() =>
-        varName === 'manual_cost'
-          ? setCostManual(value)
-          : setCostAutomation(value)
-      )
-      .catch((err) => console.log(err));
+    try {
+      await saveROI(
+        getROISaveData(
+          api.result.items,
+          hourly_manual_labor_cost,
+          hourly_automation_cost
+        )
+      );
+    } catch (err) {
+      console.log(err);
+    }
+    varName === 'manual_cost' ? setCostManual(value) : setCostAutomation(value);
   };
 
   /**
@@ -199,7 +197,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
    * and updates all calculated fields.
    * Used in top templates.
    */
-  const setDataRunTime = (seconds, id) => {
+  const setDataRunTime = async (seconds, id) => {
     const updatedData = api.result.items.map((el) => {
       if (el.id === id) {
         el.avgRunTime = seconds;
@@ -213,18 +211,26 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         return el;
       }
     });
-    const prom = saveROI(getROISaveData(updatedData));
-    prom.then(() => setValue(updatedData)).catch((err) => console.log(err));
+    try {
+      await saveROI(getROISaveData(updatedData));
+    } catch (err) {
+      console.log(err);
+    }
+    setValue(updatedData);
   };
 
-  const setEnabled = (id) => (value) => {
+  const setEnabled = (id) => async (value) => {
     const updatedData = !id
       ? api.result.items.map((el) => ({ ...el, enabled: value }))
       : api.result.items.map((el) =>
           el.id === id ? { ...el, enabled: value } : el
         );
-    const prom = saveROI(getROISaveData(updatedData));
-    prom.then(() => setValue(updatedData)).catch((err) => console.log(err));
+    try {
+      await saveROI(getROISaveData(updatedData));
+    } catch (err) {
+      console.log(err);
+    }
+    setValue(updatedData);
   };
   const getSortParams = () => {
     const onSort = (_event, index, direction) => {

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -297,6 +297,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     return tooltip;
   };
 
+  const isReadOnly = (api) => {
+    return !!api.result.rbac?.perms?.read;
+  };
+
   const renderLeft = () => (
     <Card isPlain>
       <CardHeader>
@@ -360,6 +364,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
               costManual={costManual}
               setFromCalculation={updateCalculationValues}
               costAutomation={costAutomation}
+              readOnly={isReadOnly(api)}
             />
           </StackItem>
           <StackItem>
@@ -423,6 +428,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 setDataRunTime={setDataRunTime}
                 setEnabled={setEnabled}
                 getSortParams={getSortParams}
+                readOnly={isReadOnly(api)}
               />
             )}
           </GridItem>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -194,8 +194,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     } catch {
       dispatch(
         addNotification({
-          title: `Enable to save changes to ${humanVarName}.`,
-          description: `Enable to save changes ${humanVarName}. Please try again.`,
+          title: `Unable to save changes to ${humanVarName}.`,
+          description: `Unable to save changes ${humanVarName}. Please try again.`,
           variant: NotificationType.danger,
           autoDismiss: false,
         })
@@ -230,9 +230,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     } catch {
       dispatch(
         addNotification({
-          title: 'Enable to save changes to Manual time',
+          title: 'Unable to save changes to Manual time',
           description:
-            'Enable to save changes to Manual time. Please try again.',
+            'Unable to save changes to Manual time. Please try again.',
           variant: NotificationType.danger,
           autoDismiss: false,
         })
@@ -254,9 +254,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     } catch {
       dispatch(
         addNotification({
-          title: 'Enable to save changes to visibility',
+          title: 'Unable to save changes to visibility',
           description:
-            'Enable to save changes to visibility. Please try again.',
+            'Unable to save changes to visibility. Please try again.',
           variant: NotificationType.danger,
           autoDismiss: false,
         })

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -181,6 +181,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       varName === 'automation_cost' ? value : costAutomation;
     const hourly_manual_labor_cost =
       varName === 'manual_cost' ? value : costManual;
+    const humanVarName =
+      varName === 'automation_cost' ? 'Automation cost' : 'Manual cost';
     try {
       await saveROI(
         getROISaveData(
@@ -192,8 +194,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     } catch {
       dispatch(
         addNotification({
-          title: 'Enable to save changes',
-          description: 'Enable to save changes. Please try again.',
+          title: `Enable to save changes to ${humanVarName}.`,
+          description: `Enable to save changes ${humanVarName}. Please try again.`,
           variant: NotificationType.danger,
           autoDismiss: false,
         })
@@ -226,6 +228,15 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     try {
       await saveROI(getROISaveData(updatedData), dispatch);
     } catch {
+      dispatch(
+        addNotification({
+          title: 'Enable to save changes to Manual time',
+          description:
+            'Enable to save changes to Manual time. Please try again.',
+          variant: NotificationType.danger,
+          autoDismiss: false,
+        })
+      );
       // don't update inputs
       return;
     }
@@ -240,8 +251,18 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         );
     try {
       await saveROI(getROISaveData(updatedData));
-    } catch (err) {
-      console.log(err);
+    } catch {
+      dispatch(
+        addNotification({
+          title: 'Enable to save changes to visibility',
+          description:
+            'Enable to save changes to visibility. Please try again.',
+          variant: NotificationType.danger,
+          autoDismiss: false,
+        })
+      );
+      // don't update inputs
+      return;
     }
     setValue(updatedData);
   };

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -28,7 +28,6 @@ import { ExclamationTriangleIcon as ExclamationTriangleIcon } from '@patternfly/
 // Imports from custom components
 import FilterableToolbar from '../../../../Components/Toolbar';
 import Pagination from '../../../../Components/Pagination';
-
 // Imports from utilities
 import {
   useQueryParams,
@@ -59,6 +58,9 @@ import { AutmationCalculatorProps } from '../types';
 import hydrateSchema from '../../Shared/hydrateSchema';
 import currencyFormatter from '../../../../Utilities/currencyFormatter';
 import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { NotificationType } from '../../../../globalTypes';
 
 const SpinnerDiv = styled.div`
   height: 400px;
@@ -172,6 +174,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       templates_manual_equivalent: updatedDataApi,
     };
   };
+  const dispatch = useDispatch();
 
   const updateCalculationValues = async (varName: string, value: number) => {
     const hourly_automation_cost =
@@ -186,8 +189,17 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           hourly_automation_cost
         )
       );
-    } catch (err) {
-      console.log(err);
+    } catch {
+      dispatch(
+        addNotification({
+          title: 'Enable to save changes',
+          description: 'Enable to save changes. Please try again.',
+          variant: NotificationType.danger,
+          autoDismiss: false,
+        })
+      );
+      // don't update inputs
+      return;
     }
     varName === 'manual_cost' ? setCostManual(value) : setCostAutomation(value);
   };
@@ -212,9 +224,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       }
     });
     try {
-      await saveROI(getROISaveData(updatedData));
-    } catch (err) {
-      console.log(err);
+      await saveROI(getROISaveData(updatedData), dispatch);
+    } catch {
+      // don't update inputs
+      return;
     }
     setValue(updatedData);
   };

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -21,12 +21,14 @@ interface Props {
   costManual: number;
   setFromCalculation: (varName: string, value: number) => void;
   costAutomation: number;
+  readOnly: boolean;
 }
 
 const CalculationCost: FunctionComponent<Props> = ({
   costManual = 0,
   setFromCalculation = () => ({}),
   costAutomation = 0,
+  readOnly = true,
 }) => (
   <Card isPlain isCompact>
     <CardBody>
@@ -53,6 +55,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           aria-label="manual-cost"
           value={isNaN(costManual) ? '' : costManual.toString()}
           onChange={(e) => setFromCalculation('manual_cost', validFloat(+e))}
+          isDisabled={readOnly}
         />
         <InputGroupText>/hr</InputGroupText>
       </InputGroup>
@@ -70,6 +73,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           onChange={(e) =>
             setFromCalculation('automation_cost', validFloat(+e))
           }
+          isDisabled={readOnly}
         />
         <InputGroupText>/hr</InputGroupText>
       </InputGroup>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -24,6 +24,7 @@ interface Props {
   setDataRunTime: (delta: number, id: number) => void;
   setEnabled: (enabled: boolean) => void;
   redirectToJobExplorer: (id: number) => void;
+  readOnly: boolean;
 }
 
 const setLabeledValue = (key: string, value: number) => {
@@ -52,6 +53,7 @@ const Row: FunctionComponent<Props> = ({
   setDataRunTime,
   setEnabled,
   redirectToJobExplorer,
+  readOnly = true,
 }) => {
   const [isExpanded, setIsExpanded] = useState(
     window.localStorage.getItem(template.id.toString()) === 'true' || false
@@ -103,6 +105,7 @@ const Row: FunctionComponent<Props> = ({
                 );
                 setDataRunTime(+minutes * 60, template.id);
               }}
+              isDisabled={readOnly}
             />
             <InputGroupText>min</InputGroupText>
             <InputGroupText variant={InputGroupTextVariant.plain}>
@@ -119,6 +122,7 @@ const Row: FunctionComponent<Props> = ({
             labelOff="Hide"
             isChecked={template.enabled}
             onChange={(checked) => setEnabled(checked)}
+            isDisabled={readOnly}
           />
         </Td>
       </Tr>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -20,6 +20,7 @@ interface Props {
   setEnabled: (id: number | undefined) => (enabled: boolean) => void;
   redirectToJobExplorer: (id: number) => void;
   getSortParams?: () => TableSortParams;
+  readOnly: boolean;
 }
 
 const TopTemplates: FunctionComponent<Props> = ({
@@ -29,6 +30,7 @@ const TopTemplates: FunctionComponent<Props> = ({
   setEnabled = () => () => ({}),
   redirectToJobExplorer = () => ({}),
   getSortParams = () => ({}),
+  readOnly = true,
 }) => (
   <TableComposable aria-label="ROI Table" variant={TableVariant.compact}>
     <Thead>
@@ -44,6 +46,7 @@ const TopTemplates: FunctionComponent<Props> = ({
             labelOff="Show all"
             isChecked={!data.find((d) => !d.enabled)}
             onChange={(checked) => setEnabled(undefined)(checked)}
+            isDisabled={readOnly}
           />
         </Th>
       </Tr>
@@ -57,6 +60,7 @@ const TopTemplates: FunctionComponent<Props> = ({
           setDataRunTime={setDataRunTime}
           redirectToJobExplorer={redirectToJobExplorer}
           setEnabled={setEnabled(template.id)}
+          readOnly={readOnly}
         />
       ))}
     </Tbody>

--- a/src/QueryParams/__tests__/useQueryParams.test.js
+++ b/src/QueryParams/__tests__/useQueryParams.test.js
@@ -28,8 +28,6 @@ describe('QueryParams/useQueryParams', () => {
     expect(result.current.dispatch).toBeDefined();
     expect(result.current.setFromToolbar).toBeDefined();
     expect(result.current.setFromPagination).toBeDefined();
-    expect(result.current.setFromCalculation).toBeDefined();
-    expect(result.current.setFromTable).toBeDefined();
   });
 
   it('should set the attributes with single dispatch', () => {

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -101,26 +101,6 @@ const paramsReducer = (state, { type, value }) => {
       });
       return { ...state, ...newValues };
     }
-    case 'SET_CALCULATOR_MANUAL':
-      return {
-        ...state,
-        manual_cost: value,
-      };
-    case 'SET_CALCULATOR_AUTOMATION':
-      return {
-        ...state,
-        automation_cost: value,
-      };
-    case 'SET_ENABLED_PER_ITEM':
-      return {
-        ...state,
-        enabled_per_item: value,
-      };
-    case 'SET_TIME_PER_ITEM':
-      return {
-        ...state,
-        time_per_item: value,
-      };
     default:
       throw new Error(`The query params reducer action (${type}) not found.`);
   }
@@ -145,10 +125,6 @@ const actionMapper = {
   only_root_workflows_and_standalone_jobs: 'SET_ROOT_WORKFLOWS_AND_JOBS',
   inventory_id: 'SET_INVENTORY',
   granularity: 'SET_GRANULARITY',
-  manual_cost: 'SET_CALCULATOR_MANUAL',
-  automation_cost: 'SET_CALCULATOR_AUTOMATION',
-  enabled_per_item: 'SET_ENABLED_PER_ITEM',
-  time_per_item: 'SET_TIME_PER_ITEM',
 };
 
 const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
@@ -193,12 +169,6 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
       if (limit) {
         dispatch({ type: 'SET_LIMIT', value: limit });
       }
-    },
-    setFromTable: (varName, value) => {
-      dispatch({ type: actionMapper[varName], value: value });
-    },
-    setFromCalculation: (varName, value) => {
-      dispatch({ type: actionMapper[varName], value: value });
     },
     /* v0 api usage after this line */
     setSeverity: (severity) =>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-1007
Fixes https://issues.redhat.com/browse/AA-987 as well

- Values from calculation and table are no longer saved in params but to DB.

- Not using `useRequest` for saving the values to DB allows me not to reload components. But it goes against consistency of the code so it's up to discussion :)

- rbac check - a readonly user cannot edit inputs. See screenshot at the end

- moving hide/show logic from API (based on index) to DB (based on id) solves https://issues.redhat.com/browse/AA-987

TODO: 
- [x] rbac check
- [x] changes saved in DB
- [x] values read from api not default
- [x] removw extra code
- [x] Add alert when save fails
- [x] clean the code
- [x] refresh of the page not working

### RBAC for an user with only read rights
Before:
<img width="1325" alt="Screenshot 2022-02-04 at 13 34 53" src="https://user-images.githubusercontent.com/9210860/152530004-760455f6-e4d4-4e5a-93fb-e145b0472af8.png">

After:
<img width="1323" alt="Screenshot 2022-02-03 at 13 19 28" src="https://user-images.githubusercontent.com/9210860/152529899-0127e85b-9bd7-4c69-847f-be5627fbf4f4.png">

Error:
<img width="1636" alt="Screenshot 2022-02-17 at 12 19 34" src="https://user-images.githubusercontent.com/9210860/154474908-23cc65ad-8b39-4521-9c4d-4a1bc4df4eae.png">

