### PR TITLE
Update savings planner colors

### DIFF
--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/TotalSavings/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/TotalSavings/index.tsx
@@ -18,7 +18,9 @@ const TotalSavings: FunctionComponent<Props> = ({
       <Title
         headingLevel="h3"
         size="4xl"
-        style={{ color: isMoney ? '#81C46B' : '#0063CF' }}
+        style={{
+          color: isMoney ? 'var(--pf-global--success-color--200)' : '#0063CF',
+        }}
       >
         {isMoney ? `${currencyFormatter(value)}` : `${hoursFormatter(value)}`}
       </Title>

--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
@@ -99,7 +99,7 @@ const constants = (isMoney: boolean) => ({
   },
   benefit: {
     key: isMoney ? 'total_benefits' : 'total_hours_saved',
-    color: isMoney ? '#81C46B' : '#0063CF',
+    color: isMoney ? 'var(--pf-global--success-color--100)' : '#0063CF',
   },
   net: {
     key: isMoney ? 'cumulative_net_benefits' : 'cumulative_time_net_benefits',


### PR DESCRIPTION
Updated colors used for money-based savings in savings planner to be more consistent with ROI report and patternfly guidelines. 

Before: 
![Screen Shot 2022-02-07 at 3 32 03 PM](https://user-images.githubusercontent.com/89094075/152867233-1c9171d3-de90-424e-9e7b-fbe66d7b7ad0.png)

After:
![Screen Shot 2022-02-07 at 3 31 39 PM](https://user-images.githubusercontent.com/89094075/152867277-3b5ebcc7-a777-4aec-b02b-e5dc46e304c7.png) 