### PR TITLE
Removed initialParams, addInitialParams, removeInitialParams and their references

### DIFF
--- a/src/Containers/Clusters/Clusters.test.js
+++ b/src/Containers/Clusters/Clusters.test.js
@@ -23,9 +23,9 @@ describe('Containers/Clusters', () => {
     renderPage(Clusters);
 
     await waitFor(() => {
-      expect(api.readJobExplorer).toHaveBeenCalledTimes(6);
-      expect(api.readClustersOptions).toHaveBeenCalledTimes(2);
-      expect(api.readEventExplorer).toHaveBeenCalledTimes(2);
+      expect(api.readJobExplorer).toHaveBeenCalledTimes(3);
+      expect(api.readClustersOptions).toHaveBeenCalledTimes(1);
+      expect(api.readEventExplorer).toHaveBeenCalledTimes(1);
     });
 
     expect(screen.getAllByText(/Clusters/i));

--- a/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.test.js
+++ b/src/Containers/SavingsPlanner/Shared/Form/Steps/Templates/index.test.js
@@ -31,7 +31,7 @@ describe('SavingsPlanner/Shared/Form/Templates', () => {
     });
     renderPage(Templates, undefined, defaultProps);
 
-    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(1));
 
     expect(screen.getByText('No results found')).toBeTruthy();
   });
@@ -39,7 +39,7 @@ describe('SavingsPlanner/Shared/Form/Templates', () => {
   test('has rendered Templates component with data and is clickable', async () => {
     renderPage(Templates, undefined, defaultProps);
 
-    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.readJobExplorer).toHaveBeenCalledTimes(1));
 
     expect(screen.getByText('Link a template to this plan:')).toBeTruthy();
 

--- a/src/QueryParams/Context.ts
+++ b/src/QueryParams/Context.ts
@@ -3,10 +3,7 @@ import { ContextProps } from './types';
 
 export const QueryParamsContext = createContext<ContextProps>({
   queryParams: {},
-  initialParams: {},
   update: () => null,
-  addInitialParams: () => null,
-  removeInitialParams: () => null,
   redirectWithQueryParams: () => null,
 });
 export const QueryParamsProvider = QueryParamsContext.Provider;

--- a/src/QueryParams/Provider.tsx
+++ b/src/QueryParams/Provider.tsx
@@ -7,11 +7,7 @@ import {
   DEFAULT_NAMESPACE,
 } from './helpers';
 import redirectWithQueryParams from './redirectWithQueryParams';
-import {
-  InitialParamsFunction,
-  NamespacedQueryParams,
-  UpdateFunction,
-} from './types';
+import { NamespacedQueryParams, UpdateFunction } from './types';
 
 interface Props {
   children: React.ReactNode;
@@ -20,7 +16,6 @@ interface Props {
 const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
   const history = useHistory();
   const [queryParams, setQueryParams] = useState<NamespacedQueryParams>({});
-  const [initialParams, setInitialParams] = useState<NamespacedQueryParams>({});
 
   useEffect(() => {
     if (history.location.search.length > 0) {
@@ -48,40 +43,11 @@ const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
     setQsInUrl(q, history);
   };
 
-  const addInitialParams: InitialParamsFunction = ({
-    params,
-    namespace = DEFAULT_NAMESPACE,
-  }) => {
-    setInitialParams({
-      ...initialParams,
-      [namespace]: {
-        ...initialParams[namespace],
-        ...params,
-      },
-    });
-  };
-
-  const removeInitialParams: InitialParamsFunction = ({
-    params,
-    namespace = DEFAULT_NAMESPACE,
-  }) => {
-    const newParams = { ...initialParams[namespace] };
-    Object.keys(params).forEach((e) => delete newParams[e]);
-
-    setInitialParams({
-      ...initialParams,
-      [namespace]: newParams,
-    });
-  };
-
   return (
     <Provider
       value={{
         queryParams,
-        initialParams,
         update,
-        addInitialParams,
-        removeInitialParams,
         redirectWithQueryParams: redirectWithQueryParams(history),
       }}
     >

--- a/src/QueryParams/types.ts
+++ b/src/QueryParams/types.ts
@@ -12,14 +12,6 @@ export type UpdateFunction = ({
   namespace: string;
 }) => void;
 
-export type InitialParamsFunction = ({
-  params,
-  namespace,
-}: {
-  params: QueryParams;
-  namespace: string;
-}) => void;
-
 export type RedirectWithQueryParamsProps = (
   path: string,
   queryParams: NamespacedQueryParams | undefined
@@ -27,9 +19,6 @@ export type RedirectWithQueryParamsProps = (
 
 export interface ContextProps {
   queryParams: NamespacedQueryParams;
-  initialParams: NamespacedQueryParams;
   update: UpdateFunction;
-  addInitialParams: InitialParamsFunction;
-  removeInitialParams: InitialParamsFunction;
   redirectWithQueryParams: RedirectWithQueryParamsProps;
 }

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import moment from 'moment';
 import { QueryParamsContext } from './Context';
 import useAsyncActionQueue from '../Utilities/useAsyncActionQueue';
@@ -152,33 +152,9 @@ const actionMapper = {
 };
 
 const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
-  const {
-    queryParams,
-    initialParams,
-    update,
-    addInitialParams,
-    removeInitialParams,
-  } = useContext(QueryParamsContext);
+  const { queryParams, update } = useContext(QueryParamsContext);
 
-  /**
-   * When first initializing the hook there may be no namespace for it
-   * (before the first useEffect[]), so we pass the initial params passed
-   * to the hook.
-   *
-   * If the initialProps are there already we use them until there is no qp
-   * avaiable for the namespace.
-   *
-   * If we alreadt have the initialized namespace in the URL then we use it.
-   */
-  const params = queryParams[namespace] || initialParams[namespace] || initial;
-
-  useEffect(() => {
-    addInitialParams({ params: initial, namespace });
-
-    return () => {
-      removeInitialParams({ namespace });
-    };
-  }, []);
+  const params = queryParams[namespace] || initial;
 
   const executeAction = (action) => {
     if (action.type === 'RESET_FILTER') {

--- a/src/QueryParams/useReadQueryParams.ts
+++ b/src/QueryParams/useReadQueryParams.ts
@@ -7,11 +7,9 @@ const useReadQueryParams = <T extends QueryParams>(
   initial: T,
   namespace = DEFAULT_NAMESPACE
 ): T => {
-  const { queryParams, initialParams } = useContext(QueryParamsContext);
+  const { queryParams } = useContext(QueryParamsContext);
 
-  return (
-    (queryParams[namespace] as T) || (initialParams[namespace] as T) || initial
-  );
+  return (queryParams[namespace] as T) || initial;
 };
 
 export default useReadQueryParams;


### PR DESCRIPTION

initialParams was stepping on initial default params, when clicking on links fast before previously clicked link screen was loaded.

https://issues.redhat.com/browse/AA-1013