### PR TITLE
AA-1015-Pipeline-upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "webpack-cli": "^4.6.0"
   },
   "scripts": {
-    "test": "jest --verbose",
+    "test": "TZ=UTC jest --verbose --no-cache",
     "test:watch": "jest --coverage=false --watch",
     "integration": "cypress open",
     "integration:headless": "cypress run --browser=chrome",


### PR DESCRIPTION
Pacakge Json
Before proceeding, we’ll need to turn off the cache for jest. To do this, add the following line to your package.json, or update your existing jest entry to match the following.

https://consoledot.pages.redhat.com/docs/dev/getting-started/frontend-migration.html#_pr_check_and_build_deploy

