### PR TITLE
Add missing chartType if not defined in params

### DIFF
--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -108,7 +108,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
       options.sort_options?.find(({ key }) => key === queryParams.sort_options)
         ?.value || 'Label Y',
     xTickFormat: getDateFormatByGranularity(queryParams.granularity),
-    chartType: settingsQueryParams.chartType,
+    chartType: settingsQueryParams.chartType || 'line',
   };
 
   const getSortParams = (currKey: string) => {


### PR DESCRIPTION
This is more of a monkey patch and proper investigation how the error happend should be done

Go to Reports -> select `Hosts changed by job template` -> change visibility of any item in legend

Before:
`chrome-root.5d08171132d65412fc00.js:2 Error: Minified React error #130; visit http://reactjs.org/docs/error-decoder.html?invariant=130&args[]=undefined&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
<img width="1010" alt="Screenshot 2022-02-22 at 14 50 16" src="https://user-images.githubusercontent.com/9210860/155145653-761963c4-0223-4eef-bd3a-e5882dfa3d09.png">

After:
<img width="1362" alt="Screenshot 2022-02-22 at 14 49 41" src="https://user-images.githubusercontent.com/9210860/155145503-dede7660-cfae-406d-acf8-425d7c59701b.png">

