### PR TITLE
Fix RBAC check

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -361,7 +361,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   };
 
   const isReadOnly = (api) => {
-    return !!api.result.rbac?.perms?.read;
+    return !api.result.rbac?.perms?.all && !api.result.rbac?.perms?.write;
   };
 
   const renderLeft = () => (


### PR DESCRIPTION
RBAC can return {write:true} or {all:true}. In both case inputs are enabled in ROI report