### PR TITLE
Make rounding of values in the table same as in the chart

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -42,7 +42,7 @@ const setLabeledValue = (key: string, value: number) => {
       label = currencyFormatter(value);
       break;
     default:
-      label = value;
+      label = (+value).toFixed(2);
   }
   return label;
 };


### PR DESCRIPTION
Before:
<img width="841" alt="Screenshot 2022-02-22 at 16 17 17" src="https://user-images.githubusercontent.com/9210860/155162438-3b7e68cf-1815-4a71-9808-80308ef7aef6.png">

After:
<img width="823" alt="Screenshot 2022-02-22 at 16 15 46" src="https://user-images.githubusercontent.com/9210860/155162196-38fb0255-4856-4f23-b283-35bc9c6adfba.png">

