### PR TITLE
[WIP] Fix Cypress failure

### DIFF
--- a/cypress/integration/Dashboard.spec.js
+++ b/cypress/integration/Dashboard.spec.js
@@ -374,7 +374,7 @@ describe('Dashboard page drilldown tests', () => {
     const twoMonthssAgo = moment(new Date().toISOString())
       .subtract(61, 'day')
       .format('M/D');
-
+    cy.intercept('/job_explorer/*').as('jobExplorer');
     // Filter by Job Type
     cy.get('button[class="pf-c-select__toggle"]').eq(0).click();
     cy.get('button[class*="pf-c-select__menu-item"]').contains('Job').click();
@@ -401,6 +401,7 @@ describe('Dashboard page drilldown tests', () => {
     // Filter by Date range
     cy.get('div[data-cy="quick_date_range"]').click();
     cy.get('.pf-c-select__menu-item').contains('Past 62 days').click();
+    cy.wait('@jobExplorer');
     cy.get('#d3-bar-chart-root > svg')
       .find('.x-axis')
       .find('g')


### PR DESCRIPTION
Error:
```
Timed out retrying after 10000ms: Expected to find content: '12/18' within the element: [ <g.tick>, 14 more... ] but never did.

[cypress/integration/Dashboard.spec.jsat line411](https://github.com/RedHatInsights/tower-analytics-frontend/blob/9d709d4bb78eb4dbcccdc1d04f97d19b993ff910/cypress/integration/Dashboard.spec.js#L411)
  409 |       .find('.x-axis')
  410 |       .find('g')
> 411 |       .contains(twoMonthssAgo);
```