### PR TITLE
[AA-1038] Add automationCost and manualCost to PDF button

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -25,7 +25,7 @@ export interface PDFParams {
   schemaParams: Record<string, string>;
   dataFetchingParams: {
     endpointUrl: string;
-    queryParams: Params;
+    queryParams: Params | any;
     selectOptions: OptionsReturnType;
     showExtraRows: boolean;
     chartSeriesHiddenProps: boolean[];

--- a/src/Components/Toolbar/DownloadPdfButton.tsx
+++ b/src/Components/Toolbar/DownloadPdfButton.tsx
@@ -56,6 +56,7 @@ interface Props {
   startDate: string;
   endDate: string;
   dateRange: string;
+  inputs?: { automationCost: number; manualCost: number };
 }
 
 interface RbacGroupsDataType {
@@ -88,6 +89,7 @@ const DownloadPdfButton: FC<Props> = ({
   startDate,
   endDate,
   dateRange,
+  inputs,
 }) => {
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [downloadType, setDownloadType] = useState('current');
@@ -178,6 +180,7 @@ const DownloadPdfButton: FC<Props> = ({
   useEffect(() => {
     if (selectedRbacGroups.length > 0) updateEmailInfo();
   }, [principalsFromApi]);
+  const allParams = inputs ? { ...queryParams, inputs } : queryParams;
 
   const downloadPdf = () => {
     // Don't allow user to span download button
@@ -197,7 +200,7 @@ const DownloadPdfButton: FC<Props> = ({
           dataFetchingParams: {
             showExtraRows: downloadType === 'extra_rows',
             endpointUrl,
-            queryParams,
+            queryParams: allParams,
             selectOptions,
             chartSeriesHiddenProps,
             sortOptions,

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -482,6 +482,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 startDate={queryParams.start_date}
                 endDate={queryParams.end_date}
                 dateRange={queryParams.quick_date_range}
+                inputs={{ costManual, costAutomation }}
               />
             ),
           ]}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-1038

Depends on https://gitlab.cee.redhat.com/automation-analytics/pdf-generator/-/merge_requests/83

Steps to reproduce:
* Change the followings: Automation/Manual cost, Manual time and Visibility to different value from default
* Click download button
* see the PDF

Before: 

Automation/Manual cost was hardcoded to 20/50 Manual time was hardcoded to 60 minutes Visibility of all items was hardcoded to true

After: 

Automation/Manual cost, Manual time and Visibility of all items is same as in the UI