### PR TITLE
Changed email recipient to use username instead of email

### DIFF
--- a/src/Components/Toolbar/DownloadPdfButton.tsx
+++ b/src/Components/Toolbar/DownloadPdfButton.tsx
@@ -160,7 +160,7 @@ const DownloadPdfButton: FC<Props> = ({
   };
 
   const updateEmailInfo = () => {
-    const usersList = principalsFromApi.map((user) => user.email);
+    const usersList = principalsFromApi.map((user) => user.username);
 
     const lastSelectedRbacGroup = selectedRbacGroups.at(-1) as string;
     const userHash = {


### PR DESCRIPTION
This should fix an issue with BOP not being able to send emails to some email ids that have username associated with them with different email id as username value.