### PR TITLE
[AA-1075] Report preview UX fixes

### DIFF
--- a/src/Components/ApiStatus/LoadingState.tsx
+++ b/src/Components/ApiStatus/LoadingState.tsx
@@ -9,7 +9,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 const LoadingState: FunctionComponent<Record<string, never>> = () => (
-  <EmptyState variant={EmptyStateVariant.full}>
+  <EmptyState variant={EmptyStateVariant.full} style={{ minHeight: '400px' }}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
       Loading...

--- a/src/Components/ApiStatus/NoData.tsx
+++ b/src/Components/ApiStatus/NoData.tsx
@@ -8,7 +8,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 const NoData: FunctionComponent<Record<string, never>> = () => (
-  <EmptyState variant={EmptyStateVariant.full}>
+  <EmptyState variant={EmptyStateVariant.full} style={{ minHeight: '400px' }}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
       No Data

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -437,15 +437,15 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     </Stack>
   );
 
-  const renderContents = () => (
-    <Card>
-      <CardBody>
-        <FilterableToolbar
-          categories={options}
-          filters={queryParams}
-          setFilters={setFromToolbar}
-          pagination={
-            fullCard && (
+  const renderContents = () =>
+    fullCard ? (
+      <Card>
+        <CardBody>
+          <FilterableToolbar
+            categories={options}
+            filters={queryParams}
+            setFilters={setFromToolbar}
+            pagination={
               <Pagination
                 count={api.result.meta.count}
                 perPageOptions={perPageOptions}
@@ -456,10 +456,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 setPagination={setFromPagination}
                 isCompact
               />
-            )
-          }
-          additionalControls={[
-            fullCard && (
+            }
+            additionalControls={[
               <DownloadPdfButton
                 key="download-button"
                 slug={slug}
@@ -479,14 +477,12 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 endDate={queryParams.end_date}
                 dateRange={queryParams.quick_date_range}
                 inputs={{ costManual, costAutomation }}
-              />
-            ),
-          ]}
-        />
-        <Grid hasGutter>
-          <GridItem span={9}>{renderLeft()}</GridItem>
-          <GridItem span={3}>{renderRight()}</GridItem>
-          {fullCard && (
+              />,
+            ]}
+          />
+          <Grid hasGutter>
+            <GridItem span={9}>{renderLeft()}</GridItem>
+            <GridItem span={3}>{renderRight()}</GridItem>
             <GridItem span={12}>
               <p>
                 Enter the time it takes to run the following templates manually.
@@ -507,11 +503,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 />
               )}
             </GridItem>
-          )}
-        </Grid>
-      </CardBody>
-      <CardFooter>
-        {fullCard && (
+          </Grid>
+        </CardBody>
+        <CardFooter>
           <Pagination
             count={api.result.meta.count}
             perPageOptions={perPageOptions}
@@ -522,10 +516,21 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
             setPagination={setFromPagination}
             variant={PaginationVariant.bottom}
           />
-        )}
-      </CardFooter>
-    </Card>
-  );
+        </CardFooter>
+      </Card>
+    ) : (
+      <>
+        <FilterableToolbar
+          categories={options}
+          filters={queryParams}
+          setFilters={setFromToolbar}
+        />
+        <Grid hasGutter>
+          <GridItem span={9}>{renderLeft()}</GridItem>
+          <GridItem span={3}>{renderRight()}</GridItem>
+        </Grid>
+      </>
+    );
   return (
     <ApiStatusWrapper api={api} customLoading={true}>
       {renderContents()}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -369,49 +369,45 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
 
   const renderLeft = () => (
     <Card isPlain>
-      <CardHeader>
-        <CardTitle>Automation savings</CardTitle>
-      </CardHeader>
-      <CardBody>
-        {api.isLoading ? (
-          <SpinnerDiv>
-            <Spinner isSVG />
-          </SpinnerDiv>
-        ) : filterDisabled(api?.result?.items).length > 0 ? (
-          <Chart
-            schema={hydrateSchema(schema)({
-              label: chartParams.label,
-              tooltip: chartParams.tooltip,
-              field: chartParams.field,
-            })}
-            data={{
-              items: filterDisabled(api.result.items),
-            }}
-            specificFunctions={{
-              labelFormat: {
-                customTooltipFormatting,
-              },
-            }}
-          />
-        ) : (
-          <EmptyState>
-            <EmptyStateIcon icon={ExclamationTriangleIcon} />
-            <Title headingLevel="h4" size="lg">
-              You have disabled all views
-            </Title>
-            <EmptyStateBody>
-              Enable individual views in the table below or press Show all
-              button.
-            </EmptyStateBody>
-            <Button
-              variant="primary"
-              onClick={() => setEnabled(undefined)(true)}
-            >
-              Show all
-            </Button>
-          </EmptyState>
-        )}
-      </CardBody>
+      {fullCard && (
+        <CardHeader>
+          <CardTitle>Automation savings</CardTitle>
+        </CardHeader>
+      )}
+      {api.isLoading ? (
+        <SpinnerDiv>
+          <Spinner isSVG />
+        </SpinnerDiv>
+      ) : filterDisabled(api?.result?.items).length > 0 ? (
+        <Chart
+          schema={hydrateSchema(schema)({
+            label: chartParams.label,
+            tooltip: chartParams.tooltip,
+            field: chartParams.field,
+          })}
+          data={{
+            items: filterDisabled(api.result.items),
+          }}
+          specificFunctions={{
+            labelFormat: {
+              customTooltipFormatting,
+            },
+          }}
+        />
+      ) : (
+        <EmptyState>
+          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <Title headingLevel="h4" size="lg">
+            You have disabled all views
+          </Title>
+          <EmptyStateBody>
+            Enable individual views in the table below or press Show all button.
+          </EmptyStateBody>
+          <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
+            Show all
+          </Button>
+        </EmptyState>
+      )}
     </Card>
   );
 

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -182,7 +182,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
       dateRange={queryParams.quick_date_range}
     />,
   ];
-  return (
+  return fullCard ? (
     <Card>
       <CardBody>
         <FilterableToolbar
@@ -191,20 +191,18 @@ const ReportCard: FunctionComponent<StandardProps> = ({
           filters={queryParams}
           setFilters={setFromToolbar}
           pagination={
-            fullCard && (
-              <Pagination
-                count={dataApi.result.meta.count}
-                perPageOptions={perPageOptions}
-                params={{
-                  limit: +queryParams.limit,
-                  offset: +queryParams.offset,
-                }}
-                setPagination={setFromPagination}
-                isCompact
-              />
-            )
+            <Pagination
+              count={dataApi.result.meta.count}
+              perPageOptions={perPageOptions}
+              params={{
+                limit: +queryParams.limit,
+                offset: +queryParams.offset,
+              }}
+              setPagination={setFromPagination}
+              isCompact
+            />
           }
-          {...(fullCard && (additionalControls = { additionalControls }))}
+          additionalControls={additionalControls}
         />
         {tableHeaders && (
           <ApiStatusWrapper api={dataApi}>
@@ -217,32 +215,50 @@ const ReportCard: FunctionComponent<StandardProps> = ({
               })}
               data={dataApi.result}
             />
-            {fullCard && (
-              <Table
-                legend={dataApi.result.meta.legend}
-                headers={tableHeaders}
-                getSortParams={getSortParams}
-                expandedRowName={expandedTableRowName}
-              />
-            )}
+            <Table
+              legend={dataApi.result.meta.legend}
+              headers={tableHeaders}
+              getSortParams={getSortParams}
+              expandedRowName={expandedTableRowName}
+            />
           </ApiStatusWrapper>
         )}
       </CardBody>
       <CardFooter>
-        {fullCard && (
-          <Pagination
-            count={dataApi.result.meta.count}
-            perPageOptions={perPageOptions}
-            params={{
-              limit: +queryParams.limit,
-              offset: +queryParams.offset,
-            }}
-            setPagination={setFromPagination}
-            variant={PaginationVariant.bottom}
-          />
-        )}
+        <Pagination
+          count={dataApi.result.meta.count}
+          perPageOptions={perPageOptions}
+          params={{
+            limit: +queryParams.limit,
+            offset: +queryParams.offset,
+          }}
+          setPagination={setFromPagination}
+          variant={PaginationVariant.bottom}
+        />
       </CardFooter>
     </Card>
+  ) : (
+    <>
+      <FilterableToolbar
+        categories={options}
+        defaultSelected={defaultSelectedToolbarCategory}
+        filters={queryParams}
+        setFilters={setFromToolbar}
+      />
+      {tableHeaders && (
+        <ApiStatusWrapper api={dataApi}>
+          <Chart
+            schema={hydrateSchema(schema)({
+              label: chartParams.label,
+              y: chartParams.y,
+              xTickFormat: chartParams.xTickFormat,
+              chartType: chartParams.chartType,
+            })}
+            data={dataApi.result}
+          />
+        </ApiStatusWrapper>
+      )}
+    </>
   );
 };
 

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -10,10 +10,10 @@ import {
   ButtonVariant,
   Card,
   CardActions,
-  CardBody,
   CardFooter,
   CardHeader,
   CardTitle,
+  Divider,
   Dropdown,
   DropdownItem,
   DropdownToggle,
@@ -82,7 +82,11 @@ const List: FunctionComponent<Record<string, never>> = () => {
                     isCompact
                   >
                     <CardHeader
-                      style={{ paddingTop: '15px', paddingBottom: '0px' }}
+                      style={{
+                        paddingTop: '16px',
+                        paddingBottom: '16px',
+                        paddingRight: '0px',
+                      }}
                     >
                       <CardTitle>
                         <Link to={paths.getDetails(report.layoutProps.slug)}>
@@ -90,7 +94,7 @@ const List: FunctionComponent<Record<string, never>> = () => {
                         </Link>
                       </CardTitle>
                       <CardActions
-                        style={{ marginLeft: '15px', marginTop: '-3px' }}
+                        style={{ marginLeft: '15px', marginTop: '-2px' }}
                       >
                         {report.layoutProps.tags.map((tagKey, idx) => {
                           const tag = TAGS.find((t) => t.key === tagKey);
@@ -147,12 +151,9 @@ const List: FunctionComponent<Record<string, never>> = () => {
                         </Button>
                       </CardActions>
                     </CardHeader>
-                    <CardBody
-                      style={{ paddingTop: '15px', paddingBottom: '15px' }}
-                    >
-                      {getComponent(report, false)}
-                    </CardBody>
-                    <CardFooter style={{ paddingBottom: '15px' }}>
+                    <Divider />
+                    {getComponent(report, false)}
+                    <CardFooter style={{ paddingBottom: '16px' }}>
                       <Link
                         to={paths.getDetails(report.layoutProps.slug)}
                         style={{ float: 'right' }}

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -73,9 +73,40 @@ const List: FunctionComponent<Record<string, never>> = () => {
                 (previousItem = getAllReports()[index - 1].layoutProps.slug),
               (
                 <>
-                  <Card key="all_reports" isLarge style={{ maxWidth: '100%' }}>
-                    <CardHeader>
-                      <CardTitle>All Reports</CardTitle>
+                  <Card
+                    key={report.layoutProps.slug}
+                    style={{
+                      maxWidth: '100%',
+                      marginBottom: '25px',
+                    }}
+                    isCompact
+                  >
+                    <CardHeader
+                      style={{ paddingTop: '15px', paddingBottom: '0px' }}
+                    >
+                      <CardTitle>
+                        <Link to={paths.getDetails(report.layoutProps.slug)}>
+                          {report.layoutProps.name}
+                        </Link>
+                      </CardTitle>
+                      <CardActions
+                        style={{ marginLeft: '15px', marginTop: '-3px' }}
+                      >
+                        {report.layoutProps.tags.map((tagKey, idx) => {
+                          const tag = TAGS.find((t) => t.key === tagKey);
+                          if (tag) {
+                            return (
+                              <Tooltip
+                                key={`tooltip_${idx}`}
+                                position={TooltipPosition.top}
+                                content={tag.description}
+                              >
+                                <Label key={idx}>{tag.name}</Label>
+                              </Tooltip>
+                            );
+                          }
+                        })}
+                      </CardActions>
                       <CardActions>
                         <Button
                           variant={ButtonVariant.plain}
@@ -116,38 +147,12 @@ const List: FunctionComponent<Record<string, never>> = () => {
                         </Button>
                       </CardActions>
                     </CardHeader>
-                  </Card>
-                  <Card
-                    key={report.layoutProps.slug}
-                    style={{ maxWidth: '100%', marginBottom: '25px' }}
-                  >
-                    <CardHeader>
-                      <CardTitle>
-                        <Link to={paths.getDetails(report.layoutProps.slug)}>
-                          {report.layoutProps.name}
-                        </Link>
-                      </CardTitle>
-                      <CardActions>
-                        {report.layoutProps.tags.map((tagKey, idx) => {
-                          const tag = TAGS.find((t) => t.key === tagKey);
-                          if (tag) {
-                            return (
-                              <Tooltip
-                                key={`tooltip_${idx}`}
-                                position={TooltipPosition.top}
-                                content={tag.description}
-                              >
-                                <Label key={idx}>{tag.name}</Label>
-                              </Tooltip>
-                            );
-                          }
-                        })}
-                      </CardActions>
-                    </CardHeader>
-
-                    <CardBody>{report.layoutProps.description}</CardBody>
-                    <CardBody>{getComponent(report, false)}</CardBody>
-                    <CardFooter>
+                    <CardBody
+                      style={{ paddingTop: '15px', paddingBottom: '15px' }}
+                    >
+                      {getComponent(report, false)}
+                    </CardBody>
+                    <CardFooter style={{ paddingBottom: '15px' }}>
                       <Link
                         to={paths.getDetails(report.layoutProps.slug)}
                         style={{ float: 'right' }}

--- a/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
+++ b/src/Containers/Reports/Shared/schemas/hostsByOrganizations.ts
@@ -42,7 +42,7 @@ const defaultParams = {
   quick_date_range: 'last_30_days',
   status: [],
   org_id: [],
-  job_type: ['workflowjob', 'job'],
+  job_type: [],
   cluster_id: [],
   template_id: [],
   inventory_id: [],

--- a/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
+++ b/src/Containers/Reports/Shared/schemas/jobsTasksByOrganization.ts
@@ -40,7 +40,7 @@ const defaultParams = {
   quick_date_range: 'last_30_days',
   status: [],
   org_id: [],
-  job_type: ['workflowjob', 'job'],
+  job_type: [],
   cluster_id: [],
   template_id: [],
   inventory_id: [],


### PR DESCRIPTION
Condensed and standardized the height of the preview pane for all reports. 

Jira issue: https://issues.redhat.com/browse/AA-1075

Before: 
<img width="1207" alt="Screen Shot 2022-03-22 at 5 18 37 PM" src="https://user-images.githubusercontent.com/89094075/159577845-03c8b79d-543f-47d9-8518-d420ccc49127.png">

After: 
<img width="1208" alt="Screen Shot 2022-03-23 at 3 01 56 PM" src="https://user-images.githubusercontent.com/89094075/159778538-a616f2e7-263b-453f-87ae-c2466a66f99e.png">
