### PR TITLE
Side nav changes

### DIFF
--- a/config/ansible-navigation.json
+++ b/config/ansible-navigation.json
@@ -100,24 +100,6 @@
             "title": "Operations Insights",
             "navItems": [
                 {
-                    "appId": "automationAnalytics",
-                    "title": "Organization Statistics",
-                    "href": "/ansible/insights/organization-statistics",
-                    "product": "Ansible Automation Analytics"
-                },
-                {
-                    "appId": "automationAnalytics",
-                    "title": "Job Explorer",
-                    "href": "/ansible/insights/job-explorer",
-                    "product": "Ansible Automation Analytics"
-                },
-                {
-                    "appId": "automationAnalytics",
-                    "title": "Clusters",
-                    "href": "/ansible/insights/clusters",
-                    "product": "Ansible Automation Analytics"
-                },
-                {
                     "title": "Advisor",
                     "expandable": true,
                     "routes": [
@@ -180,34 +162,57 @@
             ]
         },
         {
-            "groupId": "business",
-            "icon": "trend-up",
-            "title": "Business Insights",
-            "navItems": [
+            "title": "Automation Analytics",
+            "expandable": true,
+            "routes": [
+                {
+                    "appId": "automationAnalytics",
+                    "title": "Organization Statistics",
+                    "href": "/ansible/automation-analytics/organization-statistics",
+                    "product": "Ansible Automation Analytics"
+                },
+                {
+                    "appId": "automationAnalytics",
+                    "title": "Job Explorer",
+                    "href": "/ansible/automation-analytics/job-explorer",
+                    "product": "Ansible Automation Analytics"
+                },
+                {
+                    "appId": "automationAnalytics",
+                    "title": "Clusters",
+                    "href": "/ansible/automation-analytics/clusters",
+                    "product": "Ansible Automation Analytics"
+                },
                 {
                     "appId": "automationAnalytics",
                     "title": "Reports",
-                    "href": "/ansible/insights/reports",
+                    "href": "/ansible/automation-analytics/reports",
                     "product": "Ansible Automation Analytics"
                 },
                 {
                     "appId": "automationAnalytics",
                     "title": "Savings Planner",
-                    "href": "/ansible/insights/savings-planner",
+                    "href": "/ansible/automation-analytics/savings-planner",
                     "product": "Ansible Automation Analytics"
                 },
                 {
                     "appId": "automationAnalytics",
                     "title": "Automation Calculator",
-                    "href": "/ansible/insights/reports/automation_calculator/",
+                    "href": "/ansible/automation-analytics/reports/automation_calculator/",
                     "product": "Ansible Automation Analytics"
                 },
                 {
                     "appId": "automationAnalytics",
                     "title": "Notifications",
-                    "href": "/ansible/insights/notifications",
+                    "href": "/ansible/automation-analytics/notifications",
                     "product": "Ansible Automation Analytics"
-                },
+                }
+            ]},
+        {
+            "groupId": "business",
+            "icon": "trend-up",
+            "title": "Business Insights",
+            "navItems": [
                 {
                     "appId": "registration",
                     "title": "Register Systems",

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -19,6 +19,7 @@ const ephId = process.env.npm_config_eph_id ?? '1';
 const environmentSetup = {
   ...(env === 'standalone' && {
     https: false,
+    env: 'stage-beta',
     standalone: {
       apiAnalytics: {
         context: ['/api/tower-analytics'],
@@ -54,7 +55,10 @@ const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
   sassPrefix: '.automation-analytics, .automationAnalytics',
-  appUrl: ['/beta/ansible/insights/', '/ansible/insights/'],
+  appUrl: [
+    '/beta/ansible/automation-analytics/',
+    '/ansible/automation-analytics/',
+  ],
   deployment: 'beta/apps',
   ...environmentSetup,
 });

--- a/profiles/local-frontend-and-api.js
+++ b/profiles/local-frontend-and-api.js
@@ -5,8 +5,10 @@ const routes = {};
 
 routes[`/beta/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
 routes[`/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/ansible/insights`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/beta/ansible/insights`] = {
+routes[`/ansible/automation-analytics`] = {
+  host: `https://localhost:${FRONTEND_PORT}`,
+};
+routes[`/beta/ansible/automation-analytics`] = {
   host: `https://localhost:${FRONTEND_PORT}`,
 };
 routes[`/beta/config/main.yml`] = { host: `http://localhost:8889` };

--- a/profiles/local-frontend.js
+++ b/profiles/local-frontend.js
@@ -4,8 +4,10 @@ const routes = {};
 
 routes[`/beta/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
 routes[`/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/ansible/insights`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/beta/ansible/insights`] = {
+routes[`/ansible/automation-analytics`] = {
+  host: `https://localhost:${FRONTEND_PORT}`,
+};
+routes[`/beta/ansible/automation-analytics`] = {
   host: `https://localhost:${FRONTEND_PORT}`,
 };
 


### PR DESCRIPTION
- Move our apps in a collapsible “Automation Analytics” section
- changed our urls from ansible/insights/ to ansible/automation-analytics

https://issues.redhat.com/browse/AA-1114

@ryelo @Hyperkid123 this is a PR for standalone environment to go with cloud services PR https://github.com/RedHatInsights/cloud-services-config/pull/1097
For some reason the link does not work for me locally at the moment http://localhost:1337/beta/ansible/automation-analytics/reports/ can you help me figure out what is missing in my PR.