### PR TITLE
Export wizard fix

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -30,6 +30,7 @@ export interface PDFParams {
     showExtraRows: boolean;
     chartSeriesHiddenProps: boolean[];
     totalPages: number;
+    pageLimit: number;
     sortOptions: string;
     sortOrder: 'asc' | 'desc';
     dateGranularity: string;
@@ -50,6 +51,7 @@ export interface PDFEmailParams {
     showExtraRows: boolean;
     chartSeriesHiddenProps: boolean[];
     totalPages: number;
+    pageLimit: number;
     sortOptions: string;
     sortOrder: 'asc' | 'desc';
     dateGranularity: string;

--- a/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/index.test.js
+++ b/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/index.test.js
@@ -30,6 +30,7 @@ const mockOptions = {
   xTickFormat: 'xTickFormat',
   chartType: 'bar',
   totalPages: '3',
+  pageLimit: '6',
   sortOptions: 'hosts',
   sortOrder: 'asc',
   dateGranularity: 'monthly',

--- a/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/index.tsx
+++ b/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/index.tsx
@@ -118,12 +118,12 @@ const EmailDetails = ({
     if (selectedRbacGroups.length > 0) updateEmailInfo();
   }, [principalsFromApi]);
 
-  const { totalPages } = options;
+  const { totalPages, pageLimit } = options;
 
   const extraRowsLabel =
-    totalPages <= 17
+    totalPages <= Math.ceil(100 / pageLimit)
       ? `All ${totalPages} pages`
-      : `Top 17 of ${totalPages} pages`;
+      : `Top ${Math.ceil(100 / pageLimit)} of ${totalPages} pages`;
 
   const [showError, setShowError] = useState(false);
 

--- a/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/PdfDownload.tsx
+++ b/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/PdfDownload.tsx
@@ -12,6 +12,7 @@ interface Props {
   xTickFormat: string;
   chartType: string;
   totalPages: number;
+  pageLimit: number;
   sortOptions: string;
   sortOrder: 'asc' | 'desc';
   dateGranularity: string;
@@ -34,6 +35,7 @@ const PdfDownload: ({
   xTickFormat,
   chartType,
   totalPages,
+  pageLimit,
   sortOptions,
   sortOrder,
   dateGranularity,
@@ -54,6 +56,7 @@ const PdfDownload: ({
   xTickFormat,
   chartType,
   totalPages,
+  pageLimit,
   sortOptions,
   sortOrder,
   dateGranularity,
@@ -85,6 +88,7 @@ const PdfDownload: ({
           selectOptions,
           chartSeriesHiddenProps,
           totalPages,
+          pageLimit,
           sortOptions,
           sortOrder,
           dateGranularity,

--- a/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/index.test.js
+++ b/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/index.test.js
@@ -30,6 +30,7 @@ const mockOptions = {
   xTickFormat: 'xTickFormat',
   chartType: 'bar',
   totalPages: '3',
+  pageLimit: '6',
   sortOptions: 'hosts',
   sortOrder: 'asc',
   dateGranularity: 'monthly',

--- a/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/index.tsx
+++ b/src/Components/Toolbar/DownloadButton/Steps/PdfDetails/index.tsx
@@ -15,12 +15,12 @@ const PdfDetails = ({
   dispatchReducer: React.Dispatch<TypeValue>;
 }) => {
   const { showExtraRows } = formData;
-  const { totalPages } = options;
+  const { totalPages, pageLimit } = options;
 
   const extraRowsLabel =
-    totalPages <= 17
+    totalPages <= Math.ceil(100 / pageLimit)
       ? `All ${totalPages.toString()} pages`
-      : `Top 17 of ${totalPages.toString()} pages`;
+      : `Top ${Math.ceil(100 / pageLimit)} of ${totalPages.toString()} pages`;
 
   return (
     <>

--- a/src/Components/Toolbar/DownloadButton/index.test.js
+++ b/src/Components/Toolbar/DownloadButton/index.test.js
@@ -15,6 +15,7 @@ const mockOptions = {
   xTickFormat: 'xTickFormat',
   chartType: 'bar',
   totalPages: '3',
+  pageLimit: '6',
   sortOptions: 'hosts',
   sortOrder: 'asc',
   dateGranularity: 'monthly',

--- a/src/Components/Toolbar/DownloadButton/index.tsx
+++ b/src/Components/Toolbar/DownloadButton/index.tsx
@@ -42,6 +42,7 @@ interface Props {
   xTickFormat: string;
   chartType: string;
   totalPages: number;
+  pageLimit: number;
   sortOptions: string;
   sortOrder: 'asc' | 'desc';
   dateGranularity: string;
@@ -64,6 +65,7 @@ const DownloadButton: FC<Props> = ({
   xTickFormat,
   chartType,
   totalPages,
+  pageLimit,
   sortOptions,
   sortOrder,
   dateGranularity,
@@ -114,6 +116,7 @@ const DownloadButton: FC<Props> = ({
         xTickFormat,
         chartType,
         totalPages,
+        pageLimit,
         sortOptions,
         sortOrder,
         dateGranularity,
@@ -150,6 +153,7 @@ const DownloadButton: FC<Props> = ({
           queryParams: queryParams,
           chartSeriesHiddenProps: chartSeriesHiddenProps,
           totalPages: totalPages,
+          pageLimit: pageLimit,
           sortOptions: queryParams.sort_options as string,
           sortOrder: queryParams.sort_order === 'desc' ? 'desc' : 'asc',
           dateGranularity: queryParams.granularity as string,
@@ -224,6 +228,7 @@ const DownloadButton: FC<Props> = ({
               xTickFormat,
               chartType,
               totalPages,
+              pageLimit,
               sortOptions,
               sortOrder,
               dateGranularity,
@@ -236,7 +241,7 @@ const DownloadButton: FC<Props> = ({
           />
         ) : (
           <EmailDetails
-            options={{ totalPages }}
+            options={{ totalPages, pageLimit }}
             formData={formData}
             dispatchReducer={dispatchReducer}
           />

--- a/src/Components/Toolbar/types.ts
+++ b/src/Components/Toolbar/types.ts
@@ -74,6 +74,7 @@ export interface PdfDetailsProps {
   xTickFormat: string;
   chartType: string;
   totalPages: number;
+  pageLimit: number;
   sortOptions: string;
   sortOrder: 'asc' | 'desc';
   dateGranularity: string;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -474,6 +474,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 totalPages={Math.ceil(
                   api.result.meta.count / queryParams.limit
                 )}
+                pageLimit={queryParams.limit}
                 sortOptions={chartParams.y}
                 sortOrder={queryParams.sort_order}
                 startDate={queryParams.start_date}

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -197,6 +197,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
       label={chartParams.label}
       xTickFormat={chartParams.xTickFormat}
       totalPages={Math.ceil(dataApi.result.meta.count / queryParams.limit)}
+      pageLimit={queryParams.limit}
       chartType={settingsQueryParams.chartType}
       sortOptions={chartParams.y}
       sortOrder={queryParams.sort_order}


### PR DESCRIPTION
Fixed calculation for what to display as radio options on the export wizard when there are more than 100 items

Depends on: https://gitlab.cee.redhat.com/automation-analytics/pdf-generator/-/merge_requests/98 