### PR TITLE
Fix empty state in ROI report

### DIFF
--- a/src/Components/ApiStatus/ApiStatusWrapper.tsx
+++ b/src/Components/ApiStatus/ApiStatusWrapper.tsx
@@ -16,12 +16,14 @@ interface Props {
   };
   children: React.ReactNode;
   customLoading: boolean;
+  customEmptyState?: boolean;
 }
 
 const ApiStatusWrapper: FunctionComponent<Props> = ({
   api,
   children,
   customLoading = false,
+  customEmptyState = false,
 }) => {
   if (customLoading && api.isLoading) {
     return <>{children}</>;
@@ -30,7 +32,7 @@ const ApiStatusWrapper: FunctionComponent<Props> = ({
   if (api.error) return <ApiErrorState message={api.error.error.error} />;
 
   if (api.isSuccess) {
-    if (api.result.meta.count === 0) return <NoData />;
+    if (api.result.meta.count === 0 && !customEmptyState) return <NoData />;
     return <>{children}</>;
   }
 

--- a/src/Components/EmptyList.tsx
+++ b/src/Components/EmptyList.tsx
@@ -18,6 +18,7 @@ interface Props {
   canAdd?: boolean;
   showButton?: boolean;
   path?: string;
+  onButtonClick?: () => null;
 }
 
 const EmptyList: FunctionComponent<Props> = ({
@@ -27,6 +28,7 @@ const EmptyList: FunctionComponent<Props> = ({
   canAdd = false,
   showButton = false,
   path = undefined,
+  onButtonClick = undefined,
 }) => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   /* @ts-ignore */
@@ -48,6 +50,7 @@ const EmptyList: FunctionComponent<Props> = ({
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             /* @ts-ignore */
             if (path) redirect(path);
+            if (onButtonClick) onButtonClick();
           }}
         >
           {label}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -3,6 +3,7 @@ import { history, mountPage } from '../../../../__tests__/helpers';
 import fetchMock from 'fetch-mock-jest';
 import AutomationCalculator from './AutomationCalculator';
 import TotalSavings from './TotalSavings';
+import { EmptyStateBody } from '@patternfly/react-core';
 import { Endpoint } from '../../../../Api';
 import { roi } from '../../../../Utilities/constants';
 import {
@@ -221,9 +222,11 @@ describe('Containers/CustomReports/AutomationCalculator', () => {
     });
     wrapper.update();
 
-    expect(wrapper.text()).toEqual(expect.stringContaining('No Data'));
-    // No data displayed
-    expect(wrapper.find('input')).toHaveLength(0);
+    expect(wrapper.find(EmptyStateBody).text()).toEqual(
+      expect.stringContaining(
+        'The current filter has no results. Clear the filter and try again.'
+      )
+    );
   });
 
   xit('should call redirect to job expoler', async () => {

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -224,7 +224,7 @@ describe('Containers/CustomReports/AutomationCalculator', () => {
 
     expect(wrapper.find(EmptyStateBody).text()).toEqual(
       expect.stringContaining(
-        'The current filter has no results. Clear the filter and try again.'
+        'No results match the filter criteria. Clear all filter and try again.'
       )
     );
   });

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -224,7 +224,7 @@ describe('Containers/CustomReports/AutomationCalculator', () => {
 
     expect(wrapper.find(EmptyStateBody).text()).toEqual(
       expect.stringContaining(
-        'No results match the filter criteria. Clear all filter and try again.'
+        'No results match the filter criteria. Clear all filters and try again.'
       )
     );
   });

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -400,10 +400,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         <EmptyState>
           <EmptyStateIcon icon={SearchIcon} />
           <Title headingLevel="h4" size="lg">
-            No results
+            No results found
           </Title>
           <EmptyStateBody>
-            The current filter has no results. Clear the filter and try again.
+            No results match the filter criteria. Clear all filter and try
+            again.
           </EmptyStateBody>
           <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
             Clear filter

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -24,7 +24,7 @@ import {
   Title,
   Spinner,
 } from '@patternfly/react-core';
-import { CubesIcon as CubesIcon } from '@patternfly/react-icons';
+import { SearchIcon as SearchIcon } from '@patternfly/react-icons';
 // Imports from custom components
 import FilterableToolbar from '../../../../Components/Toolbar';
 import Pagination from '../../../../Components/Pagination';
@@ -398,7 +398,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         />
       ) : (
         <EmptyState>
-          <EmptyStateIcon icon={CubesIcon} />
+          <EmptyStateIcon icon={SearchIcon} />
           <Title headingLevel="h4" size="lg">
             No results
           </Title>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -399,7 +399,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           }
           showButton={true}
           label={'Clear all filters'}
-          onClick={() => setFromToolbar(undefined, undefined)}
+          onButtonClick={() => setFromToolbar(undefined, undefined)}
         />
       )}
     </Card>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -7,12 +7,8 @@
 // @ts-nocheck
 import React, { useState, useEffect, FC } from 'react';
 import {
-  Button,
   Card,
   CardBody,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody,
   Grid,
   GridItem,
   Stack,
@@ -21,10 +17,8 @@ import {
   CardTitle,
   CardFooter,
   PaginationVariant,
-  Title,
   Spinner,
 } from '@patternfly/react-core';
-import { SearchIcon as SearchIcon } from '@patternfly/react-icons';
 // Imports from custom components
 import FilterableToolbar from '../../../../Components/Toolbar';
 import Pagination from '../../../../Components/Pagination';
@@ -64,6 +58,7 @@ import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { NotificationType } from '../../../../globalTypes';
+import EmptyList from '../../../../Components/EmptyList';
 
 const SpinnerDiv = styled.div`
   height: 400px;
@@ -397,22 +392,15 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           }}
         />
       ) : (
-        <EmptyState>
-          <EmptyStateIcon icon={SearchIcon} />
-          <Title headingLevel="h4" size="lg">
-            No results found
-          </Title>
-          <EmptyStateBody>
-            No results match the filter criteria. Clear all filters and try
-            again.
-          </EmptyStateBody>
-          <Button
-            variant="primary"
-            onClick={() => setFromToolbar(undefined, undefined)}
-          >
-            Clear all filters
-          </Button>
-        </EmptyState>
+        <EmptyList
+          title={'No results found'}
+          message={
+            'No results match the filter criteria. Clear all filters and try again.'
+          }
+          showButton={true}
+          label={'Clear all filters'}
+          onClick={() => setFromToolbar(undefined, undefined)}
+        />
       )}
     </Card>
   );

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -406,7 +406,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
             No results match the filter criteria. Clear all filter and try
             again.
           </EmptyStateBody>
-          <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
+          <Button
+            variant="primary"
+            onClick={() => setFromToolbar(undefined, undefined)}
+          >
             Clear filter
           </Button>
         </EmptyState>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -403,14 +403,14 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
             No results found
           </Title>
           <EmptyStateBody>
-            No results match the filter criteria. Clear all filter and try
+            No results match the filter criteria. Clear all filters and try
             again.
           </EmptyStateBody>
           <Button
             variant="primary"
             onClick={() => setFromToolbar(undefined, undefined)}
           >
-            Clear filter
+            Clear all filters
           </Button>
         </EmptyState>
       )}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -24,7 +24,7 @@ import {
   Title,
   Spinner,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon as ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { CubesIcon as CubesIcon } from '@patternfly/react-icons';
 // Imports from custom components
 import FilterableToolbar from '../../../../Components/Toolbar';
 import Pagination from '../../../../Components/Pagination';
@@ -398,15 +398,15 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         />
       ) : (
         <EmptyState>
-          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <EmptyStateIcon icon={CubesIcon} />
           <Title headingLevel="h4" size="lg">
-            You have disabled all views
+            No results
           </Title>
           <EmptyStateBody>
-            Enable individual views in the table below or press Show all button.
+            The current filter has no results. Clear the filter and try again.
           </EmptyStateBody>
           <Button variant="primary" onClick={() => setEnabled(undefined)(true)}>
-            Show all
+            Clear filter
           </Button>
         </EmptyState>
       )}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -536,7 +536,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       </>
     );
   return (
-    <ApiStatusWrapper api={api} customLoading={true}>
+    <ApiStatusWrapper api={api} customLoading={true} customEmptyState={true}>
       {renderContents()}
     </ApiStatusWrapper>
   );


### PR DESCRIPTION
Requirements: when Automation Calculator report has a filter with no results it's possible to work with it like switching off a filter.

Partly fixes https://issues.redhat.com/browse/AA-1014

Before:
<img width="1365" alt="Screenshot 2022-06-01 at 13 50 06" src="https://user-images.githubusercontent.com/9210860/171402926-f64fe58f-3ca9-46cb-92f6-3cc07db51318.png">

After (updated):
<img width="1331" alt="Screenshot 2022-06-06 at 17 26 45" src="https://user-images.githubusercontent.com/9210860/172192851-0941a2c4-a94b-4e16-a725-ac4f7e78f47d.png">



