### PR TITLE
Add current page and total Savings to ROI

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.test.js
@@ -242,7 +242,8 @@ describe('Containers/CustomReports/AutomationCalculator', () => {
     expect(history.location.pathname).toBe('/job-explorer');
   });
 
-  it('should compute total savings correctly', async () => {
+  // Total savings is no longer calculated locally -> skipping
+  xit('should compute total savings correctly', async () => {
     await act(async () => {
       wrapper = mountPage(AutomationCalculator, pageParams);
     });

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -484,7 +484,12 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 startDate={queryParams.start_date}
                 endDate={queryParams.end_date}
                 dateRange={queryParams.quick_date_range}
-                inputs={{ costManual, costAutomation }}
+                inputs={{
+                  costManual,
+                  costAutomation,
+                  totalSavings : api.result?.monetary_gain_other_pages + api.result?.monetary_gain_current_page,
+                  currentPageSavings: api.result?.monetary_gain_current_page
+                }}
               />,
             ]}
           />

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -88,9 +88,6 @@ const updateDeltaCost = (data, costAutomation, costManual) =>
     return { ...el, delta, manualCost, automatedCost };
   });
 
-const computeTotalSavings = (data) =>
-  data.reduce((sum, curr) => sum + curr.delta, 0);
-
 const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   slug,
   name,
@@ -152,11 +149,12 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     }
   );
 
-  const setValue = (items) =>
+  const setValue = (items) => {
     setApiData({
       ...api.result,
       items,
     });
+  };
   const getROISaveData = (
     items: any[],
     manualCost?: number = costManual,
@@ -175,6 +173,13 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     };
   };
   const dispatch = useDispatch();
+
+  const update = async () => {
+    const res = await readData(queryParams);
+    api.result.monetary_gain_current_page = res.monetary_gain_current_page;
+    api.result.monetary_gain_other_pages = res.monetary_gain_other_pages;
+    return res;
+  };
 
   const updateCalculationValues = async (varName: string, value: number) => {
     const hourly_automation_cost =
@@ -203,6 +208,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       // don't update inputs
       return;
     }
+    await update();
     varName === 'manual_cost' ? setCostManual(value) : setCostAutomation(value);
   };
 
@@ -240,6 +246,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       // don't update inputs
       return;
     }
+    await update();
     setValue(updatedData);
   };
 
@@ -264,6 +271,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       // don't update inputs
       return;
     }
+    await update();
     setValue(updatedData);
   };
   const getSortParams = () => {
@@ -409,7 +417,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     <Stack>
       <StackItem>
         <TotalSavings
-          totalSavings={computeTotalSavings(filterDisabled(api.result.items))}
+          totalSavings={
+            api.result?.monetary_gain_other_pages +
+            api.result?.monetary_gain_current_page
+          }
+          currentPageSavings={api.result?.monetary_gain_current_page}
           isLoading={api.isLoading}
         />
       </StackItem>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -487,8 +487,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 inputs={{
                   costManual,
                   costAutomation,
-                  totalSavings : api.result?.monetary_gain_other_pages + api.result?.monetary_gain_current_page,
-                  currentPageSavings: api.result?.monetary_gain_current_page
+                  totalSavings:
+                    api.result?.monetary_gain_other_pages +
+                    api.result?.monetary_gain_current_page,
+                  currentPageSavings: api.result?.monetary_gain_current_page,
                 }}
               />,
             ]}

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -63,7 +63,6 @@ const Row: FunctionComponent<Props> = ({
     window.localStorage.setItem(id.toString(), value ? 'true' : 'false');
     setIsExpanded(value);
   };
-  console.log(template);
 
   return (
     <>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -63,6 +63,7 @@ const Row: FunctionComponent<Props> = ({
     window.localStorage.setItem(id.toString(), value ? 'true' : 'false');
     setIsExpanded(value);
   };
+  console.log(template);
 
   return (
     <>
@@ -125,7 +126,7 @@ const Row: FunctionComponent<Props> = ({
               : globalDisabledColor200.value,
           }}
         >
-          {currencyFormatter(+template.delta)}
+          {currencyFormatter(+template.monetary_gain)}
         </Td>
         <Td>
           <Switch

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
@@ -15,6 +15,7 @@ export interface Template {
   manualCost: number;
   automatedCost: number;
   enabled: boolean;
+  monetary_gain: number;
   // Anything else accidentally having it
   [key: string]: string | number | boolean;
 }

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TotalSavings.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 
 interface Props {
   totalSavings: number;
+  currentPageSavings: number;
   isLoading: boolean;
 }
 const SpinnerDiv = styled.div`
@@ -20,26 +21,31 @@ const SpinnerDiv = styled.div`
 
 const TotalSavings: FunctionComponent<Props> = ({
   totalSavings = 0,
+  currentPageSavings = 0,
   isLoading = false,
 }) => (
-  <Card isPlain isCompact>
-    <CardTitle>Total savings</CardTitle>
-    <CardBody>
-      <Title
-        headingLevel="h3"
-        size="4xl"
-        style={{ color: 'var(--pf-global--success-color--200)' }}
-      >
-        {isLoading ? (
-          <SpinnerDiv>
-            <Spinner isSVG size="lg" />
-          </SpinnerDiv>
-        ) : (
-          currencyFormatter(totalSavings)
-        )}
-      </Title>
-    </CardBody>
-  </Card>
+  <>
+    {['Total savings', 'Current page savings'].map((title, index) => (
+      <Card isPlain isCompact key={title}>
+        <CardTitle>{title}</CardTitle>
+        <CardBody>
+          <Title
+            headingLevel="h3"
+            size={index === 0 ? '4xl' : 'xl'}
+            style={{ color: 'var(--pf-global--success-color--200)' }}
+          >
+            {isLoading ? (
+              <SpinnerDiv>
+                <Spinner isSVG size="lg" />
+              </SpinnerDiv>
+            ) : (
+              currencyFormatter(index === 0 ? totalSavings : currentPageSavings)
+            )}
+          </Title>
+        </CardBody>
+      </Card>
+    ))}
+  </>
 );
 
 export default TotalSavings;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-1014

Fixes :
- The Total Savings figure in big green font reflects savings only for that page. Total Savings is always supposed to show the savings across all templates, as in, all pages. Lets have 2 displays here in order to make things very clear for the user to understand and to comply with the older version of the Automation Calculator screen where we ALWAYS displayed the overall total: 
Grand Total : This will display the entire total of the Savings across ALL pages 
Page Total : This will be a summation of all the Savings on the templates on the given page
 

- Individual page totals are not showing accurate numbers.  Note the page total number on page1. Now navigate to page2 and come back to page1. You will see a different total than what was displayed before. Hitting refresh on page1 fixes the total. Needs to be resolved ASAP since it is creating confusion and chaos on the screen

Related but independent of https://gitlab.cee.redhat.com/automation-analytics/pdf-generator/-/merge_requests/108

Before:
<img width="1297" alt="Screenshot 2022-06-14 at 13 06 14" src="https://user-images.githubusercontent.com/9210860/173563417-b8e4f290-71dc-4de0-9f82-1ddbbd258904.png">

After:
<img width="1279" alt="Screenshot 2022-06-14 at 13 04 36" src="https://user-images.githubusercontent.com/9210860/173563348-e8b8f481-8715-4cda-9c3f-3d298c77086d.png">

