### PR TITLE
Add data-cy to toolbar items

### DIFF
--- a/src/Components/Toolbar/DownloadButton/index.tsx
+++ b/src/Components/Toolbar/DownloadButton/index.tsx
@@ -332,10 +332,17 @@ const DownloadButton: FC<Props> = ({
           aria-label="Export report"
           onClick={() => setIsExportModalOpen(true)}
           isDanger={isError}
+          data-cy={'download-button'}
         >
-          {isLoading && <Spinner isSVG size="md" />}
-          {!isLoading && isError && <ExclamationCircleIcon />}
-          {!isLoading && !isError && <DownloadIcon />}
+          {isLoading && (
+            <Spinner data-cy={'download-button-loading'} isSVG size="md" />
+          )}
+          {!isLoading && isError && (
+            <ExclamationCircleIcon data-cy={'download-button-error'} />
+          )}
+          {!isLoading && !isError && (
+            <DownloadIcon data-cy={'download-button-icon'} />
+          )}
         </Button>
       </Tooltip>
       {isExportModalOpen && (

--- a/src/Components/Toolbar/Groups/SortByGroup.tsx
+++ b/src/Components/Toolbar/Groups/SortByGroup.tsx
@@ -32,9 +32,10 @@ const SortByGroup: FunctionComponent<Props> = ({
         setValue={(value) => setFilters('sort_options', value as string)}
       />
     </ToolbarItem>
-    <ToolbarItem>
+    <ToolbarItem data-cy={'sort'}>
       <Button
         variant={ButtonVariant.control}
+        data-cy={filters.sort_order === 'asc' ? 'desc' : 'asc'}
         onClick={() =>
           setFilters(
             'sort_order',

--- a/src/Components/Toolbar/Groups/ToolbarInput/Select.tsx
+++ b/src/Components/Toolbar/Groups/ToolbarInput/Select.tsx
@@ -35,7 +35,7 @@ interface Props {
 const renderValues = (values: SelectOptionProps[]) =>
   values &&
   values.map(({ key, value, description }) => (
-    <SelectOption key={key} value={key} description={description}>
+    <SelectOption key={key} value={key} description={description} data-cy={key}>
       <Tooltip content={<div>{value}</div>}>
         <OptionSpan>{value}</OptionSpan>
       </Tooltip>

--- a/src/Components/Toolbar/Groups/ToolbarInput/index.tsx
+++ b/src/Components/Toolbar/Groups/ToolbarInput/index.tsx
@@ -50,6 +50,7 @@ const ToolbarInput: FunctionComponent<Props> = ({
 
   return (
     <SelectedInput
+      data-cy={options.name}
       categoryKey={categoryKey}
       value={defaultValue()}
       selectOptions={selectOptions}

--- a/src/Components/Toolbar/Toolbar.tsx
+++ b/src/Components/Toolbar/Toolbar.tsx
@@ -107,6 +107,7 @@ const FilterableToolbar: FunctionComponent<Props> = ({
               variant={ButtonVariant.plain}
               onClick={() => setSettingsExpanded(!settingsExpanded)}
               aria-label="settings"
+              data-cy={'settings'}
               isActive={settingsExpanded}
             >
               <CogIcon />
@@ -122,6 +123,7 @@ const FilterableToolbar: FunctionComponent<Props> = ({
         )}
         {pagination && (
           <ToolbarItem
+            data-cy={'top_pagination'}
             variant={ToolbarItemVariant.pagination}
             visibility={{ default: 'hidden', lg: 'visible' }}
           >

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -176,6 +176,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
         {availableChartTypes.map((chartType) => (
           <ToggleGroupItem
             key={chartType}
+            data-cy={'chart_type'}
             text={`${capitalize(chartType)} Chart`}
             buttonId={chartType}
             isSelected={chartType === chartParams.chartType}

--- a/src/Containers/SavingsPlanner/List/List.js
+++ b/src/Containers/SavingsPlanner/List/List.js
@@ -164,6 +164,7 @@ const List = () => {
               ? [
                   <Button
                     key="add-plan-button"
+                    data-cy={'add-plan-button'}
                     variant="primary"
                     aria-label="Add plan"
                     onClick={() => {
@@ -177,6 +178,7 @@ const List = () => {
             canWrite && isSuccess && data.length > 0 && (
               <ToolbarDeleteButton
                 key="delete-plan-button"
+                data-cy={'delete-plan-button'}
                 onDelete={handleDelete}
                 itemsToDelete={data.filter((d) => selected.includes(d.id))}
                 pluralizedItemName={'Savings plan'}


### PR DESCRIPTION
All items should have an unique `data-cy` so Cypress can click on all of them using `daata-cy`. 

Only problem is pagination. It's a PF component and I'm only able to add `data-cy` to a whole thing not the buttons.

cc @fullsushidev