### PR TITLE
Update cypress tests to work on stage

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,6 +6,7 @@
     "videoUploadOnPasses": false,
     "viewportWidth": 1600,
     "defaultCommandTimeout": 10000,
+    "chromeWebSecurity": false,
     "retries": {
       "runMode": 2,
       "openMode": 0

--- a/cypress.json
+++ b/cypress.json
@@ -10,7 +10,7 @@
       "runMode": 2,
       "openMode": 0
       },
-    "baseUrl": "http://localhost:1337/beta/ansible/insights",
+    "baseUrl": "https://stage.foo.redhat.com:1337/beta/ansible/automation-analytics",
     "env": {
         "appid":"#automation-analytics-application",
         "USERNAME": "admin",

--- a/cypress.json
+++ b/cypress.json
@@ -5,7 +5,8 @@
     "video": false,
     "videoUploadOnPasses": false,
     "viewportWidth": 1600,
-    "defaultCommandTimeout": 10000,
+    "pageLoadTimeout": 120000,
+    "responseTimeout": 60000,
     "chromeWebSecurity": false,
     "retries": {
       "runMode": 2,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,6 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+import 'cypress-wait-until';
 
 Cypress.Commands.add('getBaseUrl', () => Cypress.env('baseUrl'));
 
@@ -44,6 +45,33 @@ Cypress.Commands.add('clearFeatureDialogs', () => {
   });
 });
 
+Cypress.Commands.add('acceptCookiesDialog', () => {
+
+  const getIframeDocument = () => {
+    return cy
+      .get('iframe')
+      .its('0.contentDocument').should('exist')
+  }
+
+  const getIframeBody = () => {
+    return getIframeDocument()
+      .its('body').should('not.be.undefined')
+      .then(cy.wrap)
+  }
+
+  const acceptCookies = () => {
+    return getIframeBody()
+      .find('div.pdynamicbutton')
+      .find('a.call')
+      .should('be.visible')
+      .click(true)
+  }
+
+  cy.waitUntil(() => acceptCookies());
+
+});
+
+// cy.waitUntil(() => cy.getCookie('token').then(cookie => cookie.value === '<EXPECTED_VALUE>'));
 Cypress.Commands.add('loginFlow', () => {
   cy.visit('/');
 
@@ -65,6 +93,8 @@ Cypress.Commands.add('loginFlow', () => {
       cy.get('#password').type(`${password}{enter}`, { log: false })
     );
   }
+
+  cy.acceptCookiesDialog();
 
   cy.url().should('eq', Cypress.config().baseUrl + '/');
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -45,6 +45,11 @@ Cypress.Commands.add('clearFeatureDialogs', () => {
   });
 });
 
+/* 
+ * TODO: This is a workaround and the tests runs longer than we would like.
+ * It needs to be updated in a way we don't even see the iframe,
+ * loading the cookies beforehand
+ */
 Cypress.Commands.add('acceptCookiesDialog', () => {
 
   const getIframeDocument = () => {
@@ -71,7 +76,6 @@ Cypress.Commands.add('acceptCookiesDialog', () => {
 
 });
 
-// cy.waitUntil(() => cy.getCookie('token').then(cookie => cookie.value === '<EXPECTED_VALUE>'));
 Cypress.Commands.add('loginFlow', () => {
   cy.visit('/');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -95,6 +95,6 @@ Cypress.Commands.add('loginFlow', () => {
   }
 
   cy.acceptCookiesDialog();
-
+  cy.wait(5000)
   cy.url().should('eq', Cypress.config().baseUrl + '/');
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('loginFlow', () => {
 
   // If local test runs
   if (keycloakLoginUrls.some((str) => Cypress.config().baseUrl.includes(str))) {
-    cy.getUsername().then((uname) => cy.get('#username').type(`${uname}`));
+    cy.getUsername().then((uname) => cy.get('#username-verification').type(`${uname}`));
     cy.getPassword().then((password) =>
       cy.get('#password').type(`${password}{enter}`, { log: false })
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "babel-plugin-transform-imports": "^2.0.0",
         "css-loader": "^6.3.0",
         "cypress": "^9.7.0",
+        "cypress-wait-until": "^1.7.2",
         "enzyme": "^3.11.0",
         "enzyme-to-json": "^3.6.2",
         "eslint": "7.32.0",
@@ -6259,6 +6260,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/@types/node": {
       "version": "14.17.21",
@@ -22409,6 +22416,12 @@
           }
         }
       }
+    },
+    "cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "d3": {
       "version": "5.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-transform-imports": "^2.0.0",
         "css-loader": "^6.3.0",
-        "cypress": "^9.1.1",
+        "cypress": "^9.7.0",
         "enzyme": "^3.11.0",
         "enzyme-to-json": "^3.6.2",
         "eslint": "7.32.0",
@@ -1705,6 +1705,16 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/@cypress/request": {
       "version": "2.88.10",
@@ -3676,9 +3686,10 @@
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
-      "dev": true,
-      "license": "MIT"
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "dev": true
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
@@ -5569,18 +5580,18 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.0",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
       "engines": {
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "^1.1.2"
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -6186,24 +6197,26 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "9.1.1",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -6222,15 +6235,15 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -6257,6 +6270,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -6315,6 +6352,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cypress/node_modules/supports-color": {
@@ -19231,6 +19283,13 @@
       "version": "0.2.3",
       "dev": true
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true
+    },
     "@cypress/request": {
       "version": "2.88.10",
       "dev": true,
@@ -20609,7 +20668,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -21822,11 +21883,12 @@
       "dev": true
     },
     "cli-table3": {
-      "version": "0.6.0",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
+        "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
       }
     },
@@ -22215,22 +22277,25 @@
       "version": "3.0.9"
     },
     "cypress": {
-      "version": "9.1.1",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -22249,15 +22314,15 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -22270,6 +22335,16 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "chalk": {
@@ -22307,6 +22382,15 @@
         "has-flag": {
           "version": "4.0.0",
           "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "8.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5358,13 +5358,20 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001265",
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
       "dev": true,
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -21753,7 +21760,9 @@
       "version": "1.0.0"
     },
     "caniuse-lite": {
-      "version": "1.0.30001265",
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
       "dev": true
     },
     "caseless": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-imports": "^2.0.0",
     "css-loader": "^6.3.0",
-    "cypress": "^9.1.1",
+    "cypress": "^9.7.0",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
     "eslint": "7.32.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "babel-plugin-transform-imports": "^2.0.0",
     "css-loader": "^6.3.0",
     "cypress": "^9.7.0",
+    "cypress-wait-until": "^1.7.2",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
     "eslint": "7.32.0",


### PR DESCRIPTION
- Bump cypress to v9.7 (since v10 has breaking changes)
- Bump and installs plugins

Previously, all tests were failing and now it's fixed with:
- Update login page ids
- Include command to accept the cookies