### PR TITLE
Fix: Add a redirect for the root route to the Routes

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -57,6 +57,8 @@ export const Routes: FunctionComponent<Record<string, never>> = () => {
     <Switch>
       {/* Catch urls with the trailing slash and remove it */}
       <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
+      {/* Redirect the root path to the clusters so it does not give 404. */}
+      <Redirect from="/" to={Paths.clusters} />
       {/* Render the valid routes */}
       {Object.keys(components).map((key) => (
         <InsightsRoute key={key} path={key} component={components[key]} />


### PR DESCRIPTION
The root route used the default route which is a not found
404 error screen. To make the user experience pleasant lets
redirect this route to the clusters page.