### PR TITLE
When series has no id it's never hidden

### DIFF
--- a/src/Components/Chart/index.tsx
+++ b/src/Components/Chart/index.tsx
@@ -40,7 +40,9 @@ const applyHiddenFilter = (
   ...chartData,
   series: chartData.series.map((series: ChartDataSerie) => ({
     ...series,
-    hidden: !!chartSeriesHidden.includes(series.serie[0].id.toString()),
+    hidden:
+      !!series.serie[0].id &&
+      !!chartSeriesHidden.includes(series.serie[0].id.toString()),
   })),
 });
 


### PR DESCRIPTION
Introduced by me in https://github.com/RedHatInsights/tower-analytics-frontend/pull/778

Steps to reproduce:
- go to Savings Planner
- click on any plan
- click Statistics tab


Before:


<img width="794" alt="Screenshot 2022-07-13 at 16 40 16" src="https://user-images.githubusercontent.com/9210860/178761310-0e6d4b2b-502d-4dea-a59f-6f05df0502e4.png">


`Cannot read properties of undefined (reading 'toString')`

After:
<img width="1369" alt="Screenshot 2022-07-13 at 16 38 43" src="https://user-images.githubusercontent.com/9210860/178761001-c0244672-0b95-4ade-b8a6-474aa49379d4.png">

