### PR TITLE
[AA-1256] Anomalous hosts kebab dropdown

### DIFF
--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -47,6 +47,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
   expandedTableRowName,
   clickableLinking,
   showPagination,
+  showKebab,
   defaultSelectedToolbarCategory = '',
   availableChartTypes,
   dataEndpoint,
@@ -311,6 +312,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
               getSortParams={getSortParams}
               expandedRowName={expandedTableRowName}
               clickableLinking={clickableLinking}
+              showKebab={showKebab}
             />
           </ApiStatusWrapper>
         )}

--- a/src/Containers/Reports/Layouts/Standard/Table/index.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 
 import {
   TableComposable,
@@ -12,12 +12,16 @@ import {
 import TableRow from './TableRow';
 import { LegendEntry, TableHeaders, TableSortParams } from '../types';
 import { ExpandedTableRowName } from '../Components';
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { useQueryParams } from '../../../../../QueryParams';
+import { reportDefaultParams } from '../../../../../Utilities/constants';
 
 interface Props {
   headers: TableHeaders;
   legend: LegendEntry[];
   expandedRowName?: ExpandedTableRowName;
   clickableLinking?: boolean;
+  showKebab?: boolean;
   getSortParams?: (currKey: string) => TableSortParams;
 }
 
@@ -27,17 +31,73 @@ const ReportTable: FunctionComponent<Props> = ({
   getSortParams = () => ({}),
   expandedRowName,
   clickableLinking,
+  showKebab,
 }) => {
+  const [isKebabOpen, setIsKebabOpen] = useState(false);
+  const defaultParams = reportDefaultParams('host_anomalies_scatter');
+  const { setFromToolbar } = useQueryParams(defaultParams);
+
+  const kebabDropdownItems = [
+    <DropdownItem
+      key="showAll"
+      component="button"
+      onClick={() => setFromToolbar('anomaly', undefined)}
+    >
+      Display all host rows
+    </DropdownItem>,
+    <DropdownItem
+      key="showAnomalousHosts"
+      component="button"
+      onClick={() => setFromToolbar('anomaly', true)}
+    >
+      Display only anomalous hosts
+    </DropdownItem>,
+    <DropdownItem
+      key="showNonAnomalousHosts"
+      component="button"
+      onClick={() => setFromToolbar('anomaly', false)}
+    >
+      Display only non-anomalous hosts
+    </DropdownItem>,
+  ];
+
   return (
     <TableComposable aria-label="Report Table" variant={TableVariant.compact}>
       <Thead>
         <Tr>
           {expandedRowName && <Th />}
-          {headers.map(({ key, value }) => (
-            <Th key={key} {...getSortParams(key)} data-cy={key}>
-              {value}
-            </Th>
-          ))}
+          {headers.map(({ key, value }) =>
+            showKebab && key === 'anomaly' ? (
+              <Th
+                style={{
+                  overflow: 'visible',
+                  zIndex: 1,
+                }}
+              >
+                Anomalous
+                <Dropdown
+                  onSelect={() => {
+                    setIsKebabOpen(true);
+                  }}
+                  toggle={
+                    <KebabToggle
+                      style={{ paddingBottom: '0px' }}
+                      id="table-kebab"
+                      onToggle={() => setIsKebabOpen(!isKebabOpen)}
+                    />
+                  }
+                  isOpen={isKebabOpen}
+                  isPlain
+                  dropdownItems={kebabDropdownItems}
+                  position={'right'}
+                />
+              </Th>
+            ) : (
+              <Th key={key} {...getSortParams(key)} data-cy={key}>
+                {value}
+              </Th>
+            )
+          )}
         </Tr>
       </Thead>
       <Tbody>

--- a/src/Containers/Reports/Layouts/types.ts
+++ b/src/Containers/Reports/Layouts/types.ts
@@ -34,6 +34,7 @@ export interface StandardProps extends BaseReportProps {
   fullCard?: boolean;
   clickableLinking?: boolean;
   showPagination?: boolean;
+  showKebab?: boolean;
 }
 
 export type ReportSchema =

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -96,6 +96,7 @@ const paramsReducer = (state, { type, value }) => {
     case 'SET_NAME':
     case 'SET_ROOT_WORKFLOWS_AND_JOBS':
     case 'SET_TEMPLATE_WEIGH_IN':
+    case 'SET_ANOMALY':
     case 'SET_INVENTORY':
     case 'SET_SORT_OPTIONS':
     case 'SET_CALCULATOR':
@@ -138,6 +139,7 @@ const actionMapper = {
   name: 'SET_NAME',
   only_root_workflows_and_standalone_jobs: 'SET_ROOT_WORKFLOWS_AND_JOBS',
   template_weigh_in: 'SET_TEMPLATE_WEIGH_IN',
+  anomaly: 'SET_ANOMALY',
   inventory_id: 'SET_INVENTORY',
   granularity: 'SET_GRANULARITY',
   tags: 'SET_TAGS',


### PR DESCRIPTION
Added a kebab dropdown to the host anomaly run rate report which can be used to display all host rows, display only anomalous hosts, or display only non-anomalous hosts.

Depends on: https://gitlab.cee.redhat.com/automation-analytics/automation-analytics-backend/-/merge_requests/480

Jira ticket: https://issues.redhat.com/browse/AA-1256 

Before: ![Screen Shot 2022-08-01 at 3 46 44 PM](https://user-images.githubusercontent.com/89094075/182232726-9b297c14-9bba-420e-8b55-c5f599b61724.png)

After: ![Screen Shot 2022-08-01 at 3 31 31 PM](https://user-images.githubusercontent.com/89094075/182232727-4c520a95-cc28-4bd8-a3ef-f7619214f0bb.png)
 