### PR TITLE
Cypress pagination tests

### DIFF
--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -15,51 +15,52 @@ describe('Job Explorer page smoketests', () => {
     cy.url().should('include', 'quick_date_range=last_2_weeks');
   });
 
-  it('Can navigate through all the pages', () => {
-
-    // Create commands to return the pages dropdown;
-    cy.getByCy('top_pagination')
-    .find('.pf-c-options-menu').as('top_pag_option_menu');
+  it('Can navigate through the pages', () => {
+    // TODO: navigate through ALL pages
     
-   cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle').click()
-
-    cy.get('@top_pag_option_menu')
-    .find('ul', 'per-page-5').should(($ul) => {
-      const n = parseFloat($ul.text())
-      expect(n).to.be.eq(5)
-    }).within(($ul) => {
-      cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
-      // click and check with the table was updated
-      cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
-      // click and check with the table was updated
-      cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
-      // click and check with the table was updated
-      cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
-      // click and check with the table was updated
-      cy.get('li').eq(4).find('button').should('have.attr', 'data-action').and('include', 'per-page-25')
-      // click and check with the table was updated
-    })
-
-    // // Create commands to return the amount of pages available;
-    // // get the ammount of pages => how many times the interaction should happen
+    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
+    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
     
-    // // Create commands to iterate and compare the amount of pages and how many times the pagination arrow can be clicked;
-    // // if page 1, check if previous button is disabled
+    cy.get('@previousBtn').should('be.disabled')
+    cy.get('@nextBtn').should('not.be.disabled').click()
+    
+    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
+    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
 
-    // // run next click until the ammount of pages
-    // cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
-    // cy.get('@nextBtn').click().should('be.visible')
-
-    // // check the next button is disabled at the final page
-
-    // // run previous click until the ammount of pages
-    // cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
-    // cy.get('@previousBtn').click().should('be.visible')
-    // // check again if previous button is disabled on page 1
-
+    cy.get('@nextBtn').should('not.be.disabled')
+    cy.get('@previousBtn').should('not.be.disabled').click()
   });
 
-  // it('Can change the number of items shown on the list', () => {
+  it('Can change the number of items shown on the list', () => {
+    // TODO: test all values of items per page
 
-  // });
-});
+    // toggle the list
+    cy.getByCy('top_pagination').find('.pf-c-options-menu').as('top_pag_option_menu');
+    cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'false').click()
+    
+    cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'true')
+    
+    // get table and amount of lines
+    cy.get('tbody').find('tr').should('have.length', 10)
+    
+    // assert the options available
+    cy.get('@top_pag_option_menu')
+    .find('ul', 'per-page-5').should(($ul) => {
+        const n = parseFloat($ul.text())
+        expect(n).to.be.eq(5)
+      }).within(($ul) => {
+          cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
+          cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
+          cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
+          cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
+          cy.get('li').eq(4).find('button').as('maxItems')
+          cy.get('@maxItems').should('have.attr', 'data-action')
+          .and('include', 'per-page-25')
+          cy.get('@maxItems').click()
+        })
+    cy.get('tbody').find('tr').should('have.length', 50)
+      });
+    });
+    

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -10,27 +10,52 @@ describe('Job Explorer page smoketests', () => {
 
   it('Query parameters are stored in the URL to enable refresh', () => {
     // Add more once fixtures are implemented - other filters are content-dependent.
-    cy.get('[data-cy="quick_date_range"]').click();
+    cy.getByCy('quick_date_range').click();
     cy.contains('Past 2 weeks').click();
     cy.url().should('include', 'quick_date_range=last_2_weeks');
   });
 
   it('Can navigate through all the pages', () => {
 
-    // get the ammount of pages => how many times the interaction should happen
+    // Create commands to return the pages dropdown;
+    cy.getByCy('top_pagination')
+    .find('.pf-c-options-menu').as('top_pag_option_menu');
     
-    // if page 1, check if previous button is disabled
+   cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle').click()
 
-    // run next click until the ammount of pages
-    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
-    cy.get('@nextBtn').click().should('be.visible')
+    cy.get('@top_pag_option_menu')
+    .find('ul', 'per-page-5').should(($ul) => {
+      const n = parseFloat($ul.text())
+      expect(n).to.be.eq(5)
+    }).within(($ul) => {
+      cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
+      // click and check with the table was updated
+      cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
+      // click and check with the table was updated
+      cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
+      // click and check with the table was updated
+      cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
+      // click and check with the table was updated
+      cy.get('li').eq(4).find('button').should('have.attr', 'data-action').and('include', 'per-page-25')
+      // click and check with the table was updated
+    })
 
-    // check the next button is disabled at the final page
+    // // Create commands to return the amount of pages available;
+    // // get the ammount of pages => how many times the interaction should happen
+    
+    // // Create commands to iterate and compare the amount of pages and how many times the pagination arrow can be clicked;
+    // // if page 1, check if previous button is disabled
 
-    // run previous click until the ammount of pages
-    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
-    cy.get('@previousBtn').click().should('be.visible')
-    // check again if previous button is disabled on page 1
+    // // run next click until the ammount of pages
+    // cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
+    // cy.get('@nextBtn').click().should('be.visible')
+
+    // // check the next button is disabled at the final page
+
+    // // run previous click until the ammount of pages
+    // cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
+    // cy.get('@previousBtn').click().should('be.visible')
+    // // check again if previous button is disabled on page 1
 
   });
 

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -14,4 +14,27 @@ describe('Job Explorer page smoketests', () => {
     cy.contains('Past 2 weeks').click();
     cy.url().should('include', 'quick_date_range=last_2_weeks');
   });
+
+  it('Can navigate through all the pages', () => {
+
+    // get the ammount of pages => how many times the interaction should happen
+    
+    // if page 1, check if previous button is disabled
+
+    // run next click until the ammount of pages
+    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
+    cy.get('@nextBtn').click().should('be.visible')
+
+    // check the next button is disabled at the final page
+
+    // run previous click until the ammount of pages
+    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
+    cy.get('@previousBtn').click().should('be.visible')
+    // check again if previous button is disabled on page 1
+
+  });
+
+  // it('Can change the number of items shown on the list', () => {
+
+  // });
 });

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -16,51 +16,14 @@ describe('Job Explorer page smoketests', () => {
   });
 
   it('Can navigate through the pages', () => {
-    // TODO: navigate through ALL pages
-    
-    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
-    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
-    
-    cy.get('@previousBtn').should('be.disabled')
-    cy.get('@nextBtn').should('not.be.disabled').click()
-    
-    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
-    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
 
-    cy.get('@nextBtn').should('not.be.disabled')
-    cy.get('@previousBtn').should('not.be.disabled').click()
   });
 
   it('Can change the number of items shown on the list', () => {
-    // TODO: test all values of items per page
-
-    // toggle the list
-    cy.getByCy('top_pagination').find('.pf-c-options-menu').as('top_pag_option_menu');
-    cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle')
-    .should('have.attr', 'aria-expanded', 'false').click()
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
     
-    cy.findByIdLike('@top_pag_option_menu', 'aa-pagination-toggle')
-    .should('have.attr', 'aria-expanded', 'true')
-    
-    // get table and amount of lines
-    cy.get('tbody').find('tr').should('have.length', 10)
-    
-    // assert the options available
-    cy.get('@top_pag_option_menu')
-    .find('ul', 'per-page-5').should(($ul) => {
-        const n = parseFloat($ul.text())
-        expect(n).to.be.eq(5)
-      }).within(($ul) => {
-          cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
-          cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
-          cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
-          cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
-          cy.get('li').eq(4).find('button').as('maxItems')
-          cy.get('@maxItems').should('have.attr', 'data-action')
-          .and('include', 'per-page-25')
-          cy.get('@maxItems').click()
-        })
-    cy.get('tbody').find('tr').should('have.length', 50)
-      });
-    });
-    
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -107,6 +107,21 @@ Cypress.Commands.add('getByIdLike', (selector, ...args) => {
  * @param {String} parentSelector
  * @param {String} selector - The selector value
  **/
+ Cypress.Commands.add('findFromParent', (parentSelector, selector, ...args) => {
+  cy.get(`${parentSelector}`)
+  .find(`${selector}`, ...args)
+})
+
+/**
+ * This command find an element inside a given parent with id
+ * using a partial match anywhere in the element.
+ *
+ * Example usage:
+ * cy.findByIdLike("parent-selector" "select-option-description")
+ *
+ * @param {String} parentSelector
+ * @param {String} selector - The selector value
+ **/
  Cypress.Commands.add('findByIdLike', (parentSelector, selector, ...args) => {
   cy.get(`${parentSelector}`)
   .find(`[id*="${selector}"]`, ...args)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -97,7 +97,23 @@ Cypress.Commands.add('getByIdLike', (selector, ...args) => {
   return cy.get(`[id*="${selector}"]`, ...args)
 })
 
-/** This command allows the user to enter a locator that uses a data-ouia-component-id, a data-cy, or an id, and find that locator
+/**
+ * This command find an element inside a given parent with id
+ * using a partial match anywhere in the element.
+ *
+ * Example usage:
+ * cy.findByIdLike("parent-selector" "select-option-description")
+ *
+ * @param {String} parentSelector
+ * @param {String} selector - The selector value
+ **/
+ Cypress.Commands.add('findByIdLike', (parentSelector, selector, ...args) => {
+  cy.get(`${parentSelector}`)
+  .find(`[id*="${selector}"]`, ...args)
+})
+
+/** This command allows the user to enter a locator that uses a data-ouia-component-id,
+ * a data-cy, id, or aria-labelledby, and find that locator
  * with the one command.
  *
  * User simply passes in the locator string and Cypress will find that locator.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,8 +15,8 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-import './pagination'
 import './login'
+import './pagination'
 
 // Returning false here prevents Cypress from failing the test
 Cypress.on('uncaught:exception', (err, runnable) => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './pagination'
 import './login'
 
 // Returning false here prevents Cypress from failing the test

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -24,7 +24,7 @@ Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) 
     throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
   })
 
-  /**
+/**
  * This command get a parent element using data-cy
  * then get's a child from it also using data-cy
  * 
@@ -49,3 +49,79 @@ Cypress.Commands.add('getItemsToggle', (cyParent, childBtnAction, ...args) => {
     throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
   })
 
+/**
+ * This command gets the pagination menu (top/bottom)
+ * and tests navigation arrows
+ * 
+ * Example usage:
+ * cy.testNavArrowsFlow("top_pagination")
+ * 
+ * @param {String} selector - The parent data-cy element
+ */
+Cypress.Commands.add('testNavArrowsFlow', (selector) => {
+  // TODO: navigate through ALL pages
+
+  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
+  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
+  
+  cy.get('@previousBtn').should('be.disabled')
+  cy.get('@nextBtn').should('not.be.disabled').click()
+  
+  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
+  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
+
+  cy.get('@nextBtn').should('not.be.disabled')
+  cy.get('@previousBtn').should('not.be.disabled').click()
+
+  });
+
+/**
+ * This command gets the pagination menu (top/bottom)
+ * and tests navigation arrows
+ * 
+ * Example usage:
+ * cy.testItemsList("top_pagination")
+ * 
+ * @param {String} selector - The parent data-cy element
+ */
+Cypress.Commands.add('testItemsListFlow', (selector) => {
+  // TODO: test all values of items per page
+
+  // get table and amount of lines
+  cy.get('tbody').find('tr').should('have.length', 10)
+  
+  // toggle the list
+  cy.getByCy(`${selector}`).find('.pf-c-options-menu').as('pag_option_menu');
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+  .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+  .should('have.attr', 'aria-expanded', 'true')
+
+  // assert the options available
+  cy.get('@pag_option_menu')
+  .find('ul', 'per-page-5').should(($ul) => {
+      const n = parseFloat($ul.text())
+      expect(n).to.be.eq(5)
+    }).within(($ul) => {
+        cy.get('li').eq(4).find('button').as('maxItems')
+
+        cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
+        cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
+        cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
+        cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
+        cy.get('@maxItems').should('have.attr', 'data-action').and('include', 'per-page-25')
+        cy.get('@maxItems').click()
+      })
+  cy.get('tbody').find('tr').should('have.length', 50)
+  
+  // toggle back to 5 items
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+  .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+  .should('have.attr', 'aria-expanded', 'true')
+
+  cy.get('@pag_option_menu').find('li').eq(0).as('5_items')
+  cy.get('@5_items').click()
+  cy.get('tbody').find('tr').should('have.length', 10)
+  });
+  

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -23,3 +23,29 @@ Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) 
 
     throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
   })
+
+  /**
+ * This command get a parent element using data-cy
+ * then get's a child from it also using data-cy
+ * 
+ * Example usage:
+ * cy.getPagination("top_pagination", "next_button")
+ * 
+ * @param {String} cyParent - The parent data-cy element
+ * @param {String} childBtnAction - The navigation child action: Next or Previous
+ */
+Cypress.Commands.add('getItemsToggle', (cyParent, childBtnAction, ...args) => {
+  return cy.getByCy(`${cyParent}`, ...args)
+  .find('.pf-c-pagination__nav')
+  .find(`[data-action="${childBtnAction}"]`)
+
+  });
+  
+  Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
+    let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
+
+    if (getPaginationArrows) return getPaginationArrows
+
+    throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
+  })
+

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -1,3 +1,4 @@
+import './commands'
 /**
  * This command get a parent element using data-cy
  * then get's a child from it also using data-cy
@@ -9,7 +10,7 @@
  * @param {String} childBtnAction - The navigation child action: Next or Previous
  */
 Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) => {
-  return cy.get(`[data-cy="${cyParent}"]`, ...args)
+  return cy.getByCy(`${cyParent}`, ...args)
   .find('.pf-c-pagination__nav')
   .find(`[data-action="${childBtnAction}"]`)
 

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -1,0 +1,24 @@
+/**
+ * This command get a parent element using data-cy
+ * then get's a child from it also using data-cy
+ * 
+ * Example usage:
+ * cy.getPagination("top_pagination", "next_button")
+ * 
+ * @param {String} cyParent - The parent data-cy element
+ * @param {String} childBtnAction - The navigation child action: Next or Previous
+ */
+Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) => {
+  return cy.get(`[data-cy="${cyParent}"]`, ...args)
+  .find('.pf-c-pagination__nav')
+  .find(`[data-action="${childBtnAction}"]`)
+
+  });
+  
+  Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
+    let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
+
+    if (getPaginationArrows) return getPaginationArrows
+
+    throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
+  })


### PR DESCRIPTION
**The current implementation is a simpler version of PR #849 plan** in a slightly generic way.

On this PR, the Job explorer will be used as a model to develop the way we will test pagination for all the reports who basically needs to:
- [x] Test if the user can navigate through all the pages;
- [x] Test if the user can change the number of items shown on the list;

-- 

Depends on #848


