### PR TITLE
Set selected report to default if null

### DIFF
--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -108,7 +108,7 @@ const List: FunctionComponent<Record<string, never>> = () => {
     request: fetchReport,
     isSuccess: isReportSuccess,
   } = useRequest(async () => {
-    const response = await readReport(selected);
+    const response = await readReport(selected || reports[0].slug);
     return response.report as ReportSchema;
   }, {} as ReportSchema);
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AA-1298

Steps to reproduce:
- login to stage
- go to 'reports' page
- go to any report page (host_anomalies_bar, hosts_by_organization, job_template_run_rate, module_usage_by_organization)
- click on 'reports' page to go back
- from time to time the page will not load correctly (it may take few tries to reproduce the bug)


Before:
<img width="1389" alt="Screenshot 2022-08-15 at 14 55 22" src="https://user-images.githubusercontent.com/9210860/184638958-222bccbc-9c5e-46b1-bb68-7e3dd1a75b77.png">

console log
```console
vendors-node_modules…21c725b975.js:25241  action @@chrome/load-navigation-segment @ 14:55:02.179
vendors-node_modules…21c725b975.js:25241  prev state 
{chrome: {…}, globalFilter: {…}}
vendors-node_modules…21c725b975.js:25241  action     
{type: '@@chrome/load-navigation-segment', payload: {…}}
vendors-node_modules…21c725b975.js:25241  next state 
{chrome: {…}, globalFilter: {…}}
src_js_bootstrap_js-…821c725b975.js:6773 
 GET https://stage.foo.redhat.com:1337/api/tower-analytics/v1/report// 404 (Not Found)
```

After:
<img width="1348" alt="Screenshot 2022-08-15 at 14 42 47" src="https://user-images.githubusercontent.com/9210860/184638973-046b6029-cc69-466b-96ef-3e785b2c4793.png">


Note: This is an async issue that happens irregularely. From time to time it happend that a request without `selected` is resolved later then one with it and removes all data.