### PR TITLE
AA-1259 ROI Update Table Values 

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -21,20 +21,19 @@ describe('Automation Calculator page', () => {
   it('can change manual cost', () => {
     let originalTotalSavingsValue = cy.get('[data-cy="total_savings"]').find('h3').textContent;
     let originalPageSavingsValue = cy.get('[data-cy="current_page_savings"]').find('h3').textContent;
-    //let originalSavingsValues = [];
-    //cy.get('[data-cy="savings"]').each(($el) =>  originalSavingsValues.push($el.text()));
+    let originalSavingsValues = [];
+    cy.get('[data-cy="savings"]').each(($el) => originalSavingsValues.push($el.text()));
 
     cy.get('#manual-cost').clear();
     waitToLoad();
     cy.get('#manual-cost').should('have.value', '0');
-    // TODO there's a bug in UI. Savings column is not updated when inputs change
-    /*
+
     cy.get('[data-cy="savings"]').each(($el, index) => {
       const newSavingsValue = $el.text();
       // FIXME this should be not.to.be
       expect(newSavingsValue).not.to.eq(originalSavingsValues[index]);
     });
-     */
+
     cy.get('#manual-cost').type('5');
     waitToLoad();
     // TODO explain trailing 0

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -250,6 +250,14 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       return;
     }
     await update();
+    updatedData.forEach((item, i) => {
+      if (item.id === api.result.items[i].id) {
+        item.manual_effort_minutes = api.result.items[i].manual_effort_minutes;
+        item.successful_hosts_savings =
+          api.result.items[i].successful_hosts_savings;
+        item.monetary_gain = api.result.items[i].monetary_gain;
+      }
+    });
     setValue(updatedData);
   };
 

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -178,6 +178,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     const res = await readData(queryParams);
     api.result.monetary_gain_current_page = res.monetary_gain_current_page;
     api.result.monetary_gain_other_pages = res.monetary_gain_other_pages;
+    api.result.items = api.result.items.map((item, i) =>
+      Object.assign({}, item, res.meta.legend[i])
+    );
     return res;
   };
 


### PR DESCRIPTION
This bugfix resolves issue in ROI table whereby "Savings from successful hosts" column does not update when a user changes manual/automation cost

Current:
![2022-08-15 17 26 39](https://user-images.githubusercontent.com/32466511/184902514-1027a6c0-ccd9-4972-9b91-d42435e4db1e.gif)

Fix:
![2022-08-15 17 25 32](https://user-images.githubusercontent.com/32466511/184902474-1cd7be3c-0e9e-44e5-a692-5b0f294434c2.gif)