### PR TITLE
Extend cypress pagination tests

### DIFF
--- a/cypress/e2e/Global.spec.js
+++ b/cypress/e2e/Global.spec.js
@@ -65,7 +65,7 @@ describe('Insights smoketests', () => {
     cy.get('[data-cy="page_component"]').should('exist');
   };
 
-// TODO: include assetion maybe with snapshots
+  // TODO: include assetion maybe with snapshots
   it('can open each page without breaking the UI', () => {
     cy.visit(orgsUrl);
     checkPageHasNoErrors();

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -15,26 +15,13 @@ describe('Job Explorer page smoketests', () => {
     cy.url().should('include', 'quick_date_range=last_2_weeks');
   });
 
-  it('Can navigate through all the pages', () => {
-
-    // get the ammount of pages => how many times the interaction should happen
-    
-    // if page 1, check if previous button is disabled
-
-    // run next click until the ammount of pages
-    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
-    cy.get('@nextBtn').click().should('be.visible')
-
-    // check the next button is disabled at the final page
-
-    // run previous click until the ammount of pages
-    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
-    cy.get('@previousBtn').click().should('be.visible')
-    // check again if previous button is disabled on page 1
-
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
   });
 
-  // it('Can change the number of items shown on the list', () => {
-
-  // });
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination', true, true)
+    cy.testItemsListFlow('pagination_bottom', true, true)
+  });
 });

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -15,15 +15,26 @@ describe('Job Explorer page smoketests', () => {
     cy.url().should('include', 'quick_date_range=last_2_weeks');
   });
 
-  it('Can navigate through the pages', () => {
-    cy.testNavArrowsFlow('top_pagination')
-    cy.testNavArrowsFlow('pagination_bottom')
+  it('Can navigate through all the pages', () => {
 
-  });
-
-  it('Can change the number of items shown on the list', () => {
-    cy.testItemsListFlow('top_pagination')
-    cy.testItemsListFlow('pagination_bottom')
+    // get the ammount of pages => how many times the interaction should happen
     
+    // if page 1, check if previous button is disabled
+
+    // run next click until the ammount of pages
+    cy.getPaginationBtn('top_pagination', 'next').as('nextBtn')
+    cy.get('@nextBtn').click().should('be.visible')
+
+    // check the next button is disabled at the final page
+
+    // run previous click until the ammount of pages
+    cy.getPaginationBtn('top_pagination', 'previous').as('previousBtn')
+    cy.get('@previousBtn').click().should('be.visible')
+    // check again if previous button is disabled on page 1
+
   });
+
+  // it('Can change the number of items shown on the list', () => {
+
+  // });
 });

--- a/cypress/e2e/SavingsPlanner.spec.js
+++ b/cypress/e2e/SavingsPlanner.spec.js
@@ -16,4 +16,3 @@ describe('Savings Planner page smoketests', () => {
     cy.url().should('include', 'sort_options=manual_time');
   });
 });
-

--- a/cypress/e2e/reports/AA2Migration.spec.js
+++ b/cypress/e2e/reports/AA2Migration.spec.js
@@ -1,24 +1,37 @@
-import { reportsUrl, aa21m } from '../../support/constants';
+// import { reportsUrl, aa21m } from '../../support/constants';
 
-describe('Report: AA 2.1 Migration', () => {
-  beforeEach(() => {
-    cy.loginFlow();
-    cy.visit(reportsUrl + '/' + aa21m);
-  });
-  afterEach(() => {
-    cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({ force: true });
-  });
+// // TODO: include in tests for stage BETA
+// xdescribe('Report: AA 2.1 Migration', () => {
+//   beforeEach(() => {
+//     cy.loginFlow();
+//     cy.visit(reportsUrl + '/' + aa21m);
+//   });
+//   afterEach(() => {
+//     cy.get('#UserMenu').click();
+//     cy.get('button').contains('Log out').click({ force: true });
+//   });
 
-  it('Can Switch between Line and Bar chart without breaking UI', () => {
-    cy.get('#bar').click();
-    cy.get('.pf-m-selected').contains('Bar Chart').should('exist');
-    cy.get('#line').click();
-    cy.get('.pf-m-selected').contains('Line Chart').should('exist');
-  });
+//   it('Can Switch between Line and Bar chart without breaking UI', () => {
+//     cy.get('#bar').click();
+//     cy.get('.pf-m-selected').contains('Bar Chart').should('exist');
+//     cy.get('#line').click();
+//     cy.get('.pf-m-selected').contains('Line Chart').should('exist');
+//   });
 
-  it('Can change lookback', () => {
-    cy.getByCy('quick_date_range').click();
-    cy.get('.pf-c-select__menu-item').contains('Past year').click();
-  });
-});
+//   it('Can change lookback', () => {
+//     cy.getByCy('quick_date_range').click();
+//     cy.get('.pf-c-select__menu-item').contains('Past year').click();
+//   });
+
+//   it('Can navigate through the pages', () => {
+//     cy.testNavArrowsFlow('top_pagination')
+//     cy.testNavArrowsFlow('pagination_bottom')
+
+//   });
+
+//   it('Can change the number of items shown on the list', () => {
+//     cy.testItemsListFlow('top_pagination')
+//     cy.testItemsListFlow('pagination_bottom')
+
+//   });
+// });

--- a/cypress/e2e/reports/AA2Migration.spec.js
+++ b/cypress/e2e/reports/AA2Migration.spec.js
@@ -7,7 +7,7 @@ describe('Report: AA 2.1 Migration', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {

--- a/cypress/e2e/reports/ChangesMadeByJobTemplate.spec.js
+++ b/cypress/e2e/reports/ChangesMadeByJobTemplate.spec.js
@@ -9,7 +9,7 @@ describe('Report: Changes Made By Job Template Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -20,5 +20,17 @@ describe('Report: Changes Made By Job Template Smoketests', () => {
   it('Can change lookback', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
+  });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+
   });
 });

--- a/cypress/e2e/reports/HostAnomaliesBar.spec.js
+++ b/cypress/e2e/reports/HostAnomaliesBar.spec.js
@@ -1,24 +1,36 @@
-import { reportsUrl, hab } from '../../support/constants';
+// import { reportsUrl, hab } from '../../support/constants';
 
-// swiching host anomalies off for now because it's not working on stage
-xdescribe('Report: Host Anomalies Bar', () => {
-  beforeEach(() => {
-    cy.loginFlow();
-    cy.intercept('/api/tower-analytics/v1/probe_templates/').as('probeTemplates');
-    cy.visit(reportsUrl + '/' + hab);
-    cy.wait('@probeTemplates');
-  });
-  afterEach(() => {
-    cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({ force: true });
-  });
+// // swiching host anomalies off for now because it's not working on stage
+// xdescribe('Report: Host Anomalies Bar', () => {
+//   beforeEach(() => {
+//     cy.loginFlow();
+//     cy.intercept('/api/tower-analytics/v1/probe_templates/').as('probeTemplates');
+//     cy.visit(reportsUrl + '/' + hab);
+//     cy.wait('@probeTemplates');
+//   });
+//   afterEach(() => {
+//     cy.get('#UserMenu').click();
+//     cy.get('button').contains('Log out').click({ force: true });
+//   });
 
-  it('Renders bar chart with data', () => {
-    cy.get('.pf-c-chart').should('exist');
-  });
+//   it('Renders bar chart with data', () => {
+//     cy.get('.pf-c-chart').should('exist');
+//   });
 
-  it('Can change lookback', () => {
-    cy.getByCy('quick_date_range').click();
-    cy.get('.pf-c-select__menu-item').contains('Past month').click();
-  });
-});
+//   it('Can change lookback', () => {
+//     cy.getByCy('quick_date_range').click();
+//     cy.get('.pf-c-select__menu-item').contains('Past month').click();
+//   });
+
+//   it('Can navigate through the pages', () => {
+//     cy.testNavArrowsFlow('top_pagination')
+//     cy.testNavArrowsFlow('pagination_bottom')
+
+//   });
+
+//   it('Can change the number of items shown on the list', () => {
+//     cy.testItemsListFlow('top_pagination')
+//     cy.testItemsListFlow('pagination_bottom')
+    
+//   });
+// });

--- a/cypress/e2e/reports/HostsByOrganization.spec.js
+++ b/cypress/e2e/reports/HostsByOrganization.spec.js
@@ -1,24 +1,36 @@
-import { reportsUrl, hbo } from '../../support/constants';
+// import { reportsUrl, hbo } from '../../support/constants';
 
-describe('Report: Hosts By Organization Smoketests', () => {
-  beforeEach(() => {
-    cy.loginFlow();
-    cy.visit(reportsUrl + '/' + hbo);
-    cy.getByCy('loading').should('not.exist');
-    cy.getByCy('api_error_state').should('not.exist');
-  });
-  afterEach(() => {
-    cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({ force: true });
-  });
+// xdescribe('Report: Hosts By Organization Smoketests', () => {
+//   beforeEach(() => {
+//     cy.loginFlow();
+//     cy.visit(reportsUrl + '/' + hbo);
+//     cy.getByCy('loading').should('not.exist');
+//     cy.getByCy('api_error_state').should('not.exist');
+//   });
+//   afterEach(() => {
+//     cy.get('#UserMenu').click();
+//     cy.get('button').contains('Log out').click({force: true});
+//   });
 
-  it('Can Switch between Line and Bar chart without breaking UI', () => {
-    cy.screenshot('report_hbo_bar.png');
-    cy.screenshot('report_hbo_line.png');
-  });
+//   it('Can Switch between Line and Bar chart without breaking UI', () => {
+//     cy.screenshot('report_hbo_bar.png');
+//     cy.screenshot('report_hbo_line.png');
+//   });
 
-  it('Can change lookback', () => {
-    cy.getByCy('quick_date_range').click();
-    cy.get('.pf-c-select__menu-item').contains('Past 62 days').click();
-  });
-});
+//   it('Can change lookback', () => {
+//     cy.getByCy('quick_date_range').click();
+//     cy.get('.pf-c-select__menu-item').contains('Past 62 days').click();
+//   });
+
+//   it('Can navigate through the pages', () => {
+//     cy.testNavArrowsFlow('top_pagination')
+//     cy.testNavArrowsFlow('pagination_bottom')
+
+//   });
+
+//   it('Can change the number of items shown on the list', () => {
+//     cy.testItemsListFlow('top_pagination')
+//     cy.testItemsListFlow('pagination_bottom')
+    
+//   });
+// });

--- a/cypress/e2e/reports/HostsByOrganization.spec.js
+++ b/cypress/e2e/reports/HostsByOrganization.spec.js
@@ -9,7 +9,7 @@ describe('Report: Hosts By Organization Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {

--- a/cypress/e2e/reports/HostsChangedByJobTemplate.spec.js
+++ b/cypress/e2e/reports/HostsChangedByJobTemplate.spec.js
@@ -9,7 +9,7 @@ describe('Report: Hosts Changed By Job Template Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -31,6 +31,6 @@ describe('Report: Hosts Changed By Job Template Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination', false, false, 6, 9)
     cy.testItemsListFlow('pagination_bottom', false, false, 6, 9)
-    
+
   });
 });

--- a/cypress/e2e/reports/HostsChangedByJobTemplate.spec.js
+++ b/cypress/e2e/reports/HostsChangedByJobTemplate.spec.js
@@ -21,4 +21,16 @@ describe('Report: Hosts Changed By Job Template Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination', false, false, 6, 9)
+    cy.testItemsListFlow('pagination_bottom', false, false, 6, 9)
+    
+  });
 });

--- a/cypress/e2e/reports/JobTemplateRunRate.spec.js
+++ b/cypress/e2e/reports/JobTemplateRunRate.spec.js
@@ -9,7 +9,7 @@ describe('Report: Job Template Run Rate Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -31,6 +31,6 @@ describe('Report: Job Template Run Rate Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination')
     cy.testItemsListFlow('pagination_bottom')
-    
+
   });
 });

--- a/cypress/e2e/reports/JobTemplateRunRate.spec.js
+++ b/cypress/e2e/reports/JobTemplateRunRate.spec.js
@@ -21,4 +21,16 @@ describe('Report: Job Template Run Rate Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/e2e/reports/JobsTasksByOrganization.spec.js
+++ b/cypress/e2e/reports/JobsTasksByOrganization.spec.js
@@ -22,4 +22,16 @@ describe('Report: Jobs and Tasks By Organization Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past 62 days').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination', false, false, 1, 1)
+    cy.testItemsListFlow('pagination_bottom', false, false, 1, 1)
+    
+  });
 });

--- a/cypress/e2e/reports/JobsTasksByOrganization.spec.js
+++ b/cypress/e2e/reports/JobsTasksByOrganization.spec.js
@@ -10,7 +10,7 @@ describe('Report: Jobs and Tasks By Organization Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -32,6 +32,6 @@ describe('Report: Jobs and Tasks By Organization Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination', false, false, 1, 1)
     cy.testItemsListFlow('pagination_bottom', false, false, 1, 1)
-    
+
   });
 });

--- a/cypress/e2e/reports/ModuleUsageByJobTemplate.spec.js
+++ b/cypress/e2e/reports/ModuleUsageByJobTemplate.spec.js
@@ -10,7 +10,7 @@ describe('Report: Module Usage By Job Template Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -32,6 +32,6 @@ describe('Report: Module Usage By Job Template Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination')
     cy.testItemsListFlow('pagination_bottom')
-    
+
   });
 });

--- a/cypress/e2e/reports/ModuleUsageByJobTemplate.spec.js
+++ b/cypress/e2e/reports/ModuleUsageByJobTemplate.spec.js
@@ -22,4 +22,16 @@ describe('Report: Module Usage By Job Template Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/e2e/reports/ModuleUsageByOrganization.spec.js
+++ b/cypress/e2e/reports/ModuleUsageByOrganization.spec.js
@@ -10,7 +10,7 @@ describe('Report: Module Usage By Organization Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {
@@ -32,6 +32,6 @@ describe('Report: Module Usage By Organization Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination')
     cy.testItemsListFlow('pagination_bottom')
-    
+
   });
 });

--- a/cypress/e2e/reports/ModuleUsageByOrganization.spec.js
+++ b/cypress/e2e/reports/ModuleUsageByOrganization.spec.js
@@ -22,4 +22,16 @@ describe('Report: Module Usage By Organization Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/e2e/reports/ModuleUsageByTask.spec.js
+++ b/cypress/e2e/reports/ModuleUsageByTask.spec.js
@@ -22,4 +22,16 @@ describe('Report: Module Usage By Task Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/e2e/reports/MostUsedModules.spec.js
+++ b/cypress/e2e/reports/MostUsedModules.spec.js
@@ -22,4 +22,16 @@ describe('Report: Most Used Modules Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/e2e/reports/MostUsedModules.spec.js
+++ b/cypress/e2e/reports/MostUsedModules.spec.js
@@ -32,6 +32,6 @@ describe('Report: Most Used Modules Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination')
     cy.testItemsListFlow('pagination_bottom')
-    
+
   });
 });

--- a/cypress/e2e/reports/TemplatesExplorer.spec.js
+++ b/cypress/e2e/reports/TemplatesExplorer.spec.js
@@ -10,7 +10,7 @@ describe('Report: Templates Explorer Smoketests', () => {
   });
   afterEach(() => {
     cy.get('#UserMenu').click();
-    cy.get('button').contains('Log out').click({force: true});
+    cy.get('button').contains('Log out').click({ force: true });
   });
 
   it('Can change lookback', () => {
@@ -27,6 +27,6 @@ describe('Report: Templates Explorer Smoketests', () => {
   it('Can change the number of items shown on the list', () => {
     cy.testItemsListFlow('top_pagination')
     cy.testItemsListFlow('pagination_bottom')
-    
+
   });
 });

--- a/cypress/e2e/reports/TemplatesExplorer.spec.js
+++ b/cypress/e2e/reports/TemplatesExplorer.spec.js
@@ -17,4 +17,16 @@ describe('Report: Templates Explorer Smoketests', () => {
     cy.getByCy('quick_date_range').click();
     cy.get('.pf-c-select__menu-item').contains('Past year').click();
   });
+
+  it('Can navigate through the pages', () => {
+    cy.testNavArrowsFlow('top_pagination')
+    cy.testNavArrowsFlow('pagination_bottom')
+
+  });
+
+  it('Can change the number of items shown on the list', () => {
+    cy.testItemsListFlow('top_pagination')
+    cy.testItemsListFlow('pagination_bottom')
+    
+  });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,6 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
 /**
  * This command get an element using data-ouia-component-id
  * exact match.

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -69,14 +69,14 @@ Cypress.Commands.add('loginFlow', () => {
       'password': '#password',
       'two-step': false,
       'agree-cookies': false,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
+      'landing-page': Cypress.config().baseUrl + '/'
     },
     'env-ephemeral': {
       'username': '#username',
       'password': '#password',
       'two-step': false,
       'agree-cookies': true,
-      'landing-page': Cypress.config().baseUrl + "/"
+      'landing-page': Cypress.config().baseUrl + '/'
     },
     'mocks-keycloak-ephemeral': {
       'username': '#username',
@@ -140,9 +140,9 @@ Cypress.Commands.add('loginFlow', () => {
     * It needs to be updated in a way we don't even see the iframe,
     * loading the cookies beforehand.
     */
-    /*if (cy.get('iframe').should('exist')) {
+    if (cy.get('iframe').should('exist')) {
       cy.acceptCookiesDialog();
-    }*/
+    }
     cy.wait(5000)
   }
 

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -1,4 +1,3 @@
-import './commands'
 /**
  * This command get a parent element using data-cy
  * then get's a child from it also using data-cy
@@ -10,7 +9,7 @@ import './commands'
  * @param {String} childBtnAction - The navigation child action: Next or Previous
  */
 Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) => {
-  return cy.getByCy(`${cyParent}`, ...args)
+  return cy.get(`[data-cy="${cyParent}"]`, ...args)
   .find('.pf-c-pagination__nav')
   .find(`[data-action="${childBtnAction}"]`)
 
@@ -23,105 +22,3 @@ Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) 
 
     throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
   })
-
-/**
- * This command get a parent element using data-cy
- * then get's a child from it also using data-cy
- * 
- * Example usage:
- * cy.getPagination("top_pagination", "next_button")
- * 
- * @param {String} cyParent - The parent data-cy element
- * @param {String} childBtnAction - The navigation child action: Next or Previous
- */
-Cypress.Commands.add('getItemsToggle', (cyParent, childBtnAction, ...args) => {
-  return cy.getByCy(`${cyParent}`, ...args)
-  .find('.pf-c-pagination__nav')
-  .find(`[data-action="${childBtnAction}"]`)
-
-  });
-  
-  Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
-    let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
-
-    if (getPaginationArrows) return getPaginationArrows
-
-    throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
-  })
-
-/**
- * This command gets the pagination menu (top/bottom)
- * and tests navigation arrows
- * 
- * Example usage:
- * cy.testNavArrowsFlow("top_pagination")
- * 
- * @param {String} selector - The parent data-cy element
- */
-Cypress.Commands.add('testNavArrowsFlow', (selector) => {
-  // TODO: navigate through ALL pages
-
-  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
-  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
-  
-  cy.get('@previousBtn').should('be.disabled')
-  cy.get('@nextBtn').should('not.be.disabled').click()
-  
-  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
-  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
-
-  cy.get('@nextBtn').should('not.be.disabled')
-  cy.get('@previousBtn').should('not.be.disabled').click()
-
-  });
-
-/**
- * This command gets the pagination menu (top/bottom)
- * and tests navigation arrows
- * 
- * Example usage:
- * cy.testItemsList("top_pagination")
- * 
- * @param {String} selector - The parent data-cy element
- */
-Cypress.Commands.add('testItemsListFlow', (selector) => {
-  // TODO: test all values of items per page
-
-  // get table and amount of lines
-  cy.get('tbody').find('tr').should('have.length', 10)
-  
-  // toggle the list
-  cy.getByCy(`${selector}`).find('.pf-c-options-menu').as('pag_option_menu');
-  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
-  .should('have.attr', 'aria-expanded', 'false').click()
-  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
-  .should('have.attr', 'aria-expanded', 'true')
-
-  // assert the options available
-  cy.get('@pag_option_menu')
-  .find('ul', 'per-page-5').should(($ul) => {
-      const n = parseFloat($ul.text())
-      expect(n).to.be.eq(5)
-    }).within(($ul) => {
-        cy.get('li').eq(4).find('button').as('maxItems')
-
-        cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
-        cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
-        cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
-        cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
-        cy.get('@maxItems').should('have.attr', 'data-action').and('include', 'per-page-25')
-        cy.get('@maxItems').click()
-      })
-  cy.get('tbody').find('tr').should('have.length', 50)
-  
-  // toggle back to 5 items
-  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
-  .should('have.attr', 'aria-expanded', 'false').click()
-  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
-  .should('have.attr', 'aria-expanded', 'true')
-
-  cy.get('@pag_option_menu').find('li').eq(0).as('5_items')
-  cy.get('@5_items').click()
-  cy.get('tbody').find('tr').should('have.length', 10)
-  });
-  

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -9,16 +9,196 @@
  * @param {String} childBtnAction - The navigation child action: Next or Previous
  */
 Cypress.Commands.add('getPaginationArrows', (cyParent, childBtnAction, ...args) => {
-  return cy.get(`[data-cy="${cyParent}"]`, ...args)
-  .find('.pf-c-pagination__nav')
-  .find(`[data-action="${childBtnAction}"]`)
+  return cy.getByCy(`${cyParent}`, ...args)
+    .find('.pf-c-pagination__nav')
+    .find(`[data-action="${childBtnAction}"]`)
 
+});
+
+Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
+  let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
+
+  if (getPaginationArrows) return getPaginationArrows
+
+  throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
+});
+
+Cypress.Commands.add('getItemsToggle', (cyParent, childBtnAction, ...args) => {
+  return cy.getByCy(`${cyParent}`, ...args)
+    .find('.pf-c-pagination__nav')
+    .find(`[data-action="${childBtnAction}"]`)
+});
+
+Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
+  let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
+
+  if (getPaginationArrows) return getPaginationArrows
+
+  throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
+});
+
+/**
+ * This command gets the pagination menu (top/bottom)
+ * and tests navigation arrows
+ * 
+ * Example usage:
+ * cy.testNavArrowsFlow("top_pagination")
+ * 
+ * @param {String} selector - The parent data-cy element
+ */
+Cypress.Commands.add('testNavArrowsFlow', (selector) => {
+  // TODO: navigate through ALL pages
+
+  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
+  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
+
+  cy.get('@previousBtn').should('be.disabled')
+  cy.get('@nextBtn').should('not.be.disabled').click()
+
+  cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn')
+  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn')
+
+  cy.get('@nextBtn').should('not.be.disabled')
+  cy.get('@previousBtn').should('not.be.disabled').click()
+
+});
+
+/**
+ * 
+ * @param {String} selector - The parent data-cy element
+ * @param {Boolean} [has_expanded_rows=false] - does it expand the rows?
+ * @param {Number} minRows - Min rows in the table
+ * @param {Number} maxRows - Max rows in the table
+ */
+Cypress.Commands.add('testOddItemsListFlow', (selector, has_expanded_rows = false, minRows, maxRows) => {
+  // TODO: test all values of items per page
+  cy.log('testOddItemsListFlow with RECEIVED rows range: ', minRows, maxRows)
+  // let rows = cy.getTotalRows(has_expanded_rows, minRows, maxRows);
+
+  let minTotalRows = has_expanded_rows ? (minRows * 2) : minRows++;
+  let maxTotalRows = has_expanded_rows ? (maxRows * 2) : maxRows++;
+  cy.log('testOddItemsListFlow with RESULTED rows range: ', minTotalRows, maxTotalRows)
+  // get table and amount of lines
+  cy.get('table').find('tbody').find('tr').should('have.length', minTotalRows)
+
+  // toggle the list
+  cy.getByCy(`${selector}`).find('.pf-c-options-menu').as('pag_option_menu')
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'true')
+
+  // assert the options available
+  cy.get('@pag_option_menu')
+    .find('ul', 'per-page-5').should(($ul) => {
+      const n = parseFloat($ul.text())
+      expect(n).to.be.eq(5)
+    }).within(($ul) => {
+      cy.get('li').eq(4).find('button').as('maxItems')
+      cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-5')
+      cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-10')
+      cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-15')
+      cy.get('li').eq(3).find('button').should('have.attr', 'data-action').and('include', 'per-page-20')
+      cy.get('@maxItems').should('have.attr', 'data-action').and('include', 'per-page-25')
+      cy.get('@maxItems').click()
+    });
+
+  cy.get('table').find('tbody').find('tr').should('have.length', maxTotalRows)
+
+  // toggle back to min items
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'true')
+
+  cy.get('@pag_option_menu').find('li').eq(0).as('min_items')
+  cy.get('@min_items').click()
+
+  cy.get('table').find('tbody').find('tr').should('have.length', minTotalRows)
+});
+
+/**
+ * 
+ * @param {String} selector - The parent data-cy element
+ * @param {Boolean} [has_expanded_rows=false] - does it expand the rows?
+ * @param {Number} minRows - Min rows in the table
+ * @param {Number} maxRows - Max rows in the table
+ */
+Cypress.Commands.add('testEvenItemsListFlow', (selector, has_expanded_rows = false, minRows, maxRows) => {
+  // TODO: test all values of items per page
+  cy.log('testEvenItemsListFlow with RECEIVED rows range: ', minRows, maxRows)
+
+  let minTotalRows = has_expanded_rows ? minRows * 2 : ++minRows;
+  let maxTotalRows = has_expanded_rows ? maxRows * 2 : ++maxRows;
+
+  cy.log('testEvenItemsListFlow with RESULTED rows range: ', minTotalRows, maxTotalRows)
+
+  // get table and amount of lines
+  cy.get('table').find('tbody').as('tb')
+  cy.get('@tb').find('tr').should(($tr) => {
+    const n = parseFloat($tr)
+    expect(n).to.be.eq(minTotalRows)
   });
-  
-  Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
-    let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction)
 
-    if (getPaginationArrows) return getPaginationArrows
+  // toggle the list
+  cy.getByCy(`${selector}`).find('.pf-c-options-menu').as('pag_option_menu')
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'true')
 
-    throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`
-  })
+  // assert the options available
+  cy.get('@pag_option_menu')
+    .find('ul', 'per-page-6').should(($ul) => {
+      const n = parseFloat($ul.text())
+      expect(n).to.be.eq(4)
+    }).within(($ul) => {
+      cy.get('li').eq(3).find('button').as('maxItems')
+
+      cy.get('li').eq(0).find('button').should('have.attr', 'data-action').and('include', 'per-page-4')
+      cy.get('li').eq(1).find('button').should('have.attr', 'data-action').and('include', 'per-page-6')
+      cy.get('li').eq(2).find('button').should('have.attr', 'data-action').and('include', 'per-page-8')
+      cy.get('@maxItems').should('have.attr', 'data-action').and('include', 'per-page-10')
+      cy.get('@maxItems').click()
+    })
+
+  cy.get('table').find('tbody').find('tr').should('have.length', maxTotalRows)
+
+  // toggle back to min items
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'false').click()
+  cy.findByIdLike('@pag_option_menu', 'aa-pagination-toggle')
+    .should('have.attr', 'aria-expanded', 'true')
+
+  cy.get('@pag_option_menu').find('li').eq(1).as('min_items') // 6 er page is default, not 4
+  cy.get('@min_items').click()
+
+  cy.get('table').find('tbody').find('tr').should('have.length', minTotalRows)
+});
+
+/**
+ * 
+ * @param {String} selector - The parent data-cy element
+ * @param {Boolean} [is_odd=false] - True if the list is odd (5, 10, 15, 20, 25)
+ * @param {Boolean} [has_expanded_rows=false] - does it expand the rows?
+ * @param {Number} [defaultPageRows=7]
+ */
+Cypress.Commands.add('testItemsListFlow', (selector, is_odd = false, has_expanded_rows = false, defaultPageRows = 6, maxPageRows = 10) => {
+
+  cy.log(is_odd, has_expanded_rows, defaultPageRows)
+
+  let minRows = 4;
+
+  if (is_odd) {
+    minRows = 5;
+    defaultPageRows = 5;
+    maxPageRows = 25;
+  }
+
+  cy.log('testItemsListFlow with rows range:', defaultPageRows, maxPageRows)
+
+  return is_odd
+    ? cy.testOddItemsListFlow(selector, has_expanded_rows, defaultPageRows, maxPageRows)
+    : cy.testEvenItemsListFlow(selector, has_expanded_rows, defaultPageRows, maxPageRows);
+
+});

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -137,7 +137,7 @@ export CYPRESS_ProjectID=wwyf7n
 export CYPRESS_RECORD=true
 export CYPRESS_USERNAME=jdoe
 export CYPRESS_PASSWORD=${CYPRESS_PW}
-export CYPRESS_baseUrl=$UI_URL/ansible/insights
+export CYPRESS_baseUrl=$UI_URL/ansible/automation-analytics
 
 export CYPRESS_defaultCommandTimeout=2000
 export CYPRESS_execTimeout=15000


### PR DESCRIPTION
This PR updates the pagination tests (#845) to work for most of reports pages.

--

TLDR: Since the `data-cy` wasn't possible to be added to every single component to be tested, a bigger solution is needed, and to make the test more clean, several helper commands were created to be reused among the reports pages and any other page that uses the same pagination component.

--

The final idea is to develop the following plan:
- Get the amount of pages available;
    - Iterate and compare the amount of pages and how many times the pagination arrow can be clicked;
- Return the page's dropdown;
  - Validate all existing values on the dropdown;
  - Test clicking on each option and assert if the table is correctly updated;
  - A next step would be to validate pages when the total rows are lower than the pagination options;

Maybe it would be nice to extend this tests and make it work for only a page per test run, where the page is chosen randomly.

-- 

From the original plan, the following were implemented (for top and bottom pagination components):

- [x] Navigate trough pages using pagination arrows,
- [x] Asserting if the arrows are enabled/disabled,
- [x] Toggle the items per page and assert it has all the options,
- [x] Assert the amount of rows with the items per page selected (default value and maximum value)

-- 

depends on #845