### PR TITLE
Remove non-existant pagination import

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,7 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 import './login'
-import './pagination'
 
 // Returning false here prevents Cypress from failing the test
 Cypress.on('uncaught:exception', (err, runnable) => {

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('clearFeatureDialogs', () => {
   });
 });
 
-/* 
+/*
  * TODO: This is a workaround and the tests runs longer than we would like.
  * It needs to be updated in a way we don't even see the iframe,
  * loading the cookies beforehand
@@ -98,7 +98,7 @@ Cypress.Commands.add('loginFlow', () => {
       'two-step': true,
       'agree-cookies': false,
       'landing-page': Cypress.config().baseUrl + clustersUrl
-    }    
+    }
   }
 
   let strategy = null;
@@ -130,19 +130,19 @@ Cypress.Commands.add('loginFlow', () => {
     cy.getUsername().then((uname) => cy.get(keycloakLoginFields[strategy]['username']).type(`${uname}`));
     cy.getPassword().then((password) =>
       cy.get(keycloakLoginFields[strategy]['password']).type(`${password}{enter}`, { log: false })
-    ); 
+    );
   }
 
   if(keycloakLoginFields[strategy]['agree-cookies']) {
     cy.log('Accept cookies');
-    /* 
+    /*
     * TODO: This is a workaround and the tests runs longer than we would like.
     * It needs to be updated in a way we don't even see the iframe,
     * loading the cookies beforehand.
     */
-    if (cy.get('iframe').should('exist')) {
+    /*if (cy.get('iframe').should('exist')) {
       cy.acceptCookiesDialog();
-    }
+    }*/
     cy.wait(5000)
   }
 


### PR DESCRIPTION
Seems to be a leftover from another branch.

Fixes:
```log
Oops...we found an error preparing this test file:

  > cypress/support/e2e.js

The error was:

Error: Webpack Compilation Error
./cypress/support/e2e.js
Module not found: Error: Can't resolve './pagination' in '/tmp/frontend/cypress/support'
```