### PR TITLE
[AA-1377] Reset pagination

### DIFF
--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -65,9 +65,10 @@ export enum Endpoint {
   features = '/api/featureflags/v0',
 }
 
-const mungeData = async (promise) => {
+const mungeData = async (promise, params) => {
   const response = await promise;
   const peer_host_stats = response.peer_host_stats;
+  let count;
   const tableData = response.meta.legend.map((item) => {
     if (item.anomaly) {
       return {
@@ -124,10 +125,17 @@ const mungeData = async (promise) => {
       anomaly: item.anomaly,
     };
   });
+  if (Object.keys(params).includes('anomaly')) {
+    count = params.anomaly
+      ? response.peer_hosts_stats.filter((item: any) => item.anomaly).length
+      : response.peer_hosts_stats.filter((item: any) => !item.anomaly).length;
+  } else {
+    count = response.peer_hosts_stats.length;
+  }
 
   return {
     meta: {
-      count: response.peer_hosts_stats.length,
+      count: count,
       legend: chartData.flat(),
       tableData: tableData.flat(),
     },
@@ -207,7 +215,10 @@ export const readProbeTemplates = (
 };
 
 export const readProbeTemplateForHosts = (params: Params): Promise<ApiJson> => {
-  return mungeData(postWithPagination(Endpoint.probeTemplateForHosts, params));
+  return mungeData(
+    postWithPagination(Endpoint.probeTemplateForHosts, params),
+    params
+  );
 };
 
 export const readProbeTemplatesOptions = (params: Params): Promise<ApiJson> =>

--- a/src/QueryParams/__tests__/useQueryParams.test.js
+++ b/src/QueryParams/__tests__/useQueryParams.test.js
@@ -38,11 +38,14 @@ describe('QueryParams/useQueryParams', () => {
     act(() => {
       result.current.dispatch({
         type: 'SET_ATTRIBUTES',
-        value: { attributes: ['a', 'b'] },
+        value: { attributes: ['a', 'b'], offset: '0' },
       });
     });
 
-    expect(result.current.queryParams).toEqual({ attributes: ['a', 'b'] });
+    expect(result.current.queryParams).toEqual({
+      attributes: ['a', 'b'],
+      offset: '0',
+    });
   });
 
   it('should reset the filter', () => {
@@ -52,11 +55,14 @@ describe('QueryParams/useQueryParams', () => {
     act(() => {
       result.current.dispatch({
         type: 'SET_ATTRIBUTES',
-        value: { attributes: ['a', 'b'] },
+        value: { attributes: ['a', 'b'], offset: '0' },
       });
     });
 
-    expect(result.current.queryParams).toEqual({ attributes: ['a', 'b'] });
+    expect(result.current.queryParams).toEqual({
+      attributes: ['a', 'b'],
+      offset: '0',
+    });
 
     act(() => {
       result.current.dispatch({ type: 'RESET_FILTER' });

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -104,7 +104,7 @@ const paramsReducer = (state, { type, value }) => {
     case 'SET_SORT_ORDER':
     case 'SET_TAGS':
     case 'SET_DESCRIPTION':
-      return { ...state, ...value };
+      return { ...state, ...value, offset: 0 };
     case 'SET_QUICK_DATE_RANGE':
       return value !== 'custom'
         ? { ...state, ...value, start_date: null, end_date: null }


### PR DESCRIPTION
Fixed pagination so that it resets when an item is selected from the kebab dropdown in the "Host runs in a job template" report. It now goes back to page 1 and the total items displayed in the pagination component is updated to reflect the total items that match the selected criteria. 

FYI- the fix for the same issue in "Automation calculator" was required in backend 
https://gitlab.cee.redhat.com/automation-analytics/automation-analytics-backend/-/merge_requests/554

Jira issue: https://issues.redhat.com/browse/AA-1377