### PR TITLE
[AA-1390] Always show table headers with kebab dropdown

### DIFF
--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -286,7 +286,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
           }
           additionalControls={additionalControls}
         />
-        {tableHeaders && (
+        {tableHeaders && !showKebab ? (
           <ApiStatusWrapper api={dataApi}>
             <Chart
               schema={hydrateSchema(schema)({
@@ -319,6 +319,41 @@ const ReportCard: FunctionComponent<StandardProps> = ({
               showKebab={showKebab}
             />
           </ApiStatusWrapper>
+        ) : (
+          <>
+            <ApiStatusWrapper api={dataApi}>
+              <Chart
+                schema={hydrateSchema(schema)({
+                  label: chartParams.label,
+                  y: chartParams.y,
+                  xTickFormat: chartParams.xTickFormat,
+                  chartType: chartParams.chartType,
+                })}
+                dataComponent={'foobar'}
+                data={dataApi.result}
+                specificFunctions={{
+                  labelFormat: {
+                    customTooltipFormatting,
+                  },
+                  onClick: {
+                    handleClick,
+                  },
+                }}
+              />
+            </ApiStatusWrapper>
+            <Table
+              legend={
+                dataApi.result.meta.tableData
+                  ? dataApi.result.meta.tableData
+                  : dataApi.result.meta.legend
+              }
+              headers={tableHeaders}
+              getSortParams={getSortParams}
+              expandedRowName={expandedTableRowName}
+              clickableLinking={clickableLinking}
+              showKebab={showKebab}
+            />
+          </>
         )}
       </CardBody>
       <CardFooter>


### PR DESCRIPTION
On the Host runs in a job template report: When a selection is made in the kebab dropdown and there are no matching results, the table headers remain on the page allowing you to use the kebab dropdown again to restore the page to its original state.

Jira issue: https://issues.redhat.com/browse/AA-1390

Before: <img width="1133" alt="Screen Shot 2022-10-17 at 3 46 12 PM" src="https://user-images.githubusercontent.com/89094075/196268596-d01d1fcc-80d4-43c7-bf40-cebb90acff50.png">

After: <img width="1132" alt="Screen Shot 2022-10-17 at 3 45 37 PM" src="https://user-images.githubusercontent.com/89094075/196268667-ede16bea-f4a4-40d9-8d20-cf606de563f4.png">