### PR TITLE
[AA-1412] Display multiple job statuses

### DIFF
--- a/src/Containers/SavingsPlanner/List/ListItem/index.js
+++ b/src/Containers/SavingsPlanner/List/ListItem/index.js
@@ -16,6 +16,8 @@ import {
   DropdownItem,
   KebabToggle,
   Label,
+  Tooltip,
+  TooltipPosition,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -195,8 +197,36 @@ const ListItem = ({
           )}
         </CardDetail>
         <CardDetail>
-          <CardLabel>Last job status</CardLabel>
-          {automation_status.status !== 'None' ? (
+          <Tooltip
+            key={'last_job_status_tooltip'}
+            position={TooltipPosition.top}
+            content={
+              automation_status.last_known_day
+                ? `Status last reported on: ${automation_status.last_known_day}`
+                : automation_status.last_known_month
+                ? `Status last reported on: ${automation_status.last_known_month}`
+                : automation_status.last_known_year
+                ? `Status last reported on: ${automation_status.last_known_year}`
+                : `Status last reported on: ${automation_status.last_known_date}`
+            }
+          >
+            <CardLabel>Last job status</CardLabel>
+          </Tooltip>
+          {Array.isArray(automation_status.status) ? (
+            automation_status.status.map((item) => {
+              return item !== 'None' ? (
+                <JobStatus status={item} />
+              ) : (
+                <Label
+                  variant="outline"
+                  color="red"
+                  icon={<ExclamationCircleIcon />}
+                >
+                  Not Running
+                </Label>
+              );
+            })
+          ) : automation_status.status !== 'None' ? (
             <JobStatus status={automation_status.status} />
           ) : (
             <Label


### PR DESCRIPTION
This PR addresses a bug in the savings planner that caused the page to break when there were multiple job statuses reported for one template. The UI can now handle a scenario where the API could send multiple statuses and as a result, a separate tag will appear for each status. 

A tooltip was also added to the "Last job status" label in order to display the date of the last reported status. 

Jira issue: https://issues.redhat.com/browse/AA-1412 

<img width="600" alt="Screen Shot 2022-10-25 at 2 43 26 PM" src="https://user-images.githubusercontent.com/89094075/197855860-3f4a47eb-3388-4e74-81f0-17d3e3c3164f.png">
