### PR TITLE
[AA-1412] Display multiple job statuses in details tab

### DIFF
--- a/src/Components/JobStatus.tsx
+++ b/src/Components/JobStatus.tsx
@@ -59,7 +59,12 @@ const JobStatus: FunctionComponent<Props> = ({ status }) => {
   };
 
   return (
-    <Label variant="outline" color={getColor()} icon={getIcon()}>
+    <Label
+      variant="outline"
+      color={getColor()}
+      icon={getIcon()}
+      style={{ marginRight: '0.5rem', marginBottom: '0.5rem' }}
+    >
       {capitalize(status)}
     </Label>
   );

--- a/src/Components/__snapshots__/JobStatus.test.js.snap
+++ b/src/Components/__snapshots__/JobStatus.test.js.snap
@@ -4,6 +4,7 @@ exports[`Components/JobStatus should render canceled 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-orange pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -35,6 +36,7 @@ exports[`Components/JobStatus should render error 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-red pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -66,6 +68,7 @@ exports[`Components/JobStatus should render failed 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-red pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -97,6 +100,7 @@ exports[`Components/JobStatus should render new 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -128,6 +132,7 @@ exports[`Components/JobStatus should render pending 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-blue pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -159,6 +164,7 @@ exports[`Components/JobStatus should render running 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-blue pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -190,6 +196,7 @@ exports[`Components/JobStatus should render successful 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-green pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"
@@ -221,6 +228,7 @@ exports[`Components/JobStatus should render waiting 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-label pf-m-outline"
+    style="margin-right: 0.5rem; margin-bottom: 0.5rem;"
   >
     <span
       class="pf-c-label__content"

--- a/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
+++ b/src/Containers/SavingsPlanner/Details/DetailsTab/index.js
@@ -17,6 +17,8 @@ import {
   Label,
   List,
   ListItem,
+  Tooltip,
+  TooltipPosition,
 } from '@patternfly/react-core';
 import CardActionsRow from '../../../../Components/CardActionsRow';
 import { deletePlan, readPlanOptions } from '../../../../Api/';
@@ -111,6 +113,22 @@ const DetailsTab = ({ tabsArray, plan, canWrite }) => {
     return fromOptionsValue?.value ?? '';
   };
 
+  const jobStatusLabel = (item, index) => {
+    return item !== 'None' ? (
+      <JobStatus key={index} status={item} />
+    ) : (
+      <Label
+        key={index}
+        variant="outline"
+        color="red"
+        icon={<ExclamationCircleIcon />}
+        style={{ marginRight: '0.5rem', marginBottom: '0.5rem' }}
+      >
+        Not Running
+      </Label>
+    );
+  };
+
   const labelsAndValues = {
     Name: name || undefined,
     'Automation type': category
@@ -125,14 +143,11 @@ const DetailsTab = ({ tabsArray, plan, canWrite }) => {
       ? renderOptionsBasedValue('frequency_period', frequency_period)
       : undefined,
     Template: template_id ? showTemplate(template_details) : undefined,
-    'Last job status':
-      automation_status.status && automation_status.status !== 'None' ? (
-        <JobStatus status={automation_status.status} />
-      ) : (
-        <Label variant="outline" color="red" icon={<ExclamationCircleIcon />}>
-          Not Running
-        </Label>
-      ),
+    'Last job status': Array.isArray(automation_status.status)
+      ? automation_status.status.map((item, index) =>
+          jobStatusLabel(item, index)
+        )
+      : jobStatusLabel(automation_status.status),
     'Last updated': modified ? (
       <span>{formatDateTime(modified)}</span>
     ) : undefined,
@@ -159,7 +174,25 @@ const DetailsTab = ({ tabsArray, plan, canWrite }) => {
                   (key, i) =>
                     labelsAndValues[key] !== undefined && (
                       <DescriptionListGroup key={i}>
-                        <DescriptionListTerm>{key}</DescriptionListTerm>
+                        {key === 'Last job status' ? (
+                          <Tooltip
+                            key={'last_job_status_tooltip'}
+                            position={TooltipPosition.top}
+                            content={
+                              automation_status.last_known_day
+                                ? `Status last reported on: ${automation_status.last_known_day}`
+                                : automation_status.last_known_month
+                                ? `Status last reported on: ${automation_status.last_known_month}`
+                                : automation_status.last_known_year
+                                ? `Status last reported on: ${automation_status.last_known_year}`
+                                : `Status last reported on: ${automation_status.last_known_date}`
+                            }
+                          >
+                            <DescriptionListTerm>{key}</DescriptionListTerm>
+                          </Tooltip>
+                        ) : (
+                          <DescriptionListTerm>{key}</DescriptionListTerm>
+                        )}
                         <DescriptionListDescription>
                           {labelsAndValues[key]}
                         </DescriptionListDescription>

--- a/src/Containers/SavingsPlanner/List/ListItem/index.js
+++ b/src/Containers/SavingsPlanner/List/ListItem/index.js
@@ -221,6 +221,7 @@ const ListItem = ({
                   variant="outline"
                   color="red"
                   icon={<ExclamationCircleIcon />}
+                  style={{ marginRight: '0.5rem', marginBottom: '0.5rem' }}
                 >
                   Not Running
                 </Label>
@@ -233,6 +234,7 @@ const ListItem = ({
               variant="outline"
               color="red"
               icon={<ExclamationCircleIcon />}
+              style={{ marginRight: '0.5rem', marginBottom: '0.5rem' }}
             >
               Not Running
             </Label>


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/tower-analytics-frontend/pull/873 - addressing the same issue on the details tab in savings planner.

Jira issue: https://issues.redhat.com/browse/AA-1412

![Screenshot 2022-11-02 at 3 57 14 PM](https://user-images.githubusercontent.com/89094075/199590494-256d2078-ff92-48e7-8f0a-ce9b1df6c3cf.png)