### PR TITLE
[AA-1323] Carry all filters to host anomaly scatterplot

### DIFF
--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -79,12 +79,22 @@ const ReportCard: FunctionComponent<StandardProps> = ({
   const redirectToHostScatter = (
     slug: string,
     templateId: any,
+    clusterId: any,
+    orgId: any,
+    inventoryId: any,
+    status: any,
+    hostStatus: any,
     quickDateRange: any
   ) => {
     const initialQueryParams = {
       [DEFAULT_NAMESPACE]: {
         ...specificReportDefaultParams(slug),
         template_id: templateId,
+        cluster_id: clusterId,
+        org_id: orgId,
+        inventory_id: inventoryId,
+        status: status,
+        host_status: hostStatus,
         quick_date_range: quickDateRange,
       },
     };
@@ -158,6 +168,11 @@ const ReportCard: FunctionComponent<StandardProps> = ({
     redirectToHostScatter(
       'host_anomalies_scatter',
       props.datum.id,
+      queryParams.cluster_id,
+      queryParams.org_id,
+      queryParams.inventory_id,
+      queryParams.status,
+      queryParams.host_status,
       queryParams.quick_date_range
     );
     window.location.reload();


### PR DESCRIPTION
When a specific bar is clicked in the host anomaly bar chart, ALL filters are carried to the host anomaly scatterplot report. Previously, only template and date range were being carried. 

Jira issue: https://issues.redhat.com/browse/AA-1323 

Before: 
![Screenshot 2022-11-09 at 3 14 54 PM](https://user-images.githubusercontent.com/89094075/200932616-37b45aac-d489-450a-9049-455315a90531.png)

After:
![Screenshot 2022-11-09 at 3 13 39 PM](https://user-images.githubusercontent.com/89094075/200932090-185b6d49-4e2a-419d-b3c4-40097c080e18.png)
