### PR TITLE
No data errors fix

### DIFF
--- a/src/Containers/Clusters/Clusters.js
+++ b/src/Containers/Clusters/Clusters.js
@@ -145,7 +145,7 @@ const Clusters = () => {
     fetchWorkflows(topWorkflowParams);
   }, [queryParams]);
 
-  if (error) return <ApiErrorState message={error.error} />;
+  if (error) return <ApiErrorState message={error.error.error} />;
 
   const renderContent = () => {
     // Warning: we are not checking if ALL the api succeed

--- a/src/Containers/Notifications/Notifications.tsx
+++ b/src/Containers/Notifications/Notifications.tsx
@@ -125,6 +125,7 @@ const Notifications: FC<Record<string, never>> = () => {
     result: { notifications: notificationsData, meta },
     isLoading,
     isSuccess,
+    error,
     request: fetchNotifications,
   } = useRequest<NotificationDataType>(
     useCallback(
@@ -229,6 +230,7 @@ const Notifications: FC<Record<string, never>> = () => {
                   />
                 </NotificationDrawer>
               )}
+              {error && <NoData />}
               <Pagination
                 count={meta?.count}
                 params={{

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -260,7 +260,7 @@ const OrganizationStatistics = () => {
           </Tabs>
           <CardBody>
             {orgsIsLoading && <LoadingState />}
-            {orgsError && <ApiErrorState message={orgsError.error} />}
+            {orgsError && <ApiErrorState message={orgsError.error.error} />}
             {orgsIsSuccess && orgs.dates?.length <= 0 && <NoData />}
             {orgsIsSuccess && orgs.dates?.length > 0 && (
               <GroupedBarChart
@@ -293,7 +293,7 @@ const OrganizationStatistics = () => {
           <Divider />
           <CardBody>
             {jobsIsLoading && <LoadingState />}
-            {jobsError && <ApiErrorState message={jobsError.error} />}
+            {jobsError && <ApiErrorState message={jobsError.error.error} />}
             {jobsIsSuccess && jobs.items?.length <= 0 && <NoData />}
             {jobsIsSuccess && jobs.items?.length > 0 && (
               <PieChart
@@ -314,7 +314,7 @@ const OrganizationStatistics = () => {
           <Divider />
           <CardBody>
             {tasksIsLoading && <LoadingState />}
-            {tasksError && <ApiErrorState message={tasksError.error} />}
+            {tasksError && <ApiErrorState message={tasksError.error.error} />}
             {tasksIsSuccess && tasks.items?.length <= 0 && <NoData />}
             {tasksIsSuccess && tasks.items?.length > 0 && (
               <PieChart

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
@@ -165,7 +165,7 @@ describe('Containers/OrganizationStatistics', () => {
       wrapper = mountPage(OrganizationStatistics);
     });
     wrapper.update();
-    expect(wrapper.text()).toEqual(expect.stringContaining('General Error'));
+    expect(wrapper.text()).toEqual(expect.stringContaining('Error'));
   });
 
   it('should render with empty response', async () => {

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -41,6 +41,7 @@ import { reportDefaultParams } from '../../../Utilities/constants';
 import { useQueryParams } from '../../../QueryParams';
 import FilterableToolbar from '../../../Components/Toolbar/Toolbar';
 import EmptyList from '../../../Components/EmptyList';
+import NoData from '../../../Components/ApiStatus/NoData';
 
 export interface Report {
   slug: string;
@@ -86,6 +87,7 @@ const List: FunctionComponent<Record<string, never>> = () => {
   const {
     result: { reports: data },
     isSuccess: isSuccess,
+    error: error,
     request: fetchReports,
   } = useRequest(readReports, { reports: [] });
 
@@ -315,6 +317,7 @@ const List: FunctionComponent<Record<string, never>> = () => {
           path={'/reports'}
         />
       )}
+      {error && <NoData />}
     </>
   );
 };

--- a/src/Containers/SavingsPlanner/List/List.js
+++ b/src/Containers/SavingsPlanner/List/List.js
@@ -101,7 +101,7 @@ const List = () => {
   };
 
   const renderContent = () => {
-    if (itemsError) return <ApiErrorState message={itemsError.error} />;
+    if (itemsError) return <ApiErrorState message={itemsError.error.error} />;
     if (itemsIsLoading || deleteLoading) return <LoadingState />;
     if (
       itemsIsSuccess &&


### PR DESCRIPTION
This PR fixes errors that a customer was seeing on many of the analytics pages when they have no data. Below is a list of pages that were fixed and the expected behavior:

- Organization statistics: Page will now display "No data" error component in any area (organizations, jobs, tasks) that is missing data

Before:
![Screenshot 2022-11-21 at 4 01 32 PM](https://user-images.githubusercontent.com/89094075/203157457-d581c009-0456-4cd6-aa2e-f5bc2525e881.png)

After:
![Screenshot 2022-11-21 at 3 50 24 PM](https://user-images.githubusercontent.com/89094075/203156030-8f248d8e-7a20-47cd-814f-cc6dd375c5fd.png)

- Clusters: Page will now display "No data" error component if there is missing data

Before: 
![Screenshot 2022-11-21 at 4 01 01 PM](https://user-images.githubusercontent.com/89094075/203157366-40a7e914-3272-4dc8-a256-c62a1c33fd31.png)

After: 
![Screenshot 2022-11-21 at 3 51 29 PM](https://user-images.githubusercontent.com/89094075/203155838-15680f33-f9d4-4b59-ae57-72dc7b9b0641.png)

- Reports: Page will now display "No data" component if there is missing reports data

Before: 
![Screenshot 2022-11-21 at 4 00 36 PM](https://user-images.githubusercontent.com/89094075/203157292-cb8bf399-24c0-41af-9602-24463591fc93.png)

After: 
![Screenshot 2022-11-21 at 3 53 28 PM](https://user-images.githubusercontent.com/89094075/203156166-f8f21add-f8b5-44c1-ba10-6703a2d4a3df.png)

- Savings planner: Page will now display "No data" error component if there is missing data

Before:
![Screenshot 2022-11-21 at 4 00 10 PM](https://user-images.githubusercontent.com/89094075/203157234-dd5f1c87-36b7-40c1-b82e-1acd6b3db23f.png)

After: 
![Screenshot 2022-11-21 at 3 55 38 PM](https://user-images.githubusercontent.com/89094075/203156475-279c0e24-5520-478b-bade-9d582f34bf58.png)

- Notifications: Page will now display "No data" component if there is missing data

Before:
![Screenshot 2022-11-21 at 3 59 15 PM](https://user-images.githubusercontent.com/89094075/203157092-83c6f729-9c21-4ea3-9315-169724374bb6.png)

After: 
![Screenshot 2022-11-21 at 3 57 12 PM](https://user-images.githubusercontent.com/89094075/203156749-7d7738da-37a9-4f54-9e62-3ea4e61eb102.png)

***FYI: Automation calculator and job explorer pages were already behaving as expected.
Automation calculator:
![Screenshot 2022-11-21 at 4 06 46 PM](https://user-images.githubusercontent.com/89094075/203158409-a199a534-101d-47ff-9e07-c63df185d22b.png)

Job explorer: 
![Screenshot 2022-11-21 at 4 06 29 PM](https://user-images.githubusercontent.com/89094075/203158443-22ed017f-7fbe-4132-9d15-fd66e2174587.png)