### PR TITLE
[AA-1472] crc alert banner for processing delays

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import useRequest from './Utilities/useRequest';
 import { preflightRequest } from './Api/';
 import AuthorizationErrorPage from './Components/ApiStatus/AuthorizationErrorPage';
+import { Alert } from '@patternfly/react-core';
 
 const el = document.getElementById('global-filter');
 if (el) el.style.display = 'none';
@@ -41,6 +42,11 @@ const App = () => {
 
   return (
     <div id="automation-analytics-application" version={packageJson.version}>
+      <Alert
+        isInline
+        variant="info"
+        title="Automation Analytics is experiencing performance issues. Displayed data will be delayed. We apologize for the inconvenience."
+      />
       {renderContent()}
     </div>
   );


### PR DESCRIPTION
Added an inline banner to the top of all automation analytics pages to alert customers of processing delays. The banner reads: "Automation Analytics is experiencing performance issues. Displayed data will be delayed. We apologize for the inconvenience."

Jira issue: https://issues.redhat.com/browse/AA-1472 

Before: 
![Screenshot 2022-12-05 at 12 09 53 PM](https://user-images.githubusercontent.com/89094075/205699332-9fbea7a4-3010-4379-947c-6177af0783b8.png)

After:
![Screenshot 2022-12-05 at 12 11 10 PM](https://user-images.githubusercontent.com/89094075/205699465-a86e264d-13bd-48f7-bf50-b1c13f123aa9.png)

cc @fullsushidev 