### PR TITLE
Fix reports preview not changing reports

### DIFF
--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import {
   PageHeader,

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -51,27 +51,8 @@ export interface Report {
   tableHeaders: string[];
 }
 
-export const removeFilters = (): string => {
-  const currentURL = window.location.href;
-  const newURL = '';
-  if (currentURL.includes('default.attributes[]')) {
-    newURL = currentURL.substring(
-      currentURL.indexOf('?') + 1,
-      currentURL.indexOf('default.attributes[]') - 1
-    );
-  } else if (
-    currentURL.includes('?') &&
-    currentURL.includes('default.attributes[]') === false
-  ) {
-    newURL = currentURL.substring(currentURL.indexOf('?') + 1);
-  }
-
-  return newURL;
-};
-
 const List: FunctionComponent<Record<string, never>> = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const history = useHistory();
   let index = 0;
   let nextItem = '';
   let previousItem = '';
@@ -218,9 +199,6 @@ const List: FunctionComponent<Record<string, never>> = () => {
                             data-cy={'previous_report_button'}
                             isDisabled={reports.indexOf(report) === 0}
                             onClick={() => {
-                              history.replace({
-                                search: removeFilters(),
-                              });
                               setSelected(previousItem);
                             }}
                           >
@@ -231,9 +209,6 @@ const List: FunctionComponent<Record<string, never>> = () => {
                             isPlain
                             onSelect={() => {
                               setIsOpen(!isOpen);
-                              history.replace({
-                                search: removeFilters(),
-                              });
                             }}
                             toggle={
                               <DropdownToggle
@@ -257,9 +232,6 @@ const List: FunctionComponent<Record<string, never>> = () => {
                               reports.indexOf(report) >= reports.length - 1
                             }
                             onClick={() => {
-                              history.replace({
-                                search: removeFilters(),
-                              });
                               setSelected(nextItem);
                             }}
                           >
@@ -300,7 +272,6 @@ const List: FunctionComponent<Record<string, never>> = () => {
                 report={report}
                 selected={selected}
                 setSelected={setSelected}
-                history={history}
               />
             ))}
           </Gallery>

--- a/src/Containers/Reports/List/ListItem/index.tsx
+++ b/src/Containers/Reports/List/ListItem/index.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
@@ -17,7 +17,6 @@ import {
 import paths from '../../paths';
 import { TAGS } from '../../Shared/constants';
 import { BaseReportProps } from '../../Layouts/types';
-import { removeFilters } from '../List';
 
 const CardTitle = styled(PFCardTitle)`
   word-break: break-word;
@@ -39,22 +38,17 @@ interface Props {
   report: BaseReportProps;
   selected: string;
   setSelected: (newSelection: string) => void;
-  history: RouteComponentProps['history'];
 }
 
 const ListItem: FunctionComponent<Props> = ({
   report: { slug, description, name, tags },
   selected,
   setSelected,
-  history,
 }) => {
   return (
     <Card
       data-cy={slug}
       onClick={() => {
-        history.replace({
-          search: removeFilters(),
-        });
         setSelected(slug);
       }}
       isSelectableRaised

--- a/src/QueryParams/Provider.tsx
+++ b/src/QueryParams/Provider.tsx
@@ -34,11 +34,18 @@ const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
   const update: UpdateFunction = ({
     newQueryParams,
     namespace = DEFAULT_NAMESPACE,
+    removeDefault = false,
   }) => {
-    const q = {
-      ...queryParams,
-      [namespace]: newQueryParams,
-    };
+    const q = removeDefault
+      ? {
+          ...queryParams,
+          [namespace]: newQueryParams,
+          [DEFAULT_NAMESPACE]: {},
+        }
+      : {
+          ...queryParams,
+          [namespace]: newQueryParams,
+        };
 
     setQsInUrl(q, history);
   };

--- a/src/QueryParams/types.ts
+++ b/src/QueryParams/types.ts
@@ -7,9 +7,11 @@ export type NamespacedQueryParams = Record<string, QueryParams>;
 export type UpdateFunction = ({
   newQueryParams,
   namespace,
+  removeDefault,
 }: {
   newQueryParams: QueryParams;
   namespace: string;
+  removeDefault: boolean;
 }) => void;
 
 export type RedirectWithQueryParamsProps = (

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -158,6 +158,10 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
   const executeAction = (action) => {
     if (action.type === 'RESET_FILTER') {
       update({ newQueryParams: initial, namespace });
+    } else if (action.type === 'SET_SELECTED_REPORT') {
+      const newQueryParams = paramsReducer(params, action);
+      //update params and remove everything from namespace default -> when changing selected report remove all settings for the old report
+      update({ newQueryParams, namespace, removeDefault: true });
     } else {
       const newQueryParams = paramsReducer(params, action);
       update({ newQueryParams, namespace });

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -157,7 +157,7 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
 
   const executeAction = (action) => {
     if (action.type === 'RESET_FILTER') {
-      update({ newQueryParams: initial, namespace });
+      update({ newQueryParams: initial, namespace, removeDefault: true });
     } else if (action.type === 'SET_SELECTED_REPORT') {
       const newQueryParams = paramsReducer(params, action);
       //update params and remove everything from namespace default -> when changing selected report remove all settings for the old report

--- a/src/QueryParams/useQueryParams.js
+++ b/src/QueryParams/useQueryParams.js
@@ -158,9 +158,9 @@ const useQueryParams = (initial, namespace = DEFAULT_NAMESPACE) => {
   const executeAction = (action) => {
     if (action.type === 'RESET_FILTER') {
       update({ newQueryParams: initial, namespace, removeDefault: true });
-    } else if (action.type === 'SET_SELECTED_REPORT') {
+    } else if (namespace === 'allReports') {
       const newQueryParams = paramsReducer(params, action);
-      //update params and remove everything from namespace default -> when changing selected report remove all settings for the old report
+      //update params and remove everything from namespace default -> when changing header filters (allReports)
       update({ newQueryParams, namespace, removeDefault: true });
     } else {
       const newQueryParams = paramsReducer(params, action);


### PR DESCRIPTION
**PR content:**
- removes all logic that changes URL params directly
- allows update function to take `removeDefault` params that says that all params in namespace default should be removed

**Problem:**

Before we allowed unlimited number of API calls so we could make changes to URL multiple times per one user action. Now we have limited the number of API calls so if we do multiple changes to URL per one user action only one of those changes will be processed and rest will be discarded. For the Reports page when a report is selected for preview it updates `selected_report` param and removed all default params. Only the second one was done. This PR does those two changes at once.

**Steps to reproduce:**
- Go to Reports page
- Try to select different report

**Before:**

First report is displayed 

**After:**

Selected report is displayed

_Note: This PR needs a lot of testing around selecting a report to be previewed in Reports page. Also testing that filtering in the toolbars is still working would be good._ 