### PR TITLE
No data message update

### DIFF
--- a/src/Components/ApiStatus/ApiStatusWrapper.test.js
+++ b/src/Components/ApiStatus/ApiStatusWrapper.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ApiStatusWrapper from './ApiStatusWrapper';
+
+describe('ApiStatusWrapper', () => {
+  it('should render loading state', async () => {
+    const props = {
+      api: {
+        isLoading: true,
+      },
+    };
+    render(<ApiStatusWrapper {...props} />);
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+  it('should render error state', async () => {
+    const props = {
+      api: {
+        error: {
+          error: {
+            error: 'Unauthorized',
+          },
+        },
+      },
+    };
+    render(<ApiStatusWrapper {...props} />);
+    expect(screen.getByText('Error')).toBeTruthy();
+    expect(screen.getByText('Unauthorized')).toBeTruthy();
+  });
+  it('should render custom NoData component', async () => {
+    const props = {
+      api: {
+        result: {
+          meta: {
+            count: 0,
+            tableData: [
+              {
+                host_id: 1533,
+                host_name: 'host_relevant_iguanas',
+                host_status: 'changed',
+                last_referenced: '2022-12-20T16:00:45.56121',
+                host_avg_duration_per_task: (1.0636375).toFixed(2),
+                total_tasks_executed: 12,
+                failed_duration: (1.0636375).toFixed(2),
+                successful_duration: null,
+                anomaly: false,
+              },
+            ],
+          },
+        },
+        isSuccess: true,
+      },
+      customEmptyState: false,
+    };
+    render(<ApiStatusWrapper {...props} />);
+    expect(
+      screen.getByText('There is currently no data to display.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Select a template filter to see data.')
+    ).toBeTruthy();
+  });
+  it('should render default NoData component', async () => {
+    const props = {
+      api: {
+        result: {
+          meta: {
+            count: 0,
+          },
+        },
+        isSuccess: true,
+      },
+      customEmptyState: false,
+    };
+    render(<ApiStatusWrapper {...props} />);
+    expect(screen.getByText('No Data')).toBeTruthy();
+  });
+});

--- a/src/Components/ApiStatus/ApiStatusWrapper.tsx
+++ b/src/Components/ApiStatus/ApiStatusWrapper.tsx
@@ -5,7 +5,7 @@ import NoData from './NoData';
 
 interface Props {
   api: {
-    result: { meta: { count: number } };
+    result: { meta: { count: number; tableData: [] } };
     error: {
       error: {
         error: string;
@@ -34,7 +34,19 @@ const ApiStatusWrapper: FunctionComponent<Props> = ({
     return <ApiErrorState message={api.error.error.error || api.error.error} />;
 
   if (api.isSuccess) {
-    if (api.result.meta.count === 0 && !customEmptyState) return <NoData />;
+    if (
+      api.result.meta.count === 0 &&
+      !customEmptyState &&
+      api.result.meta.tableData
+    )
+      return (
+        <NoData
+          title={'There is currently no data to display.'}
+          subtext={'Select a template filter to see data.'}
+        />
+      );
+    else if (api.result.meta.count === 0 && !customEmptyState)
+      return <NoData />;
     return <>{children}</>;
   }
 

--- a/src/Components/ApiStatus/NoData.test.js
+++ b/src/Components/ApiStatus/NoData.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NoData from './NoData';
+
+describe('NoData', () => {
+  it('should render successfully with passed params', async () => {
+    render(
+      <NoData
+        title={'There is currently no data to display.'}
+        subtext={'Select a template filter to see data.'}
+      />
+    );
+    expect(
+      screen.getByText('There is currently no data to display.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Select a template filter to see data.')
+    ).toBeTruthy();
+  });
+  it('should render successfully without params', async () => {
+    render(<NoData />);
+    expect(screen.getByText('No Data')).toBeTruthy();
+  });
+});

--- a/src/Components/ApiStatus/NoData.tsx
+++ b/src/Components/ApiStatus/NoData.tsx
@@ -4,15 +4,22 @@ import {
   EmptyState,
   EmptyStateVariant,
   EmptyStateIcon,
+  EmptyStateBody,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 
-const NoData: FunctionComponent<Record<string, never>> = () => (
+interface Props {
+  title?: string | Record<string, any>;
+  subtext?: string | Record<string, any>;
+}
+
+const NoData: FunctionComponent<Props> = ({ title, subtext }) => (
   <EmptyState variant={EmptyStateVariant.full} style={{ minHeight: '400px' }}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
-      No Data
+      {title ? title : 'No Data'}
     </Title>
+    {subtext && <EmptyStateBody>{subtext}</EmptyStateBody>}
   </EmptyState>
 );
 


### PR DESCRIPTION
The `NoData` component has been updated to display a more user-friendly message in the "Host runs in a job template" report. Previously when a user clicked on the report, a simple "No data" message was displayed. Now, the message instructs the user on how to see data in the report. 

Jira issue: https://issues.redhat.com/browse/AA-1501

Before: 
![Screenshot 2022-12-15 at 2 35 34 PM](https://user-images.githubusercontent.com/89094075/207951084-e80886de-9509-408a-b226-cfbbf2b0a859.png)

After:
![Screenshot 2022-12-15 at 2 36 00 PM](https://user-images.githubusercontent.com/89094075/207951083-4e0d3018-1ba9-4fb9-88cf-83fbe2f05896.png)