### PR TITLE
Fix left nav bar in standalone mode

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -29,8 +29,15 @@ const environmentSetup = {
     },
     registry: [
       ({ app }) =>
-        app.get('(/beta)?/config/chrome/ansible-navigation.json', (_req, res) =>
-          res.sendFile(resolve(__dirname, './ansible-navigation.json'))
+        app.get('/api/featureflags/v0', (_req, res) => {
+          res.send({ toggles: [] });
+        }),
+      ({ app }) =>
+        app.get(
+          '(/beta)?/config/chrome/ansible-navigation.json',
+          (_req, res) => {
+            res.sendFile(resolve(__dirname, './ansible-navigation.json'));
+          }
         ),
     ],
   }),


### PR DESCRIPTION
We are consuming left nav bar from https://github.com/RedHatInsights/insights-chrome/blob/ef63c8596285ab60ee2b769de2206e79662b78eb/src/components/Navigation/index.tsx
It uses https://github.com/RedHatInsights/insights-chrome/blob/master/src/utils/useNavigation.ts

After https://github.com/RedHatInsights/insights-chrome/pull/2157 it waits for Unleash to respond before it request navigation.json for the navigation component. In standalone mode we never get response from Unleash so we need to mock it to make it work.

When switching between branches with and without the fix you need to restart the UI because the change is in the webpack.

Before:
<img width="1714" alt="Screenshot 2023-01-03 at 11 26 39" src="https://user-images.githubusercontent.com/9210860/210381647-6ae0dc5e-7b91-4b75-b4e8-e199889cf925.png">

After:
<img width="978" alt="Screenshot 2023-01-03 at 15 53 48" src="https://user-images.githubusercontent.com/9210860/210381666-659b387b-54f9-4ce1-9af1-e068209b4c36.png">

Thanks @himdel and @MilanPospisil for debugging with me :)
