### PR TITLE
Add tooltips for report tiles to clarify action upon clicking on title vs description of report tiles.

### DIFF
--- a/src/Containers/Reports/List/ListItem/index.tsx
+++ b/src/Containers/Reports/List/ListItem/index.tsx
@@ -57,7 +57,9 @@ const ListItem: FunctionComponent<Props> = ({
       <CardHeader>
         <CardHeaderMain>
           <CardTitle>
-            <Link to={paths.getDetails(slug)}>{name}</Link>
+            <Tooltip content={<div>Click to go to report details.</div>}>
+              <Link to={paths.getDetails(slug)}>{name}</Link>
+            </Tooltip>
           </CardTitle>
         </CardHeaderMain>
       </CardHeader>

--- a/src/Containers/Reports/List/ListItem/index.tsx
+++ b/src/Containers/Reports/List/ListItem/index.tsx
@@ -63,7 +63,13 @@ const ListItem: FunctionComponent<Props> = ({
           </CardTitle>
         </CardHeaderMain>
       </CardHeader>
-      <CardBody>{description ? <Small>{description}</Small> : null}</CardBody>
+      <CardBody>
+        {description ? (
+          <Tooltip content={<div>Open report preview</div>} position="bottom">
+            <Small>{description}</Small>
+          </Tooltip>
+        ) : null}
+      </CardBody>
       <CardFooter>
         {tags.map((tagKey, idx) => {
           const tag = TAGS.find((t) => t.key === tagKey);

--- a/src/Containers/Reports/List/ListItem/index.tsx
+++ b/src/Containers/Reports/List/ListItem/index.tsx
@@ -57,7 +57,7 @@ const ListItem: FunctionComponent<Props> = ({
       <CardHeader>
         <CardHeaderMain>
           <CardTitle>
-            <Tooltip content={<div>Click to go to report details.</div>}>
+            <Tooltip content={<div>Click to go to report details</div>}>
               <Link to={paths.getDetails(slug)}>{name}</Link>
             </Tooltip>
           </CardTitle>
@@ -65,7 +65,10 @@ const ListItem: FunctionComponent<Props> = ({
       </CardHeader>
       <CardBody>
         {description ? (
-          <Tooltip content={<div>Open report preview</div>} position="bottom">
+          <Tooltip
+            content={<div>Show report in preview</div>}
+            position="bottom"
+          >
             <Small>{description}</Small>
           </Tooltip>
         ) : null}


### PR DESCRIPTION
This change adds tooltips to clarify action upon clicking on report tile.

Jira issue: [https://issues.redhat.com/browse/AA-1523](https://issues.redhat.com/browse/AA-1523)

![Screenshot 2023-01-13 at 9 51 53 AM](https://user-images.githubusercontent.com/14355897/212399156-0fbcf134-9049-439b-90a3-e1b61f7b896b.png)


![Screenshot 2023-01-13 at 9 52 09 AM](https://user-images.githubusercontent.com/14355897/212399225-4aaa27be-4b3d-4e59-8530-d76a6233d0d3.png)


