### PR TITLE
[AA-1528] open external job links in new tab

### DIFF
--- a/src/Containers/JobExplorer/JobExplorerListRow.js
+++ b/src/Containers/JobExplorer/JobExplorerListRow.js
@@ -150,7 +150,7 @@ const JobExplorerListRow = ({ job }) => {
           <a
             href={job.id.tower_link}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >{`${job.id.id} - ${job.id.template_name}`}</a>
         </Td>
         <Td>

--- a/src/Containers/JobExplorer/JobExplorerListRow.js
+++ b/src/Containers/JobExplorer/JobExplorerListRow.js
@@ -150,7 +150,7 @@ const JobExplorerListRow = ({ job }) => {
           <a
             href={job.id.tower_link}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >{`${job.id.id} - ${job.id.template_name}`}</a>
         </Td>
         <Td>

--- a/src/Containers/JobExplorer/JobExplorerListRow.js
+++ b/src/Containers/JobExplorer/JobExplorerListRow.js
@@ -149,6 +149,8 @@ const JobExplorerListRow = ({ job }) => {
         <Td>
           <a
             href={job.id.tower_link}
+            target="_blank"
+            rel="noreferrer"
           >{`${job.id.id} - ${job.id.template_name}`}</a>
         </Td>
         <Td>


### PR DESCRIPTION
Jira issue: [https://issues.redhat.com/browse/AA-1528](https://issues.redhat.com/browse/AA-1528)

This PR edits the external job links in the job explorer page to open in a new tab.

Links in page below now open in new tab.
![Screenshot 2023-01-19 at 11 10 21 AM](https://user-images.githubusercontent.com/14355897/213537852-4cd3fe09-1efd-484e-91ac-73abc8b702c4.png)
