### PR TITLE
Aa185 update async component loading screen

### DIFF
--- a/src/Utilities/asyncComponent.js
+++ b/src/Utilities/asyncComponent.js
@@ -1,4 +1,10 @@
 import React, { Component } from 'react';
+import {
+  Title,
+  EmptyState,
+  EmptyStateIcon,
+  Spinner,
+} from '@patternfly/react-core';
 
 /**
  * Webpack allows loading components asynchronously by using import().
@@ -44,7 +50,13 @@ export default function asyncComponent(importComponent) {
           <C {...this.props} />
         </div>
       ) : (
-        <div data-cy="loading">Loading...</div>
+        //<div data-cy="loading">Loading...</div>
+        <EmptyState>
+          <EmptyStateIcon variant="container" component={Spinner} />
+          <Title size="lg" headingLevel="h4">
+            Loading
+          </Title>
+        </EmptyState>
       );
     }
   }

--- a/src/Utilities/asyncComponent.js
+++ b/src/Utilities/asyncComponent.js
@@ -50,7 +50,6 @@ export default function asyncComponent(importComponent) {
           <C {...this.props} />
         </div>
       ) : (
-        //<div data-cy="loading">Loading...</div>
         <EmptyState>
           <EmptyStateIcon variant="container" component={Spinner} />
           <Title size="lg" headingLevel="h4">


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AA-185

This PR replaces the "Loading..." text with a spinner when loading components.

Before:

https://user-images.githubusercontent.com/14355897/214971027-04714a95-cafa-4386-9045-a4775561ad8e.mov


After:

https://user-images.githubusercontent.com/14355897/214970622-dfbbff9f-e87c-45d1-90f1-d1798d128fe7.mov

