### PR TITLE
Fix issue with missing scopes opeid and nameandterms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@babel/preset-typescript": "^7.13.0",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
         "@redhat-cloud-services/frontend-components-config": "^4.6.11",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.29",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
         "@testing-library/react-hooks": "^7.0.2",
@@ -3012,9 +3013,10 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.5.20",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.29.tgz",
+      "integrity": "sha512-YOnJEwb6AdLJxY6P81VtunECQupL32taSnCHOP1+A1P7OjNIewZJcgjqqlWip3+o5DCPyCOiOl0eBHrTCUPldg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "2.6.7"
       },
@@ -22920,7 +22922,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.5.20",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.29.tgz",
+      "integrity": "sha512-YOnJEwb6AdLJxY6P81VtunECQupL32taSnCHOP1+A1P7OjNIewZJcgjqqlWip3+o5DCPyCOiOl0eBHrTCUPldg==",
       "dev": true,
       "requires": {
         "node-fetch": "2.6.7"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
     "@redhat-cloud-services/frontend-components-config": "^4.6.11",
+    "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.29",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@testing-library/react-hooks": "^7.0.2",


### PR DESCRIPTION
Update @redhat-cloud-services/frontend-components-config-utilities to one with fixed issue with openid and nameandterms scopes

Relevant change https://github.com/RedHatInsights/frontend-components/pull/1714

Before:
Neverending looping
After:
Works correctly