### PR TITLE
[AA-1557] fix unable to save changes to manual time

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -102,14 +102,22 @@ const Row: FunctionComponent<Props> = ({
               style={{ maxWidth: '150px' }}
               type="number"
               aria-label="time run manually"
-              value={template.avgRunTime / 60}
-              onBlur={() => window.localStorage.setItem('focused', '')}
-              onChange={(minutes) => {
+              defaultValue={template.avgRunTime / 60}
+              onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
+                const minutes = +event.target.value;
+                if (minutes <= 0 || isNaN(minutes)) {
+                  event.target.value = '60';
+                  setDataRunTime(+event.target.value * 60, template.id);
+                } else {
+                  setDataRunTime(minutes * 60, template.id);
+                }
+                window.localStorage.setItem('focused', '');
+              }}
+              onChange={() => {
                 window.localStorage.setItem(
                   'focused',
                   'manual-time-' + template.id.toString()
                 );
-                setDataRunTime(+minutes * 60, template.id);
               }}
               isDisabled={readOnly}
             />


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AA-1557

This PR changes the behavior of the Manual Time textInput field to wait until the user clicks away from the field before resetting an empty value or 0 back to the default value of 60. This allows the user to clear the field and enter a new value. It also checks the value when changed, and only makes a call to the API if the value is greater than 0 or empty.

Before:

https://user-images.githubusercontent.com/14355897/229197811-511af8fe-5f84-425a-924a-45b882b34cdb.mov

After:

https://user-images.githubusercontent.com/14355897/229197463-aeb2ff3d-24fd-4450-99fc-e37f38070e9d.mov


