### PR TITLE
[AA-1649] custom date range selection fix

### DIFF
--- a/src/Utilities/helpers.test.js
+++ b/src/Utilities/helpers.test.js
@@ -28,6 +28,9 @@ describe('Utilities/helpers/formatDate', () => {
   it('handles stringy ISO formats with timestamps', () => {
     expect(formatDate('2020-10-01T00:00:00')).toBe('2020-10-01');
   });
+  it('handle date objects', () => {
+    expect(formatDate(new Date('2020-10-01'))).toBe('2020-10-01');
+  });
 });
 
 describe('Utilities/helpers/getTotal', () => {

--- a/src/Utilities/helpers.ts
+++ b/src/Utilities/helpers.ts
@@ -10,7 +10,7 @@ export const formatTotalTime = (elapsed: number): string =>
 export const formatDateTime = (dateTime: string | number): string =>
   moment(new Date(dateTime).toISOString()).format('M/D/YYYY h:mm:ssa');
 
-export const formatDate = (date: Date): string =>
+export const formatDate = (date: Date | string): string =>
   moment(date).format('YYYY-MM-DD');
 
 export const getTotal = (


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AA-1649

Issue with custom date range error seems to be caused by formatDate only taking Date objects, while some .js files pass strings to the function. This fix changes the function to take in a Date object or a string, and expands the test to also check that Date objects are formatted correctly.