### PR TITLE
Filtering fixes

### DIFF
--- a/src/Components/Toolbar/Groups/FiltersCategoriesGroup.tsx
+++ b/src/Components/Toolbar/Groups/FiltersCategoriesGroup.tsx
@@ -38,7 +38,7 @@ const FilterCategoriesGroup: FunctionComponent<Props> = ({
         <ToolbarInput
           key={key}
           categoryKey={key}
-          value={filters[key]}
+          value={filterCategories[key].length > 0 ? filters[key] : ''}
           selectOptions={filterCategories[key]}
           isVisible={currentCategory === key}
           setValue={(value) => setFilters(key, value)}

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -274,7 +274,7 @@ const List: FunctionComponent<Record<string, never>> = () => {
             'No results match the filter criteria. Clear all filters and try again.'
           }
           showButton={true}
-          path={'/reports'}
+          path={'/ansible/automation-analytics/reports'}
         />
       )}
       {error && <NoData />}


### PR DESCRIPTION
This PR addresses a bug in the "Host runs in a job template" report where if there is no data for a selected date range, the template dropdown in the toolbar got corrupted. 

Jira issue: https://issues.redhat.com/browse/AA-1502 

There was an additional change made in the reports list view to address the broken redirect upon clicking the "clear all filters" button in the empty state (no jira issue).

Before (template dropdown):
![Screenshot 2023-05-16 at 9 59 05 AM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/2ef86e07-2f33-49c0-ac8c-a2b867d3e531)

After (template dropdown):
![Screenshot 2023-05-22 at 11 50 36 AM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/00095b69-12a7-4140-a51c-fef912edff1c)

Before (clear filters redirect):
![Screenshot 2023-05-22 at 11 49 39 AM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/63f7f87d-48c8-4c5f-841c-67e14579ee68)

After (clear filters redirect):
![Screenshot 2023-05-22 at 11 48 21 AM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/ed80e058-de12-47ba-be0d-f33fbd32b52a)