### PR TITLE
Fix Jest test in GH action

### DIFF
--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.test.js
@@ -131,7 +131,7 @@ describe('Containers/OrganizationStatistics', () => {
     });
 
     fetchMock.restore();
-    wrapper = null;
+    wrapper.unmount();
   });
 
   it('should render without any errors', async () => {


### PR DESCRIPTION
Unmount wrapper to prevent error: `TypeError: Cannot read property '_location' of null`. This happens irreguleraly. 

cc: @fullsushidev 