### PR TITLE
[AA-1732] Templates by org clickable linking fix

### DIFF
--- a/src/Containers/Reports/Layouts/Standard/Table/TableRow.tsx
+++ b/src/Containers/Reports/Layouts/Standard/Table/TableRow.tsx
@@ -15,9 +15,14 @@ import { LegendEntry, TableHeaders } from '../types';
 import { ExpandedTableRowName, getExpandedRowComponent } from '../Components';
 import paths from '../../../paths';
 import { Tooltip } from '@patternfly/react-core';
-import { DEFAULT_NAMESPACE, createUrl } from '../../../../../QueryParams';
+import {
+  DEFAULT_NAMESPACE,
+  createUrl,
+  useQueryParams,
+} from '../../../../../QueryParams';
 import { useNavigate } from 'react-router-dom';
 import { specificReportDefaultParams } from '../../../../../Utilities/constants';
+import { QueryParams } from '../../../../../QueryParams/types';
 
 const timeFields: string[] = ['elapsed'];
 const costFields: string[] = [];
@@ -66,11 +71,7 @@ const TableRow: FunctionComponent<Params> = ({
   clickableLinking,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const readArray = (array: any[]) => {
-    for (let i = 0; i < array.length; i++) {
-      return array[i];
-    }
-  };
+
   const navigate = useNavigate();
 
   const navigateToModuleBy = (slug: string, moduleId: any) => {
@@ -88,11 +89,22 @@ const TableRow: FunctionComponent<Params> = ({
       )
     );
   };
-  const navigateToTemplatesExplorer = (slug: string, yPercentileList: any) => {
+  const navigateToTemplatesExplorer = (
+    slug: string,
+    org_id: any,
+    queryParams: QueryParams
+  ) => {
     const initialQueryParams = {
       [DEFAULT_NAMESPACE]: {
         ...specificReportDefaultParams(slug),
-        template_id: readArray([yPercentileList]),
+        org_id: [org_id],
+        template_id: queryParams.template_id,
+        cluster_id: queryParams.cluster_id,
+        inventory_id: queryParams.inventory_id,
+        status: queryParams.status,
+        limit: queryParams.limit,
+        granularity: queryParams.granularity,
+        quick_date_range: queryParams.quick_date_range,
       },
     };
     navigate(
@@ -108,6 +120,10 @@ const TableRow: FunctionComponent<Params> = ({
     item: Record<string, string | number>,
     key: string
   ) => {
+    const { queryParams } = useQueryParams(
+      specificReportDefaultParams('templates_by_organization')
+    );
+
     const countMapper: { [key: string]: string } = {
       host_task_count: 'module_usage_by_task',
       total_org_count: 'module_usage_by_organization',
@@ -127,14 +143,15 @@ const TableRow: FunctionComponent<Params> = ({
         </Tooltip>
       );
     }
-    if (Object.keys(countMapper).includes(key) && item.y_percentile_list) {
+    if (Object.keys(countMapper).includes(key) && item.org_id) {
       return (
         <Tooltip content={`View ${item.org_name} usage`}>
           <a
             onClick={() =>
               navigateToTemplatesExplorer(
                 countMapper[key],
-                item.y_percentile_list
+                item.org_id,
+                queryParams
               )
             }
           >{`${item[key]}`}</a>


### PR DESCRIPTION
When navigating from templates by organization to templates explorer by clicking on the numbers in the table, the templates explorer report will now be filtered by the organization id rather than by a list of templates. Any additional filters that were applied in the templates by organization report will also be carried over to templates explorer, if the filter option exists there. 

Jira issue: https://issues.redhat.com/browse/AA-1732

Before: 
![Screenshot 2023-06-08 at 5 02 00 PM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/545bfe87-f6b7-4221-ba0f-92bdf1b4c5cf)

After:
![Screenshot 2023-06-08 at 5 04 41 PM](https://github.com/RedHatInsights/tower-analytics-frontend/assets/89094075/ef62580e-4cd8-4e88-b700-5b0999a4d400)