### PR TITLE
Cypress login refactoring

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -41,9 +41,7 @@ describe('Automation Calculator page', () => {
       .getByCy('current_page_savings')
       .find('h3').textContent;
     let originalSavingsValues = [];
-    cy.getByCy('savings').each(($el) =>
-      originalSavingsValues.push($el.text())
-    );
+    cy.getByCy('savings').each(($el) => originalSavingsValues.push($el.text()));
 
     cy.get('#manual-cost').clear();
     waitToLoad();
@@ -207,9 +205,10 @@ describe('Automation Calculator page', () => {
   it('shows empty state when all rows are hidden', () => {
     // most of this is dupplicated code and should be merged
 
-    let originalTotalSavingsValue = ENV != ENVS.STAGE ? '$' : cy
-      .getByCy('total_savings')
-      .find('h3').textContent;
+    let originalTotalSavingsValue =
+      ENV != ENVS.STAGE
+        ? '$'
+        : cy.getByCy('total_savings').find('h3').textContent;
 
     if (ENV != ENVS.STAGE) {
       cy.tableShowAll();

--- a/cypress/e2e/Clusters.spec.js
+++ b/cypress/e2e/Clusters.spec.js
@@ -1,4 +1,3 @@
-/* global cy */
 import { clustersUrl, ENV, ENVS } from '../support/constants';
 const appid = Cypress.env('appid');
 
@@ -9,7 +8,7 @@ describe('Clusters page', () => {
     cy.intercept('/api/tower-analytics/v1/event_explorer/*').as(
       'eventExplorerData'
     );
-    cy.wait('@eventExplorerData', ENV == ENVS.STAGE ? {timeout: 10000}: {});
+    cy.wait('@eventExplorerData', ENV == ENVS.STAGE ? { timeout: 10000 } : {});
 
     cy.get('[data-cy="spinner"]').should('not.exist');
     cy.get('[data-cy="loading"]').should('not.exist');
@@ -21,11 +20,11 @@ describe('Clusters page', () => {
   it('loads clusters page with Bar graph and other tables', () => {
     cy.get('[data-cy="card-title-job-status"]').find('h2').textContent;
 
-    if(ENV == ENVS.STAGE) {
+    if (ENV == ENVS.STAGE) {
       cy.contains('Clear all filters').should('exist');
     }
 
-    if(ENV != ENVS.STAGE) {
+    if (ENV != ENVS.STAGE) {
       /* FIXME
       For some reason this element is considered not visible and cypress
       finds 2 of them, instead of 1.
@@ -52,7 +51,7 @@ describe('Clusters page', () => {
       .should('exist');
     cy.get('[data-cy="barchart"]').should('exist');
     cy.get('#d3-bar-chart-root').should('exist');
-    if(ENV == ENVS.STAGE) {
+    if (ENV == ENVS.STAGE) {
       cy.get('@btnClearAllFilters').should('exist');
     }
     cy.get('h3').contains('Top workflows').should('exist');
@@ -79,11 +78,11 @@ describe('Clusters page', () => {
   it('has anchor clear filters link', () => {
     cy.get('div.pf-c-empty-state__content').should('not.exist');
 
-    if(ENV == ENVS.STAGE) {
-      cy.get('[data-cy="filter-toolbar"')
+    if (ENV == ENVS.STAGE) {
+      cy.get('[data-cy="filter-toolbar"');
     }
 
-    if(ENV != ENVS.STAGE) {
+    if (ENV != ENVS.STAGE) {
       /* FIXME
       For some reason this element is considered not visible and cypress
       finds 2 of them, instead of 1.
@@ -111,18 +110,20 @@ describe('Clusters page', () => {
     // Wait for loading and check the selected filter is present
     cy.get('.pf-c-empty-state__content').should('not.exist');
     cy.get('.pf-c-chip-group__main').contains('Cluster').should('exist');
-    cy.get('.pf-c-chip-group__main').contains('ec2-52-90-106-02.compute-1.amazonaws.com').should('exist');
+    cy.get('.pf-c-chip-group__main')
+      .contains('ec2-52-90-106-02.compute-1.amazonaws.com')
+      .should('exist');
 
-    if(ENV == ENVS.STAGE) {
+    if (ENV == ENVS.STAGE) {
       cy.get('[data-cy="filter-toolbar"')
-      .find('button')
-      .contains('Clear all filters')
-      .click({
-        force: true
-      });
+        .find('button')
+        .contains('Clear all filters')
+        .click({
+          force: true,
+        });
     }
 
-    if(ENV != ENVS.STAGE) {
+    if (ENV != ENVS.STAGE) {
       cy.get('@btnClearAllFilters').should('exist');
       cy.get('@btnClearAllFilters').click({ force: true }); //FIXME
     }
@@ -155,7 +156,7 @@ describe('Clusters page', () => {
           .find('#d3-bar-chart-root > svg > g > g > rect')
           .eq(ix)
           .trigger('mouseover', {
-            force: true
+            force: true,
           });
         cy.get('[id^=svg-chart-Tooltip]').should('have.css', 'opacity', '1');
       });
@@ -169,7 +170,7 @@ describe('Clusters page', () => {
           .find('*[class^="pf-c-data-list pf-m-grid-md"] > li > div')
           .eq(ix)
           .trigger('mouseover', {
-            force: true
+            force: true,
           });
       });
   });
@@ -182,7 +183,7 @@ describe('Clusters page', () => {
           .find('[data-cy="top-modules-header"] > ul> li > div')
           .eq(ix)
           .trigger('mouseover', {
-            force: true
+            force: true,
           });
       });
   });

--- a/cypress/e2e/Dashboard.spec.js
+++ b/cypress/e2e/Dashboard.spec.js
@@ -62,7 +62,7 @@ We should review the duplicated code/tests and merge it with the clusters one.
 // }
 
 // describe('Dashboard page smoketests', () => {
-//   beforeEach(() => {    
+//   beforeEach(() => {
 //     cy.visit(dashboardUrl);
 //   });
 

--- a/cypress/e2e/Global.spec.js
+++ b/cypress/e2e/Global.spec.js
@@ -1,4 +1,3 @@
-/* global cy */
 import {
   dashboardUrl,
   orgsUrl,
@@ -12,10 +11,9 @@ import {
 } from '../support/constants';
 
 describe('Insights smoketests', () => {
-
   it('has all the AA navigation items', () => {
     cy.visit(dashboardUrl);
-   // cy.wait(5000);
+    // cy.wait(5000);
     // This is not applicable to eph. env.
     /*
     cy.getByOUIALike('OUIA-Generated-NavExpandable')
@@ -26,10 +24,10 @@ describe('Insights smoketests', () => {
 
     //cy.get('[data-quickstart-id="Automation-Analytics"]') // this is for devel or stage
     cy.get('[data-ouia-component-id="SideNavigation"]') // this is for eph. env.
-        .find('a')
+      .find('a')
       //.should('have.length', 7)
 
-        /*
+      /*
       .get('[data-quickstart-id="ansible_automation-analytics_organization-statistics"]')
       .click()
       .url().should('eq', Cypress.config().baseUrl + orgsUrl)
@@ -37,27 +35,37 @@ describe('Insights smoketests', () => {
 
       .get('[data-quickstart-id="ansible_automation-analytics_job-explorer"]')
       .click()
-      .url().should('eq', Cypress.config().baseUrl + jobExplorerUrl)
+      .url()
+      .should('eq', Cypress.config().baseUrl + jobExplorerUrl)
 
       .get('[data-quickstart-id="ansible_automation-analytics_clusters"]')
       .click()
-      .url().should('eq', Cypress.config().baseUrl + clustersUrl)
+      .url()
+      .should('eq', Cypress.config().baseUrl + clustersUrl)
 
       .get('[data-quickstart-id="ansible_automation-analytics_reports"]')
       .click()
-      .url().should('eq', Cypress.config().baseUrl + reportsUrl)
+      .url()
+      .should('eq', Cypress.config().baseUrl + reportsUrl)
 
-      .get('[data-quickstart-id="ansible_automation-analytics_savings-planner"]')
+      .get(
+        '[data-quickstart-id="ansible_automation-analytics_savings-planner"]'
+      )
       .click()
-      .url().should('eq', Cypress.config().baseUrl + savingsPlannerUrl)
+      .url()
+      .should('eq', Cypress.config().baseUrl + savingsPlannerUrl)
 
-      .get('[data-quickstart-id="ansible_automation-analytics_automation_calculator"]')
+      .get(
+        '[data-quickstart-id="ansible_automation-analytics_automation_calculator"]'
+      )
       .click()
-      .url().should('eq', Cypress.config().baseUrl + calculatorUrlDirect)
+      .url()
+      .should('eq', Cypress.config().baseUrl + calculatorUrlDirect)
 
       .get('[data-quickstart-id="ansible_automation-analytics_notifications"]')
       .click()
-      .url().should('eq', Cypress.config().baseUrl + notificationsUrl);
+      .url()
+      .should('eq', Cypress.config().baseUrl + notificationsUrl);
   });
 
   // This function checks that there's no 500/404/403 warning in the UI
@@ -70,7 +78,7 @@ describe('Insights smoketests', () => {
     cy.get('[data-cy="page_component"]').should('exist');
   };
 
-// TODO: include assetion maybe with snapshots
+  // TODO: include assetion maybe with snapshots
   it('can open each page without breaking the UI', () => {
     cy.visit(orgsUrl);
     checkPageHasNoErrors();

--- a/cypress/e2e/JobExplorer.spec.js
+++ b/cypress/e2e/JobExplorer.spec.js
@@ -1,9 +1,7 @@
 import { jobExplorerUrl } from '../support/constants';
 
-const appid = Cypress.env('appid');
-
 describe('Job Explorer page smoketests', () => {
-  beforeEach(() => {    
+  beforeEach(() => {
     cy.visit(jobExplorerUrl);
 
     cy.get('[data-cy="spinner"]').should('not.exist');
@@ -27,12 +25,12 @@ describe('Job Explorer page smoketests', () => {
   });
 
   it('Can navigate through the pages', () => {
-    cy.testNavArrowsFlow('top_pagination')
-    cy.testNavArrowsFlow('pagination_bottom')
+    cy.testNavArrowsFlow('top_pagination');
+    cy.testNavArrowsFlow('pagination_bottom');
   });
 
   it('Can change the number of items shown on the list', () => {
-    cy.testItemsListFlow('top_pagination', 'jbex')
-    cy.testItemsListFlow('pagination_bottom', 'jbex')
+    cy.testItemsListFlow('top_pagination', 'jbex');
+    cy.testItemsListFlow('pagination_bottom', 'jbex');
   });
 });

--- a/cypress/e2e/Notifications.spec.js
+++ b/cypress/e2e/Notifications.spec.js
@@ -1,4 +1,3 @@
-/* global cy, Cypress */
 import { notificationsUrl } from '../support/constants';
 
 const appid = Cypress.env('appid');

--- a/cypress/e2e/OrganizationStatistics.spec.js
+++ b/cypress/e2e/OrganizationStatistics.spec.js
@@ -1,4 +1,3 @@
-/* global cy, Cypress */
 import { orgsUrl } from '../support/constants';
 
 const appid = Cypress.env('appid');

--- a/cypress/e2e/Reports.spec.js
+++ b/cypress/e2e/Reports.spec.js
@@ -1,14 +1,14 @@
-import { aapUrl, reportsUrl, allReports, skippedTests, ENV, ENVS } from '../support/constants'
+import { reportsUrl, allReports, skippedTests } from '../support/constants';
 
 describe("Reports' navigation on Reports page - smoketests", () => {
   beforeEach(() => {
-    cy.intercept('api/tower-analytics/v1/event_explorer/*').as('eventExplorer')
-    cy.visit(reportsUrl)
-    cy.getByCy('loading').should('not.exist')
-    cy.getByCy('api_error_state').should('not.exist')
-    cy.getByCy('api_loading_state').should('not.exist')
-    cy.wait('@eventExplorer')
-  })
+    cy.intercept('api/tower-analytics/v1/event_explorer/*').as('eventExplorer');
+    cy.visit(reportsUrl);
+    cy.getByCy('loading').should('not.exist');
+    cy.getByCy('api_error_state').should('not.exist');
+    cy.getByCy('api_loading_state').should('not.exist');
+    cy.wait('@eventExplorer');
+  });
 
   // TODO: flaky and redundant test, we need to rewrite it
   // it('All report cards can appear in preview via dropdown', () => {
@@ -20,42 +20,47 @@ describe("Reports' navigation on Reports page - smoketests", () => {
 
   // FIXME: Workaround to force cypress to wait the graph to load
   it('All report are accessible in preview via arrows', () => {
-    let originalTitlePreview = cy.getByCy('preview_title_link').textContent
+    let originalTitlePreview = cy.getByCy('preview_title_link').textContent;
     allReports.forEach((report) => {
-      cy.log(report)
-      if (skippedTests["reports"].includes(report)) return;
-      cy.getByCy('next_report_button').click()
+      cy.log(report);
+      if (skippedTests['reports'].includes(report)) return;
+      cy.getByCy('next_report_button').click();
       cy.getByCy('preview_title_link').then(($previewTitle) => {
-        const newTitlePreview = $previewTitle.text()
-        expect(newTitlePreview).not.to.eq(originalTitlePreview)
-        originalTitlePreview = newTitlePreview
-      })
-    })
+        const newTitlePreview = $previewTitle.text();
+        expect(newTitlePreview).not.to.eq(originalTitlePreview);
+        originalTitlePreview = newTitlePreview;
+      });
+    });
     allReports.forEach((report) => {
-      cy.log(report)
-      if (skippedTests["reports"].includes(report)) return;
-      cy.getByCy('previous_report_button').click()
+      cy.log(report);
+      if (skippedTests['reports'].includes(report)) return;
+      cy.getByCy('previous_report_button').click();
       cy.getByCy('preview_title_link').then(($previewTitle) => {
-        const newTitlePreview = $previewTitle.text()
-        expect(newTitlePreview).not.to.eq(originalTitlePreview)
-        originalTitlePreview = newTitlePreview
-      })
-    })
-  })
+        const newTitlePreview = $previewTitle.text();
+        expect(newTitlePreview).not.to.eq(originalTitlePreview);
+        originalTitlePreview = newTitlePreview;
+      });
+    });
+  });
 
   it('All report are accessible in preview via dropdownn', () => {
-    cy.getByCy('selected_report_dropdown').should('exist')
+    cy.getByCy('selected_report_dropdown').should('exist');
     allReports.forEach((item, index) => {
-      cy.log(item)
-      if (skippedTests["reports"].includes(item)) return;
+      cy.log(item);
+      if (skippedTests['reports'].includes(item)) return;
 
-      cy.getByCy('selected_report_dropdown').click()
-      cy.get('ul.pf-c-dropdown__menu > button > li > a').should('exist')
-      cy.get('ul.pf-c-dropdown__menu > button > li > a').eq(index).click()
-      cy.getByCy('preview_title_link').invoke('text').then((item) => {
-        cy.get('[data-cy="selected_report_dropdown"] > span.pf-c-dropdown__toggle-text')
-          .invoke('text').should('eq', item)
-      })
-    })
-  })
-})
+      cy.getByCy('selected_report_dropdown').click();
+      cy.get('ul.pf-c-dropdown__menu > button > li > a').should('exist');
+      cy.get('ul.pf-c-dropdown__menu > button > li > a').eq(index).click();
+      cy.getByCy('preview_title_link')
+        .invoke('text')
+        .then((item) => {
+          cy.get(
+            '[data-cy="selected_report_dropdown"] > span.pf-c-dropdown__toggle-text'
+          )
+            .invoke('text')
+            .should('eq', item);
+        });
+    });
+  });
+});

--- a/cypress/e2e/ReportsPage.spec.js
+++ b/cypress/e2e/ReportsPage.spec.js
@@ -29,8 +29,7 @@ describe('Reports page smoketests', () => {
       cy.log(item)
       if (skippedTests["reports"].includes(item)) return;
 
-      cy.getByCy(item).should('exist')
-      cy.getByCy(item).click()
+      cy.getByCy(item).click().should('exist');
       if (ENV != ENVS.STAGE) {
         cy.waitSpinner();
       }
@@ -79,7 +78,7 @@ describe('Reports page smoketests', () => {
       cy.log(report)
       if (skippedTests["reports"].includes(report)) return;
       cy.getByCy('previous_report_button').click()
-      cy.wait(250);
+
       cy.getByCy('preview_title_link').then((previewTitle) => {
         cy.log(previewTitle)
         const newTitlePreview = previewTitle.text()

--- a/cypress/e2e/ReportsPage.spec.js
+++ b/cypress/e2e/ReportsPage.spec.js
@@ -1,53 +1,70 @@
-import { aapUrl, reportsUrl, allReports, skippedTests, ENV, ENVS } from '../support/constants'
+import {
+  aapUrl,
+  reportsUrl,
+  allReports,
+  skippedTests,
+  ENV,
+  ENVS,
+} from '../support/constants';
 
 describe('Reports page smoketests', () => {
   beforeEach(() => {
-    cy.intercept('api/tower-analytics/v1/event_explorer/*').as('eventExplorer')
-    cy.visit(reportsUrl)
-    cy.getByCy('loading').should('not.exist')
-    cy.getByCy('api_error_state').should('not.exist')
-    cy.getByCy('api_loading_state').should('not.exist')
-    cy.wait('@eventExplorer')
-  })
+    cy.intercept('api/tower-analytics/v1/event_explorer/*').as('eventExplorer');
+    cy.visit(reportsUrl);
+    cy.getByCy('loading').should('not.exist');
+    cy.getByCy('api_error_state').should('not.exist');
+    cy.getByCy('api_loading_state').should('not.exist');
+    cy.wait('@eventExplorer');
+  });
 
   it('All report cards are displayed on main reports page', () => {
     allReports.forEach((item) => {
-      cy.getByCy(item).should('exist')
-    })
-  })
+      cy.getByCy(item).should('exist');
+    });
+  });
 
   it('All report cards have correct href in the title', () => {
     allReports.forEach((item) => {
-      cy.getByCy(item).should('exist')
-      cy.getByCy(item).find('a')
-        .should('have.attr', 'href', aapUrl + reportsUrl + '/' + item)
-    })
-  })
+      cy.getByCy(item).should('exist');
+      cy.getByCy(item)
+        .find('a')
+        .should('have.attr', 'href', aapUrl + reportsUrl + '/' + item);
+    });
+  });
 
   it('All report cards can be selected for the preview with correct links', () => {
     allReports.forEach((item) => {
-      cy.log(item)
-      if (skippedTests["reports"].includes(item)) return;
+      cy.log(item);
+      if (skippedTests['reports'].includes(item)) return;
 
       cy.getByCy(item).click().should('exist');
       if (ENV != ENVS.STAGE) {
         cy.waitSpinner();
       }
       // correct card is highlighted
-      cy.getByCy(item).should('have.class', 'pf-m-selected-raised')
+      cy.getByCy(item).should('have.class', 'pf-m-selected-raised');
       // check View full report link is correct
       if (ENV != ENVS.STAGE) {
-        cy.getByCy('view_full_report_link')
-          .should('have.attr', 'href', aapUrl + reportsUrl + '/' + item)
+        cy.getByCy('view_full_report_link').should(
+          'have.attr',
+          'href',
+          aapUrl + reportsUrl + '/' + item
+        );
       } else {
-        cy.get(`[data-cy="view_full_report_link"]`)
-          .should('have.attr', 'href', aapUrl + reportsUrl + '/' + item)
+        cy.get(`[data-cy="view_full_report_link"]`).should(
+          'have.attr',
+          'href',
+          aapUrl + reportsUrl + '/' + item
+        );
       }
       // check Title link is correct
-      cy.getByCy('preview_title_link')
-        .should('have.attr', 'href', aapUrl + reportsUrl + '/' + item)
-    })
-  })
+      cy.getByCy('preview_title_link').should(
+        'have.attr',
+        'href',
+        aapUrl + reportsUrl + '/' + item
+      );
+    });
+  });
 
   // TODO: flaky and redundant test, we need to rewrite it
   // it('All report cards can appear in preview via dropdown', () => {
@@ -59,45 +76,50 @@ describe('Reports page smoketests', () => {
 
   // FIXME: Workaround to force cypress to wait the graph to load
   it('All report are accessible in preview via arrows', () => {
-    let originalTitlePreview = cy.getByCy('preview_title_link').textContent
+    let originalTitlePreview = cy.getByCy('preview_title_link').textContent;
 
     allReports.forEach((report) => {
-      cy.log(report)
-      if (skippedTests["reports"].includes(report)) return;
-      cy.getByCy('next_report_button').click()
+      cy.log(report);
+      if (skippedTests['reports'].includes(report)) return;
+      cy.getByCy('next_report_button').click();
       cy.wait(250);
       cy.getByCy('preview_title_link').then((previewTitle) => {
-        cy.log(previewTitle)
-        const newTitlePreview = previewTitle.text()
-        expect(newTitlePreview).not.to.eq(originalTitlePreview)
-        originalTitlePreview = newTitlePreview
-      })
-    })
+        cy.log(previewTitle);
+        const newTitlePreview = previewTitle.text();
+        expect(newTitlePreview).not.to.eq(originalTitlePreview);
+        originalTitlePreview = newTitlePreview;
+      });
+    });
 
     allReports.forEach((report) => {
-      cy.log(report)
-      if (skippedTests["reports"].includes(report)) return;
-      cy.getByCy('previous_report_button').click()
+      cy.log(report);
+      if (skippedTests['reports'].includes(report)) return;
+      cy.getByCy('previous_report_button').click();
 
       cy.getByCy('preview_title_link').then((previewTitle) => {
-        cy.log(previewTitle)
-        const newTitlePreview = previewTitle.text()
-        expect(newTitlePreview).not.to.eq(originalTitlePreview)
-        originalTitlePreview = newTitlePreview
-      })
-    })
-  })
+        cy.log(previewTitle);
+        const newTitlePreview = previewTitle.text();
+        expect(newTitlePreview).not.to.eq(originalTitlePreview);
+        originalTitlePreview = newTitlePreview;
+      });
+    });
+  });
 
   it('All report are accessible in preview via dropdownn', () => {
-    cy.getByCy('selected_report_dropdown').should('exist')
+    cy.getByCy('selected_report_dropdown').should('exist');
     allReports.forEach(($item, index) => {
-      cy.getByCy('selected_report_dropdown').click()
-      cy.get('ul.pf-c-dropdown__menu > button > li > a').should('exist')
-      cy.get('ul.pf-c-dropdown__menu > button > li > a').eq(index).click()
-      cy.getByCy('preview_title_link').invoke('text').then(($text) => {
-        cy.get('[data-cy="selected_report_dropdown"] > span.pf-c-dropdown__toggle-text')
-          .invoke('text').should('eq', $text)
-      })
-    })
-  })
-})
+      cy.getByCy('selected_report_dropdown').click();
+      cy.get('ul.pf-c-dropdown__menu > button > li > a').should('exist');
+      cy.get('ul.pf-c-dropdown__menu > button > li > a').eq(index).click();
+      cy.getByCy('preview_title_link')
+        .invoke('text')
+        .then(($text) => {
+          cy.get(
+            '[data-cy="selected_report_dropdown"] > span.pf-c-dropdown__toggle-text'
+          )
+            .invoke('text')
+            .should('eq', $text);
+        });
+    });
+  });
+});

--- a/cypress/e2e/ReportsPage.spec.js
+++ b/cypress/e2e/ReportsPage.spec.js
@@ -82,7 +82,7 @@ describe('Reports page smoketests', () => {
       cy.log(report);
       if (skippedTests['reports'].includes(report)) return;
       cy.getByCy('next_report_button').click();
-      cy.wait(250);
+      // cy.wait(250);
       cy.getByCy('preview_title_link').then((previewTitle) => {
         cy.log(previewTitle);
         const newTitlePreview = previewTitle.text();

--- a/cypress/e2e/SavingsPlanner.spec.js
+++ b/cypress/e2e/SavingsPlanner.spec.js
@@ -1,10 +1,8 @@
 import { savingsPlannerUrl } from '../support/constants';
 
-const appid = Cypress.env('appid');
-
 describe('Savings Planner page smoketests', () => {
-  beforeEach(() => {    
-    cy.intercept('**/plans/*').as('getPlans')
+  beforeEach(() => {
+    cy.intercept('**/plans/*').as('getPlans');
     cy.visit(savingsPlannerUrl);
     cy.wait('@getPlans');
   });
@@ -15,4 +13,3 @@ describe('Savings Planner page smoketests', () => {
     cy.url().should('include', 'sort_options=manual_time');
   });
 });
-

--- a/cypress/e2e/reports/AA2Migration.spec.js
+++ b/cypress/e2e/reports/AA2Migration.spec.js
@@ -2,7 +2,7 @@ import { aa21m as pageName } from '../../support/constants';
 
 describe('Report: AA 2.1 Migration', () => {
   beforeEach(() => {
-    cy.visitReport(pageName)
+    cy.visitReport(pageName);
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {

--- a/cypress/e2e/reports/HostsByOrganization.spec.js
+++ b/cypress/e2e/reports/HostsByOrganization.spec.js
@@ -2,7 +2,7 @@ import { hbo as pageName } from '../../support/constants';
 
 describe('Report: Hosts By Organization Smoketests', () => {
   beforeEach(() => {
-    cy.visitReport(pageName)
+    cy.visitReport(pageName);
   });
 
   it('Can Switch between Line and Bar chart without breaking UI', () => {

--- a/cypress/fixtures/0/tables_pagination.json
+++ b/cypress/fixtures/0/tables_pagination.json
@@ -65,10 +65,10 @@
   {
     "short_name": "jtbo",
     "name": "jobs_and_tasks_by_organization",
-    "has_extra_line": true,
+    "has_extra_line": false,
     "items_per_page": 6,
     "has_expanded_rows": false,
-    "total_items": 31,
+    "total_items": 2,
     "only_beta": false,
     "api_call": "/api/tower-analytics/v1/job_explorer/?*"
   },
@@ -84,10 +84,10 @@
   {
     "short_name": "mubo",
     "name": "module_usage_by_organization",
-    "has_extra_line": true,
+    "has_extra_line": false,
     "items_per_page": 6,
     "has_expanded_rows": false,
-    "total_items": 30,
+    "total_items": 2,
     "api_call": "/api/tower-analytics/v1/event_explorer/?*"
   },
   {
@@ -102,10 +102,10 @@
   {
     "short_name": "mum",
     "name": "most_used_modules",
-    "has_extra_line": true,
+    "has_extra_line": false,
     "items_per_page": 6,
     "has_expanded_rows": true,
-    "total_items": 92,
+    "total_items": 5,
     "api_call": "/api/tower-analytics/v1/event_explorer/?*"
   },
   {

--- a/cypress/fixtures/1/tables_pagination.json
+++ b/cypress/fixtures/1/tables_pagination.json
@@ -65,7 +65,7 @@
   {
     "short_name": "jtbo",
     "name": "jobs_and_tasks_by_organization",
-    "has_extra_line": true,
+    "has_extra_line": false,
     "items_per_page": 6,
     "has_expanded_rows": false,
     "total_items": 31,
@@ -84,10 +84,10 @@
   {
     "short_name": "mubo",
     "name": "module_usage_by_organization",
-    "has_extra_line": true,
+    "has_extra_line": false,
     "items_per_page": 6,
     "has_expanded_rows": false,
-    "total_items": 30,
+    "total_items": 2,
     "api_call": "/api/tower-analytics/v1/event_explorer/?*"
   },
   {

--- a/cypress/fixtures/keycloakLoginFields.json
+++ b/cypress/fixtures/keycloakLoginFields.json
@@ -2,37 +2,37 @@
   "localhost": {
     "username": "#username-verification",
     "password": "#password",
-    "2step": "false",
+    "2step": false,
     "landing-page": "/clusters"
   },
   "front-end-aggregator-ephemeral": {
     "username": "#username-verification",
     "password": "#password",
-    "2step": "false",
+    "2step": false,
     "landing-page": "/clusters"
   },
   "env-ephemeral": {
     "username": "#username",
     "password": "#password",
-    "2step": "false",
+    "2step": false,
     "landing-page": "/clusters"
   },
   "mocks-keycloak-ephemeral": {
     "username": "#username",
     "password": "#password",
-    "2step": "false",
+    "2step": false,
     "landing-page": "/clusters"
   },
   "console.stage.redhat.com": {
     "username": "#username-verification",
     "password": "#password",
-    "2step": "true",
+    "2step": true,
     "landing-page": "/clusters"
   },
   "stage.foo.redhat.com": {
     "username": "#username-verification",
     "password": "#password",
-    "2step": "true",
+    "2step": true,
     "landing-page": "/clusters"
   }
 }

--- a/cypress/fixtures/keycloakLoginFields.json
+++ b/cypress/fixtures/keycloakLoginFields.json
@@ -1,0 +1,38 @@
+{
+  "localhost": {
+    "username": "#username-verification",
+    "password": "#password",
+    "2step": "false",
+    "landing-page": "/clusters"
+  },
+  "front-end-aggregator-ephemeral": {
+    "username": "#username-verification",
+    "password": "#password",
+    "2step": "false",
+    "landing-page": "/clusters"
+  },
+  "env-ephemeral": {
+    "username": "#username",
+    "password": "#password",
+    "2step": "false",
+    "landing-page": "/clusters"
+  },
+  "mocks-keycloak-ephemeral": {
+    "username": "#username",
+    "password": "#password",
+    "2step": "false",
+    "landing-page": "/clusters"
+  },
+  "console.stage.redhat.com": {
+    "username": "#username-verification",
+    "password": "#password",
+    "2step": "true",
+    "landing-page": "/clusters"
+  },
+  "stage.foo.redhat.com": {
+    "username": "#username-verification",
+    "password": "#password",
+    "2step": "true",
+    "landing-page": "/clusters"
+  }
+}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,8 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-}
-
+// module.exports = (on, config) => {
+//   // `on` is used to hook into various events Cypress emits
+//   // `config` is the resolved Cypress config
+// };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,8 +36,8 @@ import { reportsUrl } from '../support/constants';
  * @param {String} selector - The selector value
  **/
 Cypress.Commands.add('getByOUIA', (selector, ...args) => {
-  return cy.get(`[data-ouia-component-id="${selector}"]`, ...args)
-})
+  return cy.get(`[data-ouia-component-id="${selector}"]`, ...args);
+});
 
 /**
  * This command get an element using data-ouia-component-id
@@ -49,8 +49,8 @@ Cypress.Commands.add('getByOUIA', (selector, ...args) => {
  * @param {String} selector - The selector value
  **/
 Cypress.Commands.add('getByOUIALike', (selector, ...args) => {
-  return cy.get(`[data-ouia-component-id*="${selector}"]`, ...args)
-})
+  return cy.get(`[data-ouia-component-id*="${selector}"]`, ...args);
+});
 
 /**
  * This command get an element using data-cy
@@ -63,8 +63,8 @@ Cypress.Commands.add('getByOUIALike', (selector, ...args) => {
  **/
 
 Cypress.Commands.add('getByCy', (selector, ...args) => {
-  return cy.get(`[data-cy="${selector}"]`, ...args)
-})
+  return cy.get(`[data-cy="${selector}"]`, ...args);
+});
 
 /**
  * This command get an element using data-cy
@@ -84,8 +84,8 @@ Cypress.Commands.add('getByCy', (selector, ...args) => {
 Cypress.Commands.add('getByCyLike', (selector, matchType = '*', ...args) => {
   return matchType == '*'
     ? cy.get(`[data-cy*="${selector}"]`, ...args)
-    : cy.get(`[data-cy${matchType}="${selector}"]`, ...args)
-})
+    : cy.get(`[data-cy${matchType}="${selector}"]`, ...args);
+});
 
 /**
  * This command get an element using id
@@ -97,8 +97,8 @@ Cypress.Commands.add('getByCyLike', (selector, matchType = '*', ...args) => {
  * @param {String} selector - The selector value
  **/
 Cypress.Commands.add('getByIdLike', (selector, ...args) => {
-  return cy.get(`[id*="${selector}"]`, ...args)
-})
+  return cy.get(`[id*="${selector}"]`, ...args);
+});
 
 /**
  * This command find an element inside a given parent with id
@@ -111,9 +111,8 @@ Cypress.Commands.add('getByIdLike', (selector, ...args) => {
  * @param {String} selector - The selector value
  **/
 Cypress.Commands.add('findFromParent', (parentSelector, selector, ...args) => {
-  cy.get(`${parentSelector}`)
-    .find(`${selector}`, ...args)
-})
+  cy.get(`${parentSelector}`).find(`${selector}`, ...args);
+});
 
 /**
  * This command find an element inside a given parent with id
@@ -126,9 +125,8 @@ Cypress.Commands.add('findFromParent', (parentSelector, selector, ...args) => {
  * @param {String} selector - The selector value
  **/
 Cypress.Commands.add('findByIdLike', (parentSelector, selector, ...args) => {
-  cy.get(`${parentSelector}`)
-    .find(`[id*="${selector}"]`, ...args)
-})
+  cy.get(`${parentSelector}`).find(`[id*="${selector}"]`, ...args);
+});
 
 /** This command allows the user to enter a locator that uses a data-ouia-component-id,
  * a data-cy, id, or aria-labelledby, and find that locator
@@ -140,47 +138,59 @@ Cypress.Commands.add('findByIdLike', (parentSelector, selector, ...args) => {
  * @param {String} idToFind - user inserts the locator here.
  */
 Cypress.Commands.add('findByCustomId', (idToFind) => {
-  const { queryHelpers } = require('@testing-library/dom')
-  let queryAllByOuia = queryHelpers.queryAllByAttribute.bind(null, 'data-ouia-component-id')
-  let queryAllByDataCy = queryHelpers.queryAllByAttribute.bind(null, 'data-cy')
-  let queryAllById = queryHelpers.queryAllByAttribute.bind(null, 'id')
+  const { queryHelpers } = require('@testing-library/dom');
+  let queryAllByOuia = queryHelpers.queryAllByAttribute.bind(
+    null,
+    'data-ouia-component-id'
+  );
+  let queryAllByDataCy = queryHelpers.queryAllByAttribute.bind(null, 'data-cy');
+  let queryAllById = queryHelpers.queryAllByAttribute.bind(null, 'id');
 
-  let resultA = queryAllByOuia(Cypress.$('body')[0], idToFind)
-  let resultB = queryAllByDataCy(Cypress.$('body')[0], idToFind)
-  let resultC = queryAllById(Cypress.$('body')[0], idToFind)
-  if (resultA.length) return resultA
-  if (resultB.length) return resultB
-  if (resultC.length) return resultC
+  let resultA = queryAllByOuia(Cypress.$('body')[0], idToFind);
+  let resultB = queryAllByDataCy(Cypress.$('body')[0], idToFind);
+  let resultC = queryAllById(Cypress.$('body')[0], idToFind);
+  if (resultA.length) return resultA;
+  if (resultB.length) return resultB;
+  if (resultC.length) return resultC;
 
-  throw `Unable to find an element by: [data-ouia-component-id="${idToFind}"] or [data-cy="${idToFind}"] or [id="${idToFind}"]`
-})
+  throw `Unable to find an element by: [data-ouia-component-id="${idToFind}"] or [data-cy="${idToFind}"] or [id="${idToFind}"]`;
+});
 
 Cypress.Commands.add('visitReport', (pageName) => {
   cy.loadFixture('tables_pagination').then((pages) => {
     pages.forEach((page) => {
       if (page.name == pageName) {
-        cy.intercept(page.api_call).as('apiCall')
-        cy.log('Page data from fixture:', JSON.stringify(page))
-        cy.log('Reports Url:', Cypress.config().baseUrl + reportsUrl + "/" + page.name)
-        cy.visit(Cypress.config().baseUrl + reportsUrl + "/" + page.name)
-        cy.url().should('eq',Cypress.config().baseUrl + reportsUrl + "/" + page.name);
-        cy.getByCy('loading').should('not.exist')
-        cy.getByCy('api_error_state').should('not.exist')
-        cy.getByCy('api_loading_state').should('not.exist')
-        cy.log('Intercepting the url:', page.api_call)
+        cy.intercept(page.api_call).as('apiCall');
+        cy.log('Page data from fixture:', JSON.stringify(page));
+        cy.log(
+          'Reports Url:',
+          Cypress.config().baseUrl + reportsUrl + '/' + page.name
+        );
+        cy.visit(Cypress.config().baseUrl + reportsUrl + '/' + page.name);
+        cy.url().should(
+          'eq',
+          Cypress.config().baseUrl + reportsUrl + '/' + page.name
+        );
+        cy.getByCy('loading').should('not.exist');
+        cy.getByCy('api_error_state').should('not.exist');
+        cy.getByCy('api_loading_state').should('not.exist');
+        cy.log('Intercepting the url:', page.api_call);
         // cy.wait('@apiCall', { timeout: 8000 }) // FIXME
       }
-    })
-  })
-})
+    });
+  });
+});
 
 Cypress.Commands.add('loadFixture', (name) => {
-  const fixturePath = (Cypress.env('test_env') == undefined ? "1" : Cypress.env('test_env')) + '/' + name
-  cy.log('fixturePath ', fixturePath)
+  const fixturePath =
+    (Cypress.env('test_env') == undefined ? '1' : Cypress.env('test_env')) +
+    '/' +
+    name;
+  cy.log('fixturePath ', fixturePath);
   cy.fixture(fixturePath).then((data) => {
     return data;
-  })
-})
+  });
+});
 
 Cypress.Commands.add('loadPageDataFixture', (pageName) => {
   cy.loadFixture('tables_pagination').then((pages) => {
@@ -188,9 +198,9 @@ Cypress.Commands.add('loadPageDataFixture', (pageName) => {
       if (page.name == pageName) {
         return page;
       }
-    })
-  })
-})
+    });
+  });
+});
 
 Cypress.Commands.add('waitSpinner', () => {
   cy.getByCy('spinner').should(($spinner) => {
@@ -205,11 +215,11 @@ Cypress.Commands.add('tableShowAll', () => {
       cy.get('.pf-c-dropdown__menu.pf-m-align-right')
         .find('button')
         .contains('Show all')
-        .click()
-      cy.get('#table-kebab').click()
+        .click();
+      cy.get('#table-kebab').click();
     });
-  cy.waitSpinner()
-})
+  cy.waitSpinner();
+});
 
 Cypress.Commands.add('tableHideAll', () => {
   cy.get('#table-kebab')
@@ -222,4 +232,4 @@ Cypress.Commands.add('tableHideAll', () => {
       cy.get('#table-kebab').click();
     });
   cy.waitSpinner();
-})
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -168,7 +168,7 @@ Cypress.Commands.add('visitReport', (pageName) => {
         cy.getByCy('api_error_state').should('not.exist')
         cy.getByCy('api_loading_state').should('not.exist')
         cy.log('Intercepting the url:', page.api_call)
-        cy.wait('@apiCall', { timeout: 8000 })
+        // cy.wait('@apiCall', { timeout: 8000 }) // FIXME
       }
     })
   })

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -1,5 +1,3 @@
-/* global Cypress */
-
 // When executing in eph "/ansible/automation-analytics" doesn't seem to be in the path
 // the below change foreces this in the url
 // https://env-ephemeral-kehfbd-hwwsn2eu.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/ansible/automation-analytics/reports/aa_2_1_onboarding

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -4,44 +4,43 @@
 // the below change foreces this in the url
 // https://env-ephemeral-kehfbd-hwwsn2eu.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/ansible/automation-analytics/reports/aa_2_1_onboarding
 
-// local
-// ephemeral
-// stage
-
 export const ENVS = {
-	LOCAL: 0,
-	EPHEMERAL: 1,
-	STAGE: 2
-}
+  LOCAL: 0,
+  EPHEMERAL: 1,
+  STAGE: 2,
+};
 
-export const ENV = (Cypress.env('test_env')) == undefined ? ENVS.LOCAL : parseInt(Cypress.env('test_env'))
+export const ENV =
+  Cypress.env('test_env') == undefined
+    ? ENVS.LOCAL
+    : parseInt(Cypress.env('test_env'));
 
-export const appid = Cypress.env('appid')
-export const aapUrl = '/ansible/automation-analytics'
-export const dashboardUrl = '/ansible/automation-analytics'
-export const orgsUrl = '/organization-statistics'
-export const jobExplorerUrl = '/job-explorer'
-export const clustersUrl = '/clusters'
-export const reportsUrl = '/reports'
-export const savingsPlannerUrl = '/savings-planner'
-export const calculatorUrl = '/reports/automation_calculator'
-export const calculatorUrlDirect = '/automation_calculator'
-export const notificationsUrl = '/notifications'
+export const appid = Cypress.env('appid');
+export const aapUrl = '/ansible/automation-analytics';
+export const dashboardUrl = '/ansible/automation-analytics';
+export const orgsUrl = '/organization-statistics';
+export const jobExplorerUrl = '/job-explorer';
+export const clustersUrl = '/clusters';
+export const reportsUrl = '/reports';
+export const savingsPlannerUrl = '/savings-planner';
+export const calculatorUrl = '/reports/automation_calculator';
+export const calculatorUrlDirect = '/automation_calculator';
+export const notificationsUrl = '/notifications';
 
-export const hcbjt = 'hosts_changed_by_job_template'
-export const cmbjt = 'changes_made_by_job_template'
-export const jtrr = 'job_template_run_rate'
-export const hbo = 'hosts_by_organization'
-export const jtbo = 'jobs_and_tasks_by_organization'
-export const texp = 'templates_explorer'
-export const mum = 'most_used_modules'
-export const mubo = 'module_usage_by_organization'
-export const mubjt = 'module_usage_by_job_template'
-export const mubt = 'module_usage_by_task'
-export const aa21m = 'aa_2_1_onboarding'
-export const hab = 'host_anomalies_bar'
-export const has = 'host_anomalies_scatter'
-export const tbo = 'templates_by_organization'
+export const hcbjt = 'hosts_changed_by_job_template';
+export const cmbjt = 'changes_made_by_job_template';
+export const jtrr = 'job_template_run_rate';
+export const hbo = 'hosts_by_organization';
+export const jtbo = 'jobs_and_tasks_by_organization';
+export const texp = 'templates_explorer';
+export const mum = 'most_used_modules';
+export const mubo = 'module_usage_by_organization';
+export const mubjt = 'module_usage_by_job_template';
+export const mubt = 'module_usage_by_task';
+export const aa21m = 'aa_2_1_onboarding';
+export const hab = 'host_anomalies_bar';
+export const has = 'host_anomalies_scatter';
+export const tbo = 'templates_by_organization';
 
 export const allReports = [
   hcbjt,
@@ -57,12 +56,9 @@ export const allReports = [
   aa21m,
   hab,
   has,
-  tbo
-]
+  tbo,
+];
 
 export const skippedTests = {
-  "reports": [
-    "host_anomalies_scatter",
-    "templates_by_organization"
-  ]
-}
+  reports: ['host_anomalies_scatter', 'templates_by_organization'],
+};

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -29,15 +29,5 @@ Cypress.on('uncaught:exception', (_err, _runnable) => {
 
 // these cokies should resolve the accept cookies dialog
 beforeEach(() => {
-  Cypress.Cookies.debug(true);
-  cy.setCookie('cmapi_cookie_privacy', 'permit 1,2,3', { secure: true });
-  cy.setCookie('cmapi_gtm_bl', '', { secure: true });
-  cy.setCookie('notice_preferences', '2:', { secure: true });
-  cy.setCookie('notice_behavior', 'expressed,eu', { secure: true });
-  cy.setCookie('notice_gdpr_prefs', '0,1,2:', {
-    secure: true,
-    domain: 'redhat.com',
-  });
-
-  cy.login();
+  cy.loginWithPageSession();
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,35 +14,30 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
-import './login'
-import './pagination'
+import './commands';
+import './login';
+import './pagination';
 
 // Returning false here prevents Cypress from failing the test
-Cypress.on('uncaught:exception', (err, runnable) => {
-    return false
+// using _err and _runnable arguments is optional
+Cypress.on('uncaught:exception', (_err, _runnable) => {
+  return false;
 });
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+// these cokies should resolve the accept cookies dialog
 beforeEach(() => {
   Cypress.Cookies.debug(true);
-  // these cokies should resolve the accept cookies dialog
   cy.setCookie('cmapi_cookie_privacy', 'permit 1,2,3', { secure: true });
   cy.setCookie('cmapi_gtm_bl', '', { secure: true });
   cy.setCookie('notice_preferences', '2:', { secure: true });
   cy.setCookie('notice_behavior', 'expressed,eu', { secure: true });
-  cy.setCookie('notice_gdpr_prefs', '0,1,2:', { secure: true });
+  cy.setCookie('notice_gdpr_prefs', '0,1,2:', {
+    secure: true,
+    domain: 'redhat.com',
+  });
 
   cy.login();
 });
-
-// after(() => {
-//   cy.getByIdLike('#UserMenu').as('userMenu');
-//   cy.get('@userMenu').then(() =>{
-//     cy.get('@userMenu').click({ force: true });
-//     cy.get('[aria-labelledby="UserMenu"]').find('button').as('logoutButton');
-//     cy.get('@logoutButton').contains('Log out').click({ force: true });
-//   })
-// });

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -28,20 +28,24 @@ function setCookiesForUILogin() {
 }
 
 function uiLogin(strategy, username, password) {
-  const usernameField = kcLoginFields[strategy]['username'];
-  const passwordField = kcLoginFields[strategy]['password'];
-  const loginStrategy = JSON.stringify(kcLoginFields[strategy]);
+  cy.log('Strategy:', JSON.stringify(kcLoginFields[strategy]));
 
-  cy.log('Strategy:', loginStrategy);
-  cy.get(usernameField).should('be.visible');
+  cy.get(kcLoginFields[strategy]['username']).as('usernameField');
+  cy.get('@usernameField').should('be.visible');
+  cy.get('@usernameField').type(`${username}`);
 
-  cy.get(usernameField).type(`${username}`);
   if (kcLoginFields[strategy]['2step']) {
     cy.log('Two step verfication');
-    cy.get('#login-show-step2').click();
+    cy.get('#login-show-step2').as('showStep2');
+    cy.get('@showStep2').click().should('be.visible');
   }
-  cy.get(passwordField).type(`${password}`, { log: false });
-  cy.get('#rh-password-verification-submit-button').click();
+
+  cy.get(kcLoginFields[strategy]['password']).as('passwordField');
+  cy.get('@passwordField').should('be.visible');
+  cy.get('@passwordField').type(`${password}`, { log: false });
+
+  cy.get('#rh-password-verification-submit-button').as('submitButton');
+  cy.get('@submitButton').click().should('be.visible');
 
   cy.visit(Cypress.config().baseUrl + clustersUrl);
 }

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -45,7 +45,8 @@ function uiLogin(strategy, username, password) {
   cy.get('@passwordField').type(`${password}`, { log: false });
 
   cy.get('#rh-password-verification-submit-button').as('submitButton');
-  cy.get('@submitButton').click().should('be.visible');
+  cy.get('@submitButton').should('be.visible');
+  cy.get('@submitButton').click();
 
   cy.visit(Cypress.config().baseUrl + clustersUrl);
 }

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -68,12 +68,7 @@ Cypress.Commands.add('login', () => {
     cy.get('#rh-password-verification-submit-button').click();
   }
 
-  cy.log(
-    'Checking for landing page: ' +
-      keycloakLoginFields[strategy]['landing-page']
-  );
   cy.visit(Cypress.config().baseUrl + clustersUrl);
-  cy.url().should('eq', keycloakLoginFields[strategy]['landing-page']);
   // if (strategy == "env-ephemeral") {
   // cy.visit(Cypress.config().baseUrl + clustersUrl);
   // cy.url().should('eq', Cypress.config().baseUrl + clustersUrl);

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -42,7 +42,7 @@ Cypress.Commands.add('login', () => {
   cy.log(JSON.stringify(keycloakLoginFields[strategy]));
   cy.get(keycloakLoginFields[strategy]['username']).should('be.visible');
 
-  if (keycloakLoginFields[strategy]['two-step']) {
+  if (keycloakLoginFields[strategy]['2step']) {
     cy.log('Two step verfication');
     cy.getUsername().then((uname) =>
       cy.get(keycloakLoginFields[strategy]['username']).type(`${uname}`)
@@ -59,7 +59,6 @@ Cypress.Commands.add('login', () => {
     cy.getUsername().then((uname) =>
       cy.get(keycloakLoginFields[strategy]['username']).type(`${uname}`)
     );
-    cy.get('#login-show-step2').click();
     cy.getPassword().then((password) =>
       cy
         .get(keycloakLoginFields[strategy]['password'])
@@ -69,11 +68,4 @@ Cypress.Commands.add('login', () => {
   }
 
   cy.visit(Cypress.config().baseUrl + clustersUrl);
-  // if (strategy == "env-ephemeral") {
-  // cy.visit(Cypress.config().baseUrl + clustersUrl);
-  // cy.url().should('eq', Cypress.config().baseUrl + clustersUrl);
-  // cy.get('[data-quickstart-id="ansible_automation-analytics_reports"]').click();
-  // cy.get('a[href="' + Cypress.config().baseUrl + reportsUrl + '"]', { timeout: 10000 }).should('be.visible');
-  // cy.get('[data-ouia-component-type="PF4/Title"]', { timeout: 10000 }).should('be.visible');
-  // }
 });

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -1,4 +1,5 @@
-import { clustersUrl, reportsUrl } from '../support/constants'
+import keycloakLoginFields from '../fixtures/keycloakLoginFields.json';
+import { clustersUrl } from '../support/constants';
 
 Cypress.Commands.add('getBaseUrl', () => Cypress.env('baseUrl'));
 
@@ -25,58 +26,19 @@ Cypress.Commands.add('login', () => {
 
   cy.log('Determining login strategy');
 
-  const keycloakLoginFields = {
-    'localhost': {
-      'username': '#username-verification',
-      'password': '#password',
-      'two-step': false,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    },
-    // when you login on eph, the landing page is "/"
-    'front-end-aggregator-ephemeral': {
-      'username': '#username-verification',
-      'password': '#password',
-      'two-step': false,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    },
-    'env-ephemeral': {
-      'username': '#username',
-      'password': '#password',
-      'two-step': false,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    },
-    'mocks-keycloak-ephemeral': {
-      'username': '#username',
-      'password': '#password',
-      'two-step': false,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    },
-    'console.stage.redhat.com': {
-      'username': '#username-verification',
-      'password': '#password',
-      'two-step': true,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    },
-    'stage.foo.redhat.com': {
-      'username': '#username-verification',
-      'password': '#password',
-      'two-step': true,
-      'landing-page': Cypress.config().baseUrl + clustersUrl
-    }
-  }
+  cy.log(JSON.stringify(keycloakLoginFields));
 
   let strategy = null;
 
-  // probably some fancy filter function for this
-  for (const element of Object.keys(keycloakLoginFields)) {
-    if (Cypress.config().baseUrl.includes(element)) {
-      cy.log('Baseurl contains: ' + element);
-      strategy = element;
+  for (const index of Object.keys(keycloakLoginFields)) {
+    if (Cypress.config().baseUrl.includes(index)) {
+      cy.log('Baseurl contains: ' + index);
+      strategy = index;
       break;
     }
   }
 
-  cy.log('Strategy: ');
+  cy.log('Strategy:');
   cy.log(JSON.stringify(keycloakLoginFields[strategy]));
   cy.get(keycloakLoginFields[strategy]['username']).should('be.visible');
 
@@ -87,24 +49,36 @@ Cypress.Commands.add('login', () => {
     );
     cy.get('#login-show-step2').click();
     cy.getPassword().then((password) =>
-      cy.get(keycloakLoginFields[strategy]['password']).type(`${password}{enter}`, { log: false })
+      cy
+        .get(keycloakLoginFields[strategy]['password'])
+        .type(`${password}`, { log: false })
     );
+    cy.get('#rh-password-verification-submit-button').click();
   } else {
     cy.log('One step verfication');
-    cy.getUsername().then((uname) => cy.get(keycloakLoginFields[strategy]['username']).type(`${uname}`));
-    cy.getPassword().then((password) =>
-      cy.get(keycloakLoginFields[strategy]['password']).type(`${password}{enter}`, { log: false })
+    cy.getUsername().then((uname) =>
+      cy.get(keycloakLoginFields[strategy]['username']).type(`${uname}`)
     );
+    cy.get('#login-show-step2').click();
+    cy.getPassword().then((password) =>
+      cy
+        .get(keycloakLoginFields[strategy]['password'])
+        .type(`${password}`, { log: false })
+    );
+    cy.get('#rh-password-verification-submit-button').click();
   }
 
-  cy.log('Checking for landing page: ' + keycloakLoginFields[strategy]['landing-page']);
+  cy.log(
+    'Checking for landing page: ' +
+      keycloakLoginFields[strategy]['landing-page']
+  );
   cy.visit(Cypress.config().baseUrl + clustersUrl);
   cy.url().should('eq', keycloakLoginFields[strategy]['landing-page']);
   // if (strategy == "env-ephemeral") {
-    // cy.visit(Cypress.config().baseUrl + clustersUrl);
-    // cy.url().should('eq', Cypress.config().baseUrl + clustersUrl);
-    // cy.get('[data-quickstart-id="ansible_automation-analytics_reports"]').click();
-    // cy.get('a[href="' + Cypress.config().baseUrl + reportsUrl + '"]', { timeout: 10000 }).should('be.visible');
-    // cy.get('[data-ouia-component-type="PF4/Title"]', { timeout: 10000 }).should('be.visible');    
+  // cy.visit(Cypress.config().baseUrl + clustersUrl);
+  // cy.url().should('eq', Cypress.config().baseUrl + clustersUrl);
+  // cy.get('[data-quickstart-id="ansible_automation-analytics_reports"]').click();
+  // cy.get('a[href="' + Cypress.config().baseUrl + reportsUrl + '"]', { timeout: 10000 }).should('be.visible');
+  // cy.get('[data-ouia-component-type="PF4/Title"]', { timeout: 10000 }).should('be.visible');
   // }
 });

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -34,7 +34,7 @@ function uiLogin(strategy, username, password) {
   cy.get('@usernameField').should('be.visible');
   cy.get('@usernameField').type(`${username}`);
 
-  if (kcLoginFields[strategy]['2step']) {
+  if (kcLoginFields[strategy]['2step'] === true) {
     cy.log('Two step verfication');
     cy.get('#login-show-step2').as('showStep2');
     cy.get('@showStep2').click().should('be.visible');

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -42,11 +42,12 @@ function uiLogin(strategy, username, password) {
 
   cy.get(kcLoginFields[strategy]['password']).as('passwordField');
   cy.get('@passwordField').should('be.visible');
-  cy.get('@passwordField').type(`${password}`, { log: false });
+  cy.get('@passwordField').type(`${password}{enter}`, { log: false });
 
-  cy.get('#rh-password-verification-submit-button').as('submitButton');
-  cy.get('@submitButton').should('be.visible');
-  cy.get('@submitButton').click();
+  // FIXME: update the button name to be found in ephemera;
+  // cy.get('#rh-password-verification-submit-button').as('submitButton');
+  // cy.get('@submitButton').should('be.visible');
+  // cy.get('@submitButton').click();
 
   cy.visit(Cypress.config().baseUrl + clustersUrl);
 }

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -52,8 +52,7 @@ Cypress.Commands.add('testNavArrows', (selector, data) => {
   cy.get('@previousBtn').should('be.disabled');
 
   if (hasSecondPage) {
-    cy.get('@nextBtn').should('not.be.disabled');
-    cy.get('@nextBtn').click();
+    cy.get('@nextBtn').click().should('not.be.disabled');
   } else {
     cy.get('@nextBtn').should('be.disabled');
   }
@@ -62,14 +61,12 @@ Cypress.Commands.add('testNavArrows', (selector, data) => {
   cy.get('@previousBtn');
 
   if (hasSecondPage) {
-    cy.get('@previousBtn').should('not.be.disabled');
     // cy.get('@nextBtn').should('not.be.disabled'); // TODO: improve this test considering all pages
-    cy.get('@previousBtn').click();
+    cy.get('@previousBtn').click().should('not.be.disabled');
   } else {
     cy.get('@previousBtn').should('be.disabled');
     cy.get('@nextBtn').should('be.disabled');
   }
-
 });
 
 /**
@@ -248,12 +245,9 @@ Cypress.Commands.add('testPageDataWithPagination', (selector, data) => {
     cy.get('@tableLines').should('have.length.greaterThan', 1)
 
     // toggle back to min items
-    cy.findByIdLike('@pag_option_menu', 'aa-pagination-').click();
-    cy.findByIdLike('@pag_option_menu', 'aa-pagination-').should(
-      'have.attr',
-      'aria-expanded',
-      'true'
-    );
+    cy.findByIdLike('@pag_option_menu', 'aa-pagination-')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
 
     cy.get('@pag_option_menu').find('li').eq(1).as('min_items');
     // .contains('per-page-'+itemsPerPage).

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -11,17 +11,18 @@
 Cypress.Commands.add(
   'getPaginationArrows',
   (cyParent, childBtnAction, ...args) => {
-    return cy
-      .getByCy(`${cyParent}`, ...args)
+    cy.getByCy(`${cyParent}`, ...args)
       .find('.pf-c-pagination__nav')
-      .find(`[data-action="${childBtnAction}"]`);
+      .find(`[data-action="${childBtnAction}"]`)
+      .as('arrowBtn');
+    return cy.get('@arrowBtn');
   }
 );
 
 Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
-  let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction);
+  cy.getPaginationArrows(cyParent, btnAction).as('paginationArrows');
 
-  if (getPaginationArrows) return getPaginationArrows;
+  if (cy.get('@paginationArrows')) return cy.get('@paginationArrows');
 
   throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`;
 });
@@ -33,40 +34,30 @@ Cypress.Commands.add('getItemsToggle', (cyParent, childBtnAction, ...args) => {
     .find(`[data-action="${childBtnAction}"]`);
 });
 
-Cypress.Commands.add('getPaginationBtn', (cyParent, btnAction) => {
-  let getPaginationArrows = cy.getPaginationArrows(cyParent, btnAction);
-
-  if (getPaginationArrows) return getPaginationArrows;
-
-  throw `Unable to find "${btnAction}" button for data-cy parent: "${cyParent}"`;
-});
-
 Cypress.Commands.add('testNavArrows', (selector, data) => {
   const itemsPerPage = parseFloat(data.items_per_page);
   const totalItems = parseFloat(data.total_items);
+  cy.log('items per page:', itemsPerPage);
+  cy.log('total items:', totalItems);
   let hasSecondPage = totalItems > itemsPerPage ? true : false;
 
   cy.getPaginationBtn(`${selector}`, 'next').as('nextBtn');
-  cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn');
-
-  cy.get('@previousBtn').should('be.disabled');
+  // cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn');
+  // cy.get('@previousBtn').should('be.disabled');
 
   if (hasSecondPage) {
-    cy.get('@nextBtn').click().should('not.be.disabled');
+    cy.log('moving to the next page');
+    cy.get('@nextBtn').should('not.be.disabled');
+    cy.get('@nextBtn').click();
+    // cy.get('@nextBtn').should('not.be.disabled'); // improve this code to consider all pages
+    cy.log('moving back to the 1st page');
+    cy.getPaginationBtn(`${selector}`, 'previous').as('previousBtn');
+    cy.get('@previousBtn').should('not.be.disabled');
+    cy.get('@previousBtn').click();
   } else {
     cy.get('@nextBtn').should('be.disabled');
   }
 
-  cy.get('@nextBtn');
-  cy.get('@previousBtn');
-
-  if (hasSecondPage) {
-    // cy.get('@nextBtn').should('not.be.disabled'); // TODO: improve this test considering all pages
-    cy.get('@previousBtn').click().should('not.be.disabled');
-  } else {
-    cy.get('@previousBtn').should('be.disabled');
-    cy.get('@nextBtn').should('be.disabled');
-  }
 });
 
 /**

--- a/cypress/support/pagination.js
+++ b/cypress/support/pagination.js
@@ -57,7 +57,6 @@ Cypress.Commands.add('testNavArrows', (selector, data) => {
   } else {
     cy.get('@nextBtn').should('be.disabled');
   }
-
 });
 
 /**
@@ -97,7 +96,7 @@ Cypress.Commands.add('testSelectItemsPerPage', (selector, itemsPerPage) => {
         const n = parseFloat($ul.text());
         expect(n).to.be.eq(5);
       })
-      .within(($ul) => {
+      .within(() => {
         cy.get('li').eq(4).find('button').as('maxItems');
         cy.get('li')
           .eq(0)
@@ -132,7 +131,7 @@ Cypress.Commands.add('testSelectItemsPerPage', (selector, itemsPerPage) => {
           const n = parseFloat($ul.text());
           expect(n).to.be.eq(4);
         })
-        .within(($ul) => {
+        .within(() => {
           cy.get('li').eq(3).find('button').as('maxItems');
           cy.get('li')
             .eq(0)
@@ -183,14 +182,14 @@ Cypress.Commands.add('testPageDataWithPagination', (selector, data) => {
   const itemsPerPage = parseFloat(data.items_per_page);
   const totalItems = parseFloat(data.total_items);
 
-  let minRows = 0;
+  // let minRows = 0;
   let maxRows = 0;
 
   if (totalItems <= itemsPerPage) {
-    minRows = totalItems;
+    // minRows = totalItems;
     maxRows = totalItems;
   } else {
-    minRows = itemsPerPage;
+    // minRows = itemsPerPage;
     maxRows = itemsPerPage == 5 ? 25 : 10;
     if (totalItems <= maxRows) {
       maxRows = totalItems - 1; // when showing all items the page doesn't have the extra line
@@ -198,25 +197,31 @@ Cypress.Commands.add('testPageDataWithPagination', (selector, data) => {
   }
 
   // TODO: improve  AND simplify this logic
-  let minTotalRows = data.has_expanded_rows ? minRows * 2 : minRows;
-  let maxTotalRows = data.has_expanded_rows ? maxRows * 2 : maxRows;
+  // let minTotalRows = data.has_expanded_rows ? minRows * 2 : minRows;
+  // let maxTotalRows = data.has_expanded_rows ? maxRows * 2 : maxRows;
 
-  minTotalRows = data.has_extra_line ? minTotalRows + 1 : minTotalRows;
-  maxTotalRows = data.has_extra_line ? maxTotalRows + 1 : maxTotalRows;
+  // minTotalRows = data.has_extra_line ? minTotalRows + 1 : minTotalRows;
+  // maxTotalRows = data.has_extra_line ? maxTotalRows + 1 : maxTotalRows;
 
-  // include one more row in case the extra line also has an expanded row
-  minTotalRows = (data.has_extra_line && data.has_expanded_rows) ? minTotalRows + 1 : minTotalRows;
-  maxTotalRows = (data.has_extra_line && data.has_expanded_rows) ? maxTotalRows + 1 : maxTotalRows;
+  // // include one more row in case the extra line also has an expanded row
+  // minTotalRows =
+  //   data.has_extra_line && data.has_expanded_rows
+  //     ? minTotalRows + 1
+  //     : minTotalRows;
+  // maxTotalRows =
+  //   data.has_extra_line && data.has_expanded_rows
+  //     ? maxTotalRows + 1
+  //     : maxTotalRows;
 
   // get table and amount of lines
   cy.get('table').find('tbody').as('table');
   // cy.get('@table').find('tr').should('have.length', minTotalRows);
-  cy.get('@table').find('tr').should('have.length.greaterThan', 1)
+  cy.get('@table').find('tr').should('have.length.greaterThan', 1);
 
   // toggle the list
   cy.getByCy(`${selector}`).find('.pf-c-options-menu').as('pag_option_menu');
   cy.findByIdLike('@pag_option_menu', 'aa-pagination-').click({
-    force: true
+    force: true,
   });
   cy.findByIdLike('@pag_option_menu', 'aa-pagination-').should(
     'have.attr',
@@ -233,12 +238,12 @@ Cypress.Commands.add('testPageDataWithPagination', (selector, data) => {
     // the lenght to be 0 or undefined
 
     // cy.get('@tableLines').should('have.length', maxTotalRows);
-    cy.get('@tableLines').should('have.length.greaterThan', 1)
+    cy.get('@tableLines').should('have.length.greaterThan', 1);
 
     // toggle back to min items
-    cy.findByIdLike('@pag_option_menu', 'aa-pagination-')
-      .click()
-      .should('have.attr', 'aria-expanded', 'true');
+    cy.findByIdLike('@pag_option_menu', 'aa-pagination-').as('pagMenu1');
+    cy.get('@pagMenu1').should('have.attr', 'aria-expanded', 'true');
+    cy.get('@pagMenu1').click;
 
     cy.get('@pag_option_menu').find('li').eq(1).as('min_items');
     // .contains('per-page-'+itemsPerPage).
@@ -246,6 +251,6 @@ Cypress.Commands.add('testPageDataWithPagination', (selector, data) => {
     cy.wait('@apiCall');
 
     // cy.get('@tableLines').should('have.length', minTotalRows);
-    cy.get('@tableLines').should('have.length.greaterThan', 1)
+    cy.get('@tableLines').should('have.length.greaterThan', 1);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33641,7 +33641,7 @@
         "parse5": "6.0.1",
         "saxes": "^5.0.1",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
+        "tough-cookie": "^4.1.3",
         "w3c-hr-time": "^1.0.2",
         "w3c-xmlserializer": "^2.0.0",
         "webidl-conversions": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,6 +4003,141 @@
         "redux": ">=4.2.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-styles": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
+      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w==",
+      "peer": true
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
+      "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
+      "peer": true,
+      "dependencies": {
+        "@patternfly/react-core": "^5.0.1",
+        "@patternfly/react-icons": "^5.0.1",
+        "@patternfly/react-styles": "^5.0.1",
+        "@patternfly/react-tokens": "^5.0.1",
+        "lodash": "^4.17.19",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
+      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+      "peer": true,
+      "dependencies": {
+        "@patternfly/react-icons": "^5.0.1",
+        "@patternfly/react-styles": "^5.0.1",
+        "@patternfly/react-tokens": "^5.0.1",
+        "focus-trap": "7.4.3",
+        "react-dropzone": "^14.2.3",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table/node_modules/@patternfly/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-tokens": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
+      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw==",
+      "peer": true
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components-utilities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
+      "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
+      "dependencies": {
+        "@redhat-cloud-services/types": "^0.0.24",
+        "@sentry/browser": "^5.30.0",
+        "awesome-debounce-promise": "^2.1.0",
+        "axios": "^0.27.2",
+        "commander": "^2.20.3",
+        "mkdirp": "^1.0.4",
+        "react-content-loader": "^6.2.0"
+      },
+      "peerDependencies": {
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-table": "^5.0.0",
+        "@redhat-cloud-services/rbac-client": "^1.0.100",
+        "cypress": ">=12.0.0 < 14.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-redux": ">=7.0.0",
+        "react-router-dom": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/focus-trap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.1.2"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "peer": true,
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "peer": true
+    },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.6.tgz",
@@ -25585,6 +25720,112 @@
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.3"
+      },
+      "dependencies": {
+        "@patternfly/react-styles": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
+          "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w==",
+          "peer": true
+        },
+        "@patternfly/react-table": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
+          "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
+          "peer": true,
+          "requires": {
+            "@patternfly/react-core": "^5.0.1",
+            "@patternfly/react-icons": "^5.0.1",
+            "@patternfly/react-styles": "^5.0.1",
+            "@patternfly/react-tokens": "^5.0.1",
+            "lodash": "^4.17.19",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@patternfly/react-core": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
+              "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
+              "peer": true,
+              "requires": {
+                "@patternfly/react-icons": "^5.0.1",
+                "@patternfly/react-styles": "^5.0.1",
+                "@patternfly/react-tokens": "^5.0.1",
+                "focus-trap": "7.4.3",
+                "react-dropzone": "^14.2.3",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@patternfly/react-icons": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
+              "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
+              "peer": true,
+              "requires": {}
+            }
+          }
+        },
+        "@patternfly/react-tokens": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
+          "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw==",
+          "peer": true
+        },
+        "@redhat-cloud-services/frontend-components-utilities": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
+          "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
+          "requires": {
+            "@redhat-cloud-services/types": "^0.0.24",
+            "@sentry/browser": "^5.30.0",
+            "awesome-debounce-promise": "^2.1.0",
+            "axios": "^0.27.2",
+            "commander": "^2.20.3",
+            "mkdirp": "^1.0.4",
+            "react-content-loader": "^6.2.0"
+          }
+        },
+        "attr-accept": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+          "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+          "peer": true
+        },
+        "file-selector": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+          "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+          "peer": true,
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "focus-trap": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+          "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+          "peer": true,
+          "requires": {
+            "tabbable": "^6.1.2"
+          }
+        },
+        "react-dropzone": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+          "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+          "peer": true,
+          "requires": {
+            "attr-accept": "^2.2.2",
+            "file-selector": "^0.6.0",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "tabbable": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+          "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+          "peer": true
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20951,8 +20951,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -37844,7 +37845,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,9 @@
     "deploy-only": "npm-run-all build:prod",
     "verify": "npm-run-all build:prod lint test",
     "cy:open": "DEBUG=cypress cypress open",
-    "cy:headless": "DEBUG=cypress cypress run --browser=chrome"
+    "cy:headless": "DEBUG=cypress cypress run --browser=chrome",
+    "cy:lint": "eslint config cypress",
+    "cy:lint-fix": "eslint config cypress --fix"
   },
   "insights": {
     "appname": "automation-analytics"

--- a/package.json
+++ b/package.json
@@ -132,5 +132,8 @@
   },
   "insights": {
     "appname": "automation-analytics"
+  },
+  "overrides": {
+    "tough-cookie": "^4.1.3"
   }
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,7 +28,7 @@ export IMAGE_BACKEND_TAG=$(curl -s https://gitlab.cee.redhat.com/api/v4/projects
 # frontend
 export IMAGE="quay.io/cloudservices/automation-analytics-frontend"
 export IMAGE_FRONTEND="quay.io/cloudservices/automation-analytics-frontend"
-export IMAGE_FRONTEND_TAG=$(git rev-parse --short=7 HEAD)
+#export IMAGE_FRONTEND_TAG=$(git rev-parse --short=7 HEAD)
 export IMAGE_FRONTEND_SHA1=$(git rev-parse HEAD)
 
 # iqe
@@ -60,7 +60,7 @@ bonfire deploy \
     --set-template-ref $BONFIRE_COMPONENT_NAME=main \
     --set-template-ref tower-analytics-frontend=$IMAGE_FRONTEND_SHA1 \
     --set-image-tag $IMAGE_BACKEND=$IMAGE_BACKEND_TAG \
-    --set-image-tag $IMAGE_FRONTEND=$IMAGE_FRONTEND_TAG \
+    --set-image-tag $IMAGE_FRONTEND=$IMAGE_TAG \
     --frontends=true \
     --namespace $NAMESPACE \
     $BONFIRE_COMPONENTS_ARG


### PR DESCRIPTION
## **TLDR:**

- [x] Yet another login strategy
- [x] New fixture for login strategies
- [x] Simplifying commands and removing duplicated code
- [x] Some linters
<br>

## **Motivation:**
Currently, we have some flaky tests on pr_checks and some other when running locally.
This PR attempts to solve most of the login issues between environments by:

- Wrapping the login into a session to keep for all the specs and including a validation to re-login when the session expired, speeding up the tests in approx. ~60%.
- Cleaning the code by moving the login strategy values into a fixture, simplifying redundant commands and deleting duplicated code.
<br>

### **Testing:**
Expect 5 specs (~ 7 tests) failing that will be fixed in a separate PR

- [x] Automation Calculator
- [x] Clusters
- [x] Global
- [x] Reports (flaky)
- [x] Reports Page


<br>

depends on [AA backend MR-771](https://gitlab.cee.redhat.com/automation-analytics/automation-analytics-backend/-/merge_requests/771)
related to [AA-1723](https://issues.redhat.com/browse/AA-1723), [AA-1721](https://issues.redhat.com/browse/AA-1721)