### PR TITLE
Fix broken pipeline from PR 988

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ services:
   - docker
 notifications:
   email: false
-node_js:
-  - '18'
 # npm 9 causes an issue while using node 18 preventing pr image build to finish
 before_install:
   - npm install -g npm@8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ notifications:
   email: false
 node_js:
   - '18'
+# npm 9 causes an issue while using node 18 preventing pr image build to finish
+before_install:
+  - npm install -g npm@8
 install:
   - npm ci
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3330,9 +3330,9 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.276.12",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.12.tgz",
-      "integrity": "sha512-bBN2BMFhWjl/27zmTG5z3+6aH7XMO8our9nsaryxuzN5wFn6S8cIDILsw5NY7N8SLOOtmqbFJUgcM5GAn1ZAXg==",
+      "version": "4.277.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.277.0.tgz",
+      "integrity": "sha512-bA0hIYclQN7CebBahjTl8c1j1zEAa8uUY/KtFOq7aHBWQTZjf3+By0ue2GktHAUq8diseBj+8LirScDbzi1DvQ==",
       "dependencies": {
         "@patternfly/react-icons": "^4.93.7",
         "@patternfly/react-styles": "^4.92.8",
@@ -3362,11 +3362,11 @@
       "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.113.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.113.4.tgz",
-      "integrity": "sha512-WN00JBlJR8VVXpNH/IBmuTj70/Ww4vNQwB67mJ8yPzZ0refgAMqMGHCsp9yo5GImJhcBqQr4xlQNpHpeJIKphQ==",
+      "version": "4.113.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.113.5.tgz",
+      "integrity": "sha512-iBBY/81Md5pn4LQ72Ui+WZPnH6RZ/or+KqR7HxTYTE1b7HDbQ6kFAErcr5catEE54P/3kI9Ox5IhgdZOrsIt6w==",
       "dependencies": {
-        "@patternfly/react-core": "^4.276.12",
+        "@patternfly/react-core": "^4.277.0",
         "@patternfly/react-icons": "^4.93.7",
         "@patternfly/react-styles": "^4.92.8",
         "@patternfly/react-tokens": "^4.94.7",
@@ -4002,141 +4002,6 @@
         "react-redux": ">=7.2.9",
         "redux": ">=4.2.0"
       }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-      "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w==",
-      "peer": true
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
-      "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
-      "peer": true,
-      "dependencies": {
-        "@patternfly/react-core": "^5.0.1",
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "lodash": "^4.17.19",
-        "tslib": "^2.5.0"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-      "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
-      "peer": true,
-      "dependencies": {
-        "@patternfly/react-icons": "^5.0.1",
-        "@patternfly/react-styles": "^5.0.1",
-        "@patternfly/react-tokens": "^5.0.1",
-        "focus-trap": "7.4.3",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.5.0"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-table/node_modules/@patternfly/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@patternfly/react-tokens": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-      "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw==",
-      "peer": true
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
-      "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
-      "dependencies": {
-        "@redhat-cloud-services/types": "^0.0.24",
-        "@sentry/browser": "^5.30.0",
-        "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.27.2",
-        "commander": "^2.20.3",
-        "mkdirp": "^1.0.4",
-        "react-content-loader": "^6.2.0"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "@redhat-cloud-services/rbac-client": "^1.0.100",
-        "cypress": ">=12.0.0 < 14.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/attr-accept": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
-      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
-      "peer": true,
-      "dependencies": {
-        "tabbable": "^6.1.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
-      "peer": true,
-      "dependencies": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8 || 18.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "peer": true
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
       "version": "3.7.6",
@@ -4825,9 +4690,9 @@
       "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/debounce-promise": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.6.tgz",
-      "integrity": "sha512-DowqK95aku+OxMCeG2EQSeXeGeE8OCwLpMsUfIbP7hMF8Otj8eQXnzpwdtIKV+UqQBtkMcF6vbi4Otbh8P/wmg=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.7.tgz",
+      "integrity": "sha512-XzqG8zCd9n33gmusdQo0d4p9iRKg/mZbG52wfHxnuZZyeO68ryOT5xyv9Fk3vLAvQBUsHmSL14Cqpsx4jjzz1Q=="
     },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
@@ -4968,9 +4833,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -25262,9 +25127,9 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.276.12",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.12.tgz",
-      "integrity": "sha512-bBN2BMFhWjl/27zmTG5z3+6aH7XMO8our9nsaryxuzN5wFn6S8cIDILsw5NY7N8SLOOtmqbFJUgcM5GAn1ZAXg==",
+      "version": "4.277.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.277.0.tgz",
+      "integrity": "sha512-bA0hIYclQN7CebBahjTl8c1j1zEAa8uUY/KtFOq7aHBWQTZjf3+By0ue2GktHAUq8diseBj+8LirScDbzi1DvQ==",
       "requires": {
         "@patternfly/react-icons": "^4.93.7",
         "@patternfly/react-styles": "^4.92.8",
@@ -25287,11 +25152,11 @@
       "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
     },
     "@patternfly/react-table": {
-      "version": "4.113.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.113.4.tgz",
-      "integrity": "sha512-WN00JBlJR8VVXpNH/IBmuTj70/Ww4vNQwB67mJ8yPzZ0refgAMqMGHCsp9yo5GImJhcBqQr4xlQNpHpeJIKphQ==",
+      "version": "4.113.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.113.5.tgz",
+      "integrity": "sha512-iBBY/81Md5pn4LQ72Ui+WZPnH6RZ/or+KqR7HxTYTE1b7HDbQ6kFAErcr5catEE54P/3kI9Ox5IhgdZOrsIt6w==",
       "requires": {
-        "@patternfly/react-core": "^4.276.12",
+        "@patternfly/react-core": "^4.277.0",
         "@patternfly/react-icons": "^4.93.7",
         "@patternfly/react-styles": "^4.92.8",
         "@patternfly/react-tokens": "^4.94.7",
@@ -25720,112 +25585,6 @@
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.3"
-      },
-      "dependencies": {
-        "@patternfly/react-styles": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.0.1.tgz",
-          "integrity": "sha512-kHP/lbvmhBnNfWiqJJLNwOQZnkcl6wfwAesRp22s4Lj941EWe0oFIqn925/uORIOAOz2du1121t7T4UTfLZg4w==",
-          "peer": true
-        },
-        "@patternfly/react-table": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.0.1.tgz",
-          "integrity": "sha512-2YbM6XvgG9ubJE4caPQKPMFBkcf7zYzLUFbHnkyfInpWeVNBs/+ZDAP2wnIHce7uaPLnJ1t0FVzGwaD/UuPwkg==",
-          "peer": true,
-          "requires": {
-            "@patternfly/react-core": "^5.0.1",
-            "@patternfly/react-icons": "^5.0.1",
-            "@patternfly/react-styles": "^5.0.1",
-            "@patternfly/react-tokens": "^5.0.1",
-            "lodash": "^4.17.19",
-            "tslib": "^2.5.0"
-          },
-          "dependencies": {
-            "@patternfly/react-core": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.0.1.tgz",
-              "integrity": "sha512-Eevd+8ACLFV733J+cpo4FRgNtRBObIgmUcrqLjf9H99jZ1hFpBgacFyHiALFi2cuoNVGmdEzskFl+4c7Uo0n+w==",
-              "peer": true,
-              "requires": {
-                "@patternfly/react-icons": "^5.0.1",
-                "@patternfly/react-styles": "^5.0.1",
-                "@patternfly/react-tokens": "^5.0.1",
-                "focus-trap": "7.4.3",
-                "react-dropzone": "^14.2.3",
-                "tslib": "^2.5.0"
-              }
-            },
-            "@patternfly/react-icons": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.1.tgz",
-              "integrity": "sha512-MduetDRzve3eRlKAioM/UxmVuPyFccdeBWAKhbN4SBn7RaZWS7kO7/xZzNkpeT5pqQIeAACvz3uiV2/3uAf38w==",
-              "peer": true,
-              "requires": {}
-            }
-          }
-        },
-        "@patternfly/react-tokens": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.0.1.tgz",
-          "integrity": "sha512-YafAGJYvxDP4GaQ0vMybalWmx7MJ+etUf1cGoaMh0wRD2eswltT/RckygtEBKR/M61qXbgG+CxKmMyY8leoiDw==",
-          "peer": true
-        },
-        "@redhat-cloud-services/frontend-components-utilities": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
-          "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
-          "requires": {
-            "@redhat-cloud-services/types": "^0.0.24",
-            "@sentry/browser": "^5.30.0",
-            "awesome-debounce-promise": "^2.1.0",
-            "axios": "^0.27.2",
-            "commander": "^2.20.3",
-            "mkdirp": "^1.0.4",
-            "react-content-loader": "^6.2.0"
-          }
-        },
-        "attr-accept": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
-          "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
-          "peer": true
-        },
-        "file-selector": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-          "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "focus-trap": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-          "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
-          "peer": true,
-          "requires": {
-            "tabbable": "^6.1.2"
-          }
-        },
-        "react-dropzone": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-          "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
-          "peer": true,
-          "requires": {
-            "attr-accept": "^2.2.2",
-            "file-selector": "^0.6.0",
-            "prop-types": "^15.8.1"
-          }
-        },
-        "tabbable": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-          "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-          "peer": true
-        }
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
@@ -26373,9 +26132,9 @@
       "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/debounce-promise": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.6.tgz",
-      "integrity": "sha512-DowqK95aku+OxMCeG2EQSeXeGeE8OCwLpMsUfIbP7hMF8Otj8eQXnzpwdtIKV+UqQBtkMcF6vbi4Otbh8P/wmg=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.7.tgz",
+      "integrity": "sha512-XzqG8zCd9n33gmusdQo0d4p9iRKg/mZbG52wfHxnuZZyeO68ryOT5xyv9Fk3vLAvQBUsHmSL14Cqpsx4jjzz1Q=="
     },
     "@types/eslint": {
       "version": "8.44.2",
@@ -26510,9 +26269,9 @@
       "version": "7.0.9"
     },
     "@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "@types/mdast": {
       "version": "3.0.10",


### PR DESCRIPTION
TLDR: small change to workaround npm versions with travis.


Just like in #986, this PR attempts to fix travis build errors.
The latest one being the npm v9 that doesn't accept deprecated commands.
When trying to downgrade to npm v8 the build fails because of the node installation step.

After some research, I've removed node version from the travis file in favor of the .nvmrc

This fixed the issue for now, but we might want to revisit and rework this pipeline.