### PR TITLE
Update the Automation Analytics documentation url to the latest version

### DIFF
--- a/src/Components/ApiStatus/AuthorizationErrorPage.tsx
+++ b/src/Components/ApiStatus/AuthorizationErrorPage.tsx
@@ -33,7 +33,7 @@ const AuthorizationErrorPage: FunctionComponent<Props> = ({ error }) => (
         <EmptyStateBody>
           Please visit{' '}
           <a
-            href="https://docs.ansible.com/ansible-tower/latest/html/administration/usability_data_collection.html#automation-analytics"
+            href="https://docs.ansible.com/automation-controller/latest/html/administration/usability_data_collection.html#automation-analytics"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
When there is no data found in the Automation Analytics page in the Hybrid Cloud Console, it prompts users to enable Automation Analytics with a documentation url attached. 

https://docs.ansible.com/ansible-tower/latest/html/administration/usability_data_collection.html#automation-analytics

The above url, however, points to Ansible Tower 3.8.6 version, which is not the latest version of AAP.

This PR updates this url to the following latest url.

https://docs.ansible.com/automation-controller/latest/html/administration/usability_data_collection.html#automation-analytics