### PR TITLE
Resource match routes. Remove paths.

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -10,6 +10,9 @@ objects:
     spec:
       envName: ${ENV_NAME}
       title: Automation Analytics
+      frontend:
+        paths:
+          - /apps/automation-analytics
       deploymentRepo: https://github.com/RedHatInsights/tower-analytics-frontend
       API:
         versions:

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -6,7 +6,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: tower-analytics
+      name: automation-analytics
     spec:
       envName: ${ENV_NAME}
       title: Automation Analytics
@@ -14,10 +14,6 @@ objects:
       API:
         versions:
           - v1
-      frontend:
-        paths:
-          - /apps/tower-analytics
-          - /apps/automation-analytics
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
         - appId: "automationAnalytics"


### PR DESCRIPTION
This patch makes the frontend resource name match the desired open shift route names, and then removes the redundant paths.