### PR TITLE
Filter: clicking clear all filters when using default filters breaks filters

### DIFF
--- a/src/QueryParams/Provider.tsx
+++ b/src/QueryParams/Provider.tsx
@@ -35,8 +35,8 @@ const QueryParamsProvider: FunctionComponent<Props> = ({ children }) => {
     const q = removeDefault
       ? {
           ...queryParams,
-          [namespace]: newQueryParams,
           [DEFAULT_NAMESPACE]: {},
+          [namespace]: newQueryParams,
         }
       : {
           ...queryParams,


### PR DESCRIPTION
Before: Go to any screen with filters .. filters work; click clear all filters, twice (or once with default filters); filters don't work.
Now: filters keep working after resetting filters regardless

Looks like the problem was that when `namespace == DEFAULT_NAMESPACE` (which is the default state),
resetting it to `newQueryParams` would never happen, because right after that it would be overwritten by `{}` thanks to `removeDefault`. IIUC `removeDefault` should remove the default completely only when not replacing it with a new default, and it seems to work :)