### PR TITLE
package.json: bump version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-analytics",
-  "version": "1.1.0",
+  "version": "1.7.0",
   "private": false,
   "dependencies": {
     "@ansible/react-json-chart-builder": "^2.0.1",


### PR DESCRIPTION
(v1.6.0 tag already exists)

mostly because crc mounts the app under a

    div id="automation-analytics-application" version="1.1.0"

so we'll know the update happened :)