### PR TITLE
Automation calculator: fix missing download button

### DIFF
--- a/src/Components/Toolbar/Toolbar.tsx
+++ b/src/Components/Toolbar/Toolbar.tsx
@@ -8,7 +8,7 @@ import { ToolbarItem } from '@patternfly/react-core/dist/dynamic/components/Tool
 import { ToolbarItemVariant } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import CogIcon from '@patternfly/react-icons/dist/dynamic/icons/cog-icon';
 import FilterIcon from '@patternfly/react-icons/dist/dynamic/icons/filter-icon';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, ReactNode, useState } from 'react';
 import { FilterCategoriesGroup, QuickDateGroup, SortByGroup } from './Groups';
 import { optionsForCategories } from './constants';
 import { ApiOptionsType, AttributeType, SetValues } from './types';
@@ -19,13 +19,13 @@ interface Props {
   filters: Record<string, AttributeType>;
   defaultSelected?: string;
   setFilters: SetValues;
-  pagination?: FunctionComponent | null;
+  pagination?: ReactNode | null;
   settingsPanel?: (
     setSettingsExpanded: (arg0: boolean) => void,
     settingsExpanded: boolean
-  ) => FunctionComponent;
+  ) => ReactNode;
   hasSettings?: boolean;
-  additionalControls?: FunctionComponent[];
+  additionalControls?: ReactNode[];
 }
 
 const FilterableToolbar: FunctionComponent<Props> = ({

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -525,7 +525,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
             categories={options as any}
             filters={queryParams as any}
             setFilters={setFromToolbar}
-            pagination={() => (
+            pagination={
               <Pagination
                 count={api.result.meta.count}
                 perPageOptions={perPageOptions}
@@ -536,40 +536,38 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                 setPagination={setFromPagination as any}
                 isCompact
               />
-            )}
+            }
             additionalControls={[
-              () => (
-                <DownloadButton
-                  key='download-button'
-                  slug={slug}
-                  isMoney={isMoney}
-                  name={name}
-                  description={description}
-                  endpointUrl={dataEndpoint}
-                  queryParams={queryParams as any}
-                  selectOptions={options as any}
-                  y={chartParams.y as any}
-                  label={chartParams.label as any}
-                  xTickFormat={chartParams.xTickFormat}
-                  totalPages={Math.ceil(
-                    api.result.meta.count / (queryParams.limit as any)
-                  )}
-                  pageLimit={queryParams.limit as any}
-                  sortOptions={chartParams.y as any}
-                  sortOrder={queryParams.sort_order as any}
-                  startDate={queryParams.start_date as any}
-                  endDate={queryParams.end_date as any}
-                  dateRange={queryParams.quick_date_range as any}
-                  inputs={
-                    {
-                      costManual,
-                      costAutomation,
-                      totalSavings: computeTotalSavings(),
-                      currentPageSavings: computeCurrentPageSavings(),
-                    } as any
-                  }
-                />
-              ),
+              <DownloadButton
+                key='download-button'
+                slug={slug}
+                isMoney={isMoney}
+                name={name}
+                description={description}
+                endpointUrl={dataEndpoint}
+                queryParams={queryParams as any}
+                selectOptions={options as any}
+                y={chartParams.y as any}
+                label={chartParams.label as any}
+                xTickFormat={chartParams.xTickFormat}
+                totalPages={Math.ceil(
+                  api.result.meta.count / (queryParams.limit as any)
+                )}
+                pageLimit={queryParams.limit as any}
+                sortOptions={chartParams.y as any}
+                sortOrder={queryParams.sort_order as any}
+                startDate={queryParams.start_date as any}
+                endDate={queryParams.end_date as any}
+                dateRange={queryParams.quick_date_range as any}
+                inputs={
+                  {
+                    costManual,
+                    costAutomation,
+                    totalSavings: computeTotalSavings(),
+                    currentPageSavings: computeCurrentPageSavings(),
+                  } as any
+                }
+              />,
             ]}
           />
           <Grid hasGutter>

--- a/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
+++ b/src/Containers/Reports/Layouts/Standard/ReportCard.tsx
@@ -262,7 +262,7 @@ const ReportCard: FunctionComponent<StandardProps> = ({
                 )
               : null
           }
-          additionalControls={additionalControls as any}
+          additionalControls={additionalControls}
         />
         {tableHeaders && !showKebab && slug !== 'templates_by_organization' ? (
           <ApiStatusWrapper api={dataApi as any}>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-33165

introduced while doing another automation calculator fix in #1045, the download button & pagination was accidentally hidden in Automation Calculator

restoring and adjusting types to match

Before:
![20241009131546](https://github.com/user-attachments/assets/5ed9072e-1105-490b-a35e-42e09ec04751)

After:
![20241009131426](https://github.com/user-attachments/assets/dc30367b-f094-43c8-9afe-1ba371d64e31)
![20241009131434](https://github.com/user-attachments/assets/c6ade4eb-024b-491f-b64a-92808f89b745)
