### PR TITLE
dependabot: ignore patternfly 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
         patterns:
           - '@victory/*'
     ignore:
+      - dependency-name: '@patternfly/*'
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: '@patternfly/react-charts'
         update-types:
           - 'version-update:semver-major'


### PR DESCRIPTION
PF6 came out, crc doesn't support it yet,
stopping dependabot from offering that update.

(Also https://github.com/RedHatInsights/ansible-platform-dashboard/pull/159, https://github.com/ansible/ansible-hub-ui/pull/5305)

(Closes #1092)