### PR TITLE
Chart legend - hide/unhide on click

### DIFF
--- a/src/Components/Chart/index.tsx
+++ b/src/Components/Chart/index.tsx
@@ -69,10 +69,7 @@ const applyHiddenFilter = (
     hidden:
       (!!series.serie[0].id || !!series.serie[0].host_id) &&
       !!chartSeriesHidden.includes(
-        // eslint-disable-next-line no-prototype-builtins
-        series.serie[0].hasOwnProperty('host_id').toString() ||
-          // eslint-disable-next-line no-prototype-builtins
-          series.serie[0].hasOwnProperty('id').toString()
+        (series.serie[0].host_id || series.serie[0].id || '').toString()
       ),
   })),
 });
@@ -98,6 +95,7 @@ const Chart: FC<Props> = ({
     legend: [],
   });
 
+  // gets called when clicking on legend, .series[x].hidden is updated
   const setChartDataHook = (newChartData: ChartData) => {
     dispatch({
       type: 'SET_CHART_SERIES_HIDDEN_PROPS',
@@ -114,7 +112,8 @@ const Chart: FC<Props> = ({
         chartSeriesHiddenProps as string[]
       )
     );
-  }, [data]);
+  }, [data, chartSeriesHiddenProps]);
+
   return (
     <ChartBuilder
       schema={schema}


### PR DESCRIPTION
Fixes AAP-32262

`hasOwnProperty` returns a bool, not the id value we need to filter by - replacing with the actual id value, stringified

---

Testing:

https://stage.foo.redhat.com:1337/ansible/automation-analytics/reports?allReports.description=&allReports.limit=20&allReports.name[]&allReports.offset=0&allReports.selected_report=changes_made_by_job_template&allReports.slug[]&allReports.sort_options=name&allReports.sort_order=asc&allReports.tags[]&default.attributes[]=host_count,changed_host_count,host_task_count,host_task_changed_count&default.cluster_id[]&default.end_date&default.granularity=monthly&default.group_by=template&default.group_by_time=true&default.inventory_id[]&default.job_type[]&default.limit=6&default.offset=0&default.org_id[]&default.quick_date_range=last_year&default.sort_options=changed_host_count&default.sort_order=desc&default.start_date&default.status[]&default.template_id[]&settings.chartSeriesHiddenProps[]=112885&settings.offset=0

click on a field in the legend, see it get hidden/unhidden :tada: 