### PR TITLE
[AAP-71806] fix: ensure PatternFly dark mode compatibility

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import packageJson from '../package.json';
 import { preflightRequest } from './Api/';
 import './App.scss';
+import './Charts/Utilities/chartDarkMode.css';
 import AuthorizationErrorPage from './Components/ApiStatus/AuthorizationErrorPage';
 import { AnalyticsRoutes } from './Routes';
 import useRequest from './Utilities/useRequest';

--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -7,6 +7,11 @@ import { formatDate } from '../Utilities/helpers';
 import { Paths } from '../paths';
 import initializeChart from './BaseChart';
 import Tooltip from './Utilities/Tooltip';
+import {
+  chartDangerColor,
+  chartGridColor,
+  chartSuccessColor,
+} from './Utilities/chartTheme';
 
 class BarChart extends Component {
   constructor(props) {
@@ -91,7 +96,7 @@ class BarChart extends Component {
           ')',
       );
     //[fail, success]
-    let colors = d3.scaleOrdinal(['#6EC664', '#A30000']);
+    let colors = d3.scaleOrdinal([chartSuccessColor(), chartDangerColor()]);
 
     const barTooltip = new Tooltip({
       svg: '#' + this.props.id,
@@ -116,11 +121,12 @@ class BarChart extends Component {
       .attr('class', 'y-axis')
       .call(d3.axisLeft(y).tickSize(-width, 0, 0))
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', chartGridColor());
     svg.selectAll('.y-axis .tick text').attr('x', -5);
     // text label for the y axis
     svg
       .append('text')
+      .attr('class', 'y-axis')
       .attr('transform', 'rotate(-90)')
       .attr('y', 0 - this.props.margin.left)
       .attr('x', 0 - height / 2)
@@ -145,12 +151,13 @@ class BarChart extends Component {
         d3.axisBottom(x).tickValues(ticks).tickFormat(d3.timeFormat('%-m/%-d')), // "1/19"
       )
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', chartGridColor());
     svg.selectAll('.x-axis .tick text').attr('y', 10);
 
     // text label for the x axis
     svg
       .append('text')
+      .attr('class', 'x-axis')
       .attr(
         'transform',
         'translate(' +

--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -11,6 +11,7 @@ import {
   chartDangerColor,
   chartGridColor,
   chartSuccessColor,
+  chartTextVar,
 } from './Utilities/chartTheme';
 
 class BarChart extends Component {
@@ -122,7 +123,10 @@ class BarChart extends Component {
       .call(d3.axisLeft(y).tickSize(-width, 0, 0))
       .selectAll('line')
       .attr('stroke', chartGridColor());
-    svg.selectAll('.y-axis .tick text').attr('x', -5);
+    svg
+      .selectAll('.y-axis .tick text')
+      .attr('x', -5)
+      .style('fill', chartTextVar);
     // text label for the y axis
     svg
       .append('text')
@@ -132,6 +136,7 @@ class BarChart extends Component {
       .attr('x', 0 - height / 2)
       .attr('dy', '1em')
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text('Jobs across all clusters');
     // Add the X Axis
     let ticks;
@@ -152,7 +157,10 @@ class BarChart extends Component {
       )
       .selectAll('line')
       .attr('stroke', chartGridColor());
-    svg.selectAll('.x-axis .tick text').attr('y', 10);
+    svg
+      .selectAll('.x-axis .tick text')
+      .attr('y', 10)
+      .style('fill', chartTextVar);
 
     // text label for the x axis
     svg
@@ -167,6 +175,7 @@ class BarChart extends Component {
           ')',
       )
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text('Date');
 
     const layer = svg

--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -8,9 +8,9 @@ import { Paths } from '../paths';
 import initializeChart from './BaseChart';
 import Tooltip from './Utilities/Tooltip';
 import {
-  chartDangerColor,
-  chartGridColor,
-  chartSuccessColor,
+  chartDangerColorVar,
+  chartGridColorVar,
+  chartSuccessColorVar,
   chartTextVar,
 } from './Utilities/chartTheme';
 
@@ -97,7 +97,7 @@ class BarChart extends Component {
           ')',
       );
     //[fail, success]
-    let colors = d3.scaleOrdinal([chartSuccessColor(), chartDangerColor()]);
+    let colors = d3.scaleOrdinal([chartSuccessColorVar, chartDangerColorVar]);
 
     const barTooltip = new Tooltip({
       svg: '#' + this.props.id,
@@ -122,7 +122,7 @@ class BarChart extends Component {
       .attr('class', 'y-axis')
       .call(d3.axisLeft(y).tickSize(-width, 0, 0))
       .selectAll('line')
-      .attr('stroke', chartGridColor());
+      .style('stroke', chartGridColorVar);
     svg
       .selectAll('.y-axis .tick text')
       .attr('x', -5)
@@ -156,7 +156,7 @@ class BarChart extends Component {
         d3.axisBottom(x).tickValues(ticks).tickFormat(d3.timeFormat('%-m/%-d')), // "1/19"
       )
       .selectAll('line')
-      .attr('stroke', chartGridColor());
+      .style('stroke', chartGridColorVar);
     svg
       .selectAll('.x-axis .tick text')
       .attr('y', 10)

--- a/src/Charts/GroupedBarChart/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart/GroupedBarChart.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import initializeChart from '.././BaseChart';
 import Legend from '../Utilities/Legend';
-import { chartGridColor, chartTextVar } from '../Utilities/chartTheme';
+import { chartGridColorVar, chartTextVar } from '../Utilities/chartTheme';
 
 const Wrapper = styled.div`
   display: flex;
@@ -107,7 +107,7 @@ const GroupedBarChart = ({
       .attr('class', 'y axis')
       .call(yAxis)
       .selectAll('line')
-      .attr('stroke', chartGridColor())
+      .style('stroke', chartGridColorVar)
       .append('text')
       .attr('transform', 'rotate(-90)')
       .attr('y', 6)
@@ -133,7 +133,7 @@ const GroupedBarChart = ({
       .attr('transform', 'translate(0,' + height + ')')
       .call(xAxis)
       .selectAll('line')
-      .attr('stroke', chartGridColor());
+      .style('stroke', chartGridColorVar);
     svg
       .append('text')
       .attr('class', 'x axis')

--- a/src/Charts/GroupedBarChart/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart/GroupedBarChart.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import initializeChart from '.././BaseChart';
 import Legend from '../Utilities/Legend';
+import { chartGridColor } from '../Utilities/chartTheme';
 
 const Wrapper = styled.div`
   display: flex;
@@ -106,7 +107,7 @@ const GroupedBarChart = ({
       .attr('class', 'y axis')
       .call(yAxis)
       .selectAll('line')
-      .attr('stroke', '#d7d7d7')
+      .attr('stroke', chartGridColor())
       .append('text')
       .attr('transform', 'rotate(-90)')
       .attr('y', 6)
@@ -116,6 +117,7 @@ const GroupedBarChart = ({
       .text('Value');
     svg
       .append('text')
+      .attr('class', 'y axis')
       .attr('transform', 'rotate(-90)')
       .attr('y', 0 - props.margin.left)
       .attr('x', 0 - height / 2)
@@ -130,9 +132,10 @@ const GroupedBarChart = ({
       .attr('transform', 'translate(0,' + height + ')')
       .call(xAxis)
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', chartGridColor());
     svg
       .append('text')
+      .attr('class', 'x axis')
       .attr(
         'transform',
         'translate(' +

--- a/src/Charts/GroupedBarChart/GroupedBarChart.js
+++ b/src/Charts/GroupedBarChart/GroupedBarChart.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import initializeChart from '.././BaseChart';
 import Legend from '../Utilities/Legend';
-import { chartGridColor } from '../Utilities/chartTheme';
+import { chartGridColor, chartTextVar } from '../Utilities/chartTheme';
 
 const Wrapper = styled.div`
   display: flex;
@@ -123,6 +123,7 @@ const GroupedBarChart = ({
       .attr('x', 0 - height / 2)
       .attr('dy', '1em')
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text(props.yLabel);
 
     // add x axis
@@ -145,6 +146,7 @@ const GroupedBarChart = ({
           ')',
       )
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text('Date');
     // add the groups
     let slice = svg.selectAll('.slice').data(data);

--- a/src/Charts/GroupedBarChart/HostsTooltip.js
+++ b/src/Charts/GroupedBarChart/HostsTooltip.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { chartTooltipBg } from '../Utilities/chartTheme';
 
 const formatDate = (date) => {
   const pieces = date.split('-');
@@ -29,7 +30,7 @@ export default class HostsTooltip {
       .attr('y', 0)
       .attr('height', 20)
       .attr('width', 20)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.boundingBox = this.toolTipBase
       .append('rect')
       .attr('x', 10)
@@ -37,7 +38,7 @@ export default class HostsTooltip {
       .attr('rx', 2)
       .attr('height', 50)
       .attr('width', this.boxWidth)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.date = this.toolTipBase
       .append('text')
       .attr('x', 20)

--- a/src/Charts/GroupedBarChart/OrgsTooltip.js
+++ b/src/Charts/GroupedBarChart/OrgsTooltip.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { chartTooltipBg } from '../Utilities/chartTheme';
 
 const formatDate = (date) => {
   const pieces = date.split('-');
@@ -30,7 +31,7 @@ export default class OrgsTooltip {
       .attr('y', 0)
       .attr('height', 20)
       .attr('width', 20)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.boundingBox = this.toolTipBase
       .append('rect')
       .attr('x', 10)
@@ -38,7 +39,7 @@ export default class OrgsTooltip {
       .attr('rx', 2)
       .attr('height', 50)
       .attr('width', this.boxWidth)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.date = this.toolTipBase
       .append('text')
       .attr('x', 20)

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -8,11 +8,10 @@ import { Paths } from '../paths';
 import initializeChart from './BaseChart';
 import Tooltip from './Utilities/Tooltip';
 import {
-  chartDangerColor,
-  chartGridColor,
-  chartInfoColor,
-  chartSuccessColor,
-  chartText,
+  chartDangerColorVar,
+  chartGridColorVar,
+  chartInfoColorVar,
+  chartSuccessColorVar,
   chartTextVar,
 } from './Utilities/chartTheme';
 
@@ -91,9 +90,9 @@ class LineChart extends Component {
 
     //[success, fail, total]
     let colors = d3.scaleOrdinal([
-      chartSuccessColor(),
-      chartDangerColor(),
-      chartInfoColor(),
+      chartSuccessColorVar,
+      chartDangerColorVar,
+      chartInfoColorVar,
     ]);
     const svg = d3
       .select('#' + this.props.id)
@@ -167,7 +166,7 @@ class LineChart extends Component {
       .attr('class', 'y-axis')
       .call(d3.axisLeft(y).ticks(10).tickSize(-width))
       .selectAll('line')
-      .attr('stroke', chartGridColor());
+      .style('stroke', chartGridColorVar);
     svg
       .selectAll('.y-axis .tick text')
       .attr('x', -5)
@@ -206,7 +205,7 @@ class LineChart extends Component {
           .tickFormat(d3.timeFormat('%-m/%-d')), // "1/19"
       ) // "Jan-01"
       .selectAll('line')
-      .attr('stroke', chartGridColor());
+      .style('stroke', chartGridColorVar);
     svg
       .selectAll('.x-axis .tick text')
       .attr('y', 10)
@@ -230,7 +229,7 @@ class LineChart extends Component {
     const vertical = svg
       .append('path')
       .attr('class', 'mouse-line')
-      .style('stroke', chartText())
+      .style('stroke', chartTextVar)
       .style('stroke-width', '3px')
       .style('stroke-dasharray', '3, 3')
       .style('opacity', '0');

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -13,6 +13,7 @@ import {
   chartInfoColor,
   chartSuccessColor,
   chartText,
+  chartTextVar,
 } from './Utilities/chartTheme';
 
 class LineChart extends Component {
@@ -167,7 +168,10 @@ class LineChart extends Component {
       .call(d3.axisLeft(y).ticks(10).tickSize(-width))
       .selectAll('line')
       .attr('stroke', chartGridColor());
-    svg.selectAll('.y-axis .tick text').attr('x', -5);
+    svg
+      .selectAll('.y-axis .tick text')
+      .attr('x', -5)
+      .style('fill', chartTextVar);
 
     // text label for the y axis
     svg
@@ -178,6 +182,7 @@ class LineChart extends Component {
       .attr('x', 0 - height / 2)
       .attr('dy', '1em')
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text('Job runs');
     // Add the X Axis
     let ticks;
@@ -202,7 +207,10 @@ class LineChart extends Component {
       ) // "Jan-01"
       .selectAll('line')
       .attr('stroke', chartGridColor());
-    svg.selectAll('.x-axis .tick text').attr('y', 10);
+    svg
+      .selectAll('.x-axis .tick text')
+      .attr('y', 10)
+      .style('fill', chartTextVar);
 
     // text label for the x axis
     svg
@@ -217,6 +225,7 @@ class LineChart extends Component {
           ')',
       )
       .style('text-anchor', 'middle')
+      .style('fill', chartTextVar)
       .text('Date');
     const vertical = svg
       .append('path')

--- a/src/Charts/LineChart.js
+++ b/src/Charts/LineChart.js
@@ -7,6 +7,13 @@ import { formatDate } from '../Utilities/helpers';
 import { Paths } from '../paths';
 import initializeChart from './BaseChart';
 import Tooltip from './Utilities/Tooltip';
+import {
+  chartDangerColor,
+  chartGridColor,
+  chartInfoColor,
+  chartSuccessColor,
+  chartText,
+} from './Utilities/chartTheme';
 
 class LineChart extends Component {
   constructor(props) {
@@ -82,7 +89,11 @@ class LineChart extends Component {
     const y = d3.scaleLinear().range([height, 0]);
 
     //[success, fail, total]
-    let colors = d3.scaleOrdinal(['#6EC664', '#A30000', '#06C']);
+    let colors = d3.scaleOrdinal([
+      chartSuccessColor(),
+      chartDangerColor(),
+      chartInfoColor(),
+    ]);
     const svg = d3
       .select('#' + this.props.id)
       .append('svg')
@@ -155,12 +166,13 @@ class LineChart extends Component {
       .attr('class', 'y-axis')
       .call(d3.axisLeft(y).ticks(10).tickSize(-width))
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', chartGridColor());
     svg.selectAll('.y-axis .tick text').attr('x', -5);
 
     // text label for the y axis
     svg
       .append('text')
+      .attr('class', 'y-axis')
       .attr('transform', 'rotate(-90)')
       .attr('y', 0 - this.props.margin.left)
       .attr('x', 0 - height / 2)
@@ -189,12 +201,13 @@ class LineChart extends Component {
           .tickFormat(d3.timeFormat('%-m/%-d')), // "1/19"
       ) // "Jan-01"
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', chartGridColor());
     svg.selectAll('.x-axis .tick text').attr('y', 10);
 
     // text label for the x axis
     svg
       .append('text')
+      .attr('class', 'x-axis')
       .attr(
         'transform',
         'translate(' +
@@ -208,7 +221,7 @@ class LineChart extends Component {
     const vertical = svg
       .append('path')
       .attr('class', 'mouse-line')
-      .style('stroke', 'black')
+      .style('stroke', chartText())
       .style('stroke-width', '3px')
       .style('stroke-dasharray', '3, 3')
       .style('opacity', '0');

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { getTotal } from '../Utilities/helpers';
 import initializeChart from './BaseChart';
 import Legend from './Utilities/Legend';
+import { chartTooltipBg } from './Utilities/chartTheme';
 
 const Wrapper = styled.div`
   display: flex;
@@ -41,7 +42,7 @@ class Tooltip {
       .attr('y', 0)
       .attr('height', 20)
       .attr('width', 20)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.boundingBOx = this.toolTipBase
       .append('rect')
       .attr('x', 10)
@@ -49,7 +50,7 @@ class Tooltip {
       .attr('rx', 2)
       .attr('height', boundingHeight)
       .attr('width', boundingWidth)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.orgName = this.toolTipBase
       .append('text')
       .attr('fill', 'white')

--- a/src/Charts/Utilities/Tooltip.js
+++ b/src/Charts/Utilities/Tooltip.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { chartTooltipBg } from './chartTheme';
 
 class Tooltip {
   constructor(opts) {
@@ -24,7 +25,7 @@ class Tooltip {
       .attr('y', 0)
       .attr('height', 20)
       .attr('width', 20)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.boundingBox = this.toolTipBase
       .append('rect')
       .attr('x', 10)
@@ -32,7 +33,7 @@ class Tooltip {
       .attr('rx', 2)
       .attr('height', 110)
       .attr('width', this.boxWidth)
-      .attr('fill', '#393f44');
+      .attr('fill', chartTooltipBg());
     this.circleSuccess = this.toolTipBase
       .append('circle')
       .attr('cx', 26)

--- a/src/Charts/Utilities/chartDarkMode.css
+++ b/src/Charts/Utilities/chartDarkMode.css
@@ -1,0 +1,9 @@
+:root:where(.pf-v6-theme-dark) svg text,
+:root:where(.pf-theme-dark) svg text {
+  fill: #e0e0e0;
+}
+
+:root:where(.pf-v6-theme-dark) svg .domain,
+:root:where(.pf-theme-dark) svg .domain {
+  stroke: #444548;
+}

--- a/src/Charts/Utilities/chartDarkMode.css
+++ b/src/Charts/Utilities/chartDarkMode.css
@@ -1,9 +1,9 @@
 :root:where(.pf-v6-theme-dark) svg text,
 :root:where(.pf-theme-dark) svg text {
-  fill: #e0e0e0;
+  fill: var(--pf-t--global--dark--text--color--100);
 }
 
 :root:where(.pf-v6-theme-dark) svg .domain,
 :root:where(.pf-theme-dark) svg .domain {
-  stroke: #444548;
+  stroke: var(--pf-t--global--dark--border--color--100);
 }

--- a/src/Charts/Utilities/chartTheme.ts
+++ b/src/Charts/Utilities/chartTheme.ts
@@ -29,10 +29,14 @@ export function chartText(): string {
   return pfVar(t_global_text_color_regular);
 }
 
-// Returns the CSS variable reference rather than the resolved value.
-// Use this for D3 .style() calls so the colour updates reactively when
+// The exports below return the CSS variable reference rather than the resolved
+// value. Use these for D3 .style() calls so colours update reactively when
 // the user switches theme, without needing to redraw the chart.
 export const chartTextVar = t_global_text_color_regular.var;
+export const chartGridColorVar = t_global_border_color_100.var;
+export const chartSuccessColorVar = t_chart_color_green_300.var;
+export const chartDangerColorVar = t_chart_color_red_orange_400.var;
+export const chartInfoColorVar = t_chart_color_blue_300.var;
 
 export function chartTextSecondary(): string {
   return pfVar(t_global_text_color_subtle);

--- a/src/Charts/Utilities/chartTheme.ts
+++ b/src/Charts/Utilities/chartTheme.ts
@@ -13,7 +13,6 @@ import {
 // PF redefines semantic tokens under .pf-v6-theme-dark, so dark mode is handled
 // automatically without any manual isDark() check.
 function pfVar(token: { name: string; value: string }): string {
-  if (typeof document === 'undefined') return token.value;
   return (
     getComputedStyle(document.documentElement)
       .getPropertyValue(token.name)
@@ -51,16 +50,4 @@ export function chartGridColor(): string {
 // use a static palette value rather than pfVar().
 export function chartTooltipBg(): string {
   return t_color_gray_90.value;
-}
-
-export function chartSuccessColor(): string {
-  return pfVar(t_chart_color_green_300);
-}
-
-export function chartDangerColor(): string {
-  return pfVar(t_chart_color_red_orange_400);
-}
-
-export function chartInfoColor(): string {
-  return pfVar(t_chart_color_blue_300);
 }

--- a/src/Charts/Utilities/chartTheme.ts
+++ b/src/Charts/Utilities/chartTheme.ts
@@ -1,37 +1,54 @@
-function isDark(): boolean {
-  if (typeof document === 'undefined') return false;
-  const cl = document.documentElement.classList;
-  return cl.contains('pf-v6-theme-dark') || cl.contains('pf-theme-dark');
+import {
+  t_chart_color_blue_300,
+  t_chart_color_green_300,
+  t_chart_color_red_orange_400,
+  t_global_background_color_100,
+  t_global_background_color_inverse_default,
+  t_global_border_color_100,
+  t_global_text_color_regular,
+  t_global_text_color_subtle,
+} from '@patternfly/react-tokens';
+
+// Reads the resolved value of a PF CSS custom property from the document root.
+// PF redefines semantic tokens under .pf-v6-theme-dark, so dark mode is handled
+// automatically without any manual isDark() check.
+function pfVar(token: { name: string; value: string }): string {
+  if (typeof document === 'undefined') return token.value;
+  return (
+    getComputedStyle(document.documentElement)
+      .getPropertyValue(token.name)
+      .trim() || token.value
+  );
 }
 
 export function chartBackground(): string {
-  return isDark() ? '#1b1d21' : '#ffffff';
+  return pfVar(t_global_background_color_100);
 }
 
 export function chartText(): string {
-  return isDark() ? '#e0e0e0' : '#151515';
+  return pfVar(t_global_text_color_regular);
 }
 
 export function chartTextSecondary(): string {
-  return isDark() ? '#c9c9c9' : '#4f5255';
+  return pfVar(t_global_text_color_subtle);
 }
 
 export function chartGridColor(): string {
-  return isDark() ? '#444548' : '#d2d2d2';
+  return pfVar(t_global_border_color_100);
 }
 
 export function chartTooltipBg(): string {
-  return isDark() ? '#e0e0e0' : '#151515';
+  return pfVar(t_global_background_color_inverse_default);
 }
 
 export function chartSuccessColor(): string {
-  return isDark() ? '#5ba352' : '#3e8635';
+  return pfVar(t_chart_color_green_300);
 }
 
 export function chartDangerColor(): string {
-  return isDark() ? '#fe5142' : '#c9190b';
+  return pfVar(t_chart_color_red_orange_400);
 }
 
 export function chartInfoColor(): string {
-  return isDark() ? '#1fa7f8' : '#0066cc';
+  return pfVar(t_chart_color_blue_300);
 }

--- a/src/Charts/Utilities/chartTheme.ts
+++ b/src/Charts/Utilities/chartTheme.ts
@@ -1,0 +1,37 @@
+function isDark(): boolean {
+  if (typeof document === 'undefined') return false;
+  const cl = document.documentElement.classList;
+  return cl.contains('pf-v6-theme-dark') || cl.contains('pf-theme-dark');
+}
+
+export function chartBackground(): string {
+  return isDark() ? '#1b1d21' : '#ffffff';
+}
+
+export function chartText(): string {
+  return isDark() ? '#e0e0e0' : '#151515';
+}
+
+export function chartTextSecondary(): string {
+  return isDark() ? '#c9c9c9' : '#4f5255';
+}
+
+export function chartGridColor(): string {
+  return isDark() ? '#444548' : '#d2d2d2';
+}
+
+export function chartTooltipBg(): string {
+  return isDark() ? '#e0e0e0' : '#151515';
+}
+
+export function chartSuccessColor(): string {
+  return isDark() ? '#5ba352' : '#3e8635';
+}
+
+export function chartDangerColor(): string {
+  return isDark() ? '#fe5142' : '#c9190b';
+}
+
+export function chartInfoColor(): string {
+  return isDark() ? '#1fa7f8' : '#0066cc';
+}

--- a/src/Charts/Utilities/chartTheme.ts
+++ b/src/Charts/Utilities/chartTheme.ts
@@ -2,8 +2,8 @@ import {
   t_chart_color_blue_300,
   t_chart_color_green_300,
   t_chart_color_red_orange_400,
+  t_color_gray_90,
   t_global_background_color_100,
-  t_global_background_color_inverse_default,
   t_global_border_color_100,
   t_global_text_color_regular,
   t_global_text_color_subtle,
@@ -29,6 +29,11 @@ export function chartText(): string {
   return pfVar(t_global_text_color_regular);
 }
 
+// Returns the CSS variable reference rather than the resolved value.
+// Use this for D3 .style() calls so the colour updates reactively when
+// the user switches theme, without needing to redraw the chart.
+export const chartTextVar = t_global_text_color_regular.var;
+
 export function chartTextSecondary(): string {
   return pfVar(t_global_text_color_subtle);
 }
@@ -37,8 +42,11 @@ export function chartGridColor(): string {
   return pfVar(t_global_border_color_100);
 }
 
+// Tooltips use a fixed dark background with white text in both themes.
+// SVG presentation attributes (fill=) don't resolve CSS variables, so we
+// use a static palette value rather than pfVar().
 export function chartTooltipBg(): string {
-  return pfVar(t_global_background_color_inverse_default);
+  return t_color_gray_90.value;
 }
 
 export function chartSuccessColor(): string {

--- a/src/Components/Chart/PlotlyChart.js
+++ b/src/Components/Chart/PlotlyChart.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Plot from 'react-plotly.js';
+import {
+  chartBackground,
+  chartGridColor,
+  chartText,
+  chartTextSecondary,
+  chartTooltipBg,
+} from '../../Charts/Utilities/chartTheme';
 import { useQueryParams } from '../../QueryParams';
 import { reportDefaultParams } from '../../Utilities/constants';
 
@@ -68,6 +75,12 @@ const PlotlyChart = ({ data }) => {
     }
   });
 
+  const bg = chartBackground();
+  const text = chartText();
+  const textSecondary = chartTextSecondary();
+  const grid = chartGridColor();
+  const tooltipBg = chartTooltipBg();
+
   const state = {
     config: {
       modeBarButtonsToRemove: ['zoom'],
@@ -76,15 +89,15 @@ const PlotlyChart = ({ data }) => {
     },
     data: [
       {
-        customdata: items, //customization: items from API
-        hovertemplate: ` <br>  <b>${xLabel}</b>: %{${xLabelValue}}  <br>  <b>${yToolTipLabel}</b>: %{${yToolTipLabelValue}}  <br>  <b>${findZLabel()}</b>: %{${findZLabelValue()}}  <br> `, //customization: All labels and values defined above
+        customdata: items,
+        hovertemplate: ` <br>  <b>${xLabel}</b>: %{${xLabelValue}}  <br>  <b>${yToolTipLabel}</b>: %{${yToolTipLabelValue}}  <br>  <b>${findZLabel()}</b>: %{${findZLabelValue()}}  <br> `,
         marker: {
-          color: ZArray, //customization: Derived from items
+          color: ZArray,
           coloraxis: 'coloraxis',
         },
         name: '',
-        x: orgArray, //customization: Derived from items
-        y: templateCountArray, //customization: Derived from items
+        x: orgArray,
+        y: templateCountArray,
         type: 'bar',
       },
     ],
@@ -94,14 +107,14 @@ const PlotlyChart = ({ data }) => {
           bar: [
             {
               error_x: {
-                color: '#2a3f5f',
+                color: textSecondary,
               },
               error_y: {
-                color: '#2a3f5f',
+                color: textSecondary,
               },
               marker: {
                 line: {
-                  color: 'white',
+                  color: bg,
                   width: 0.5,
                 },
                 pattern: {
@@ -119,26 +132,26 @@ const PlotlyChart = ({ data }) => {
             align: 'left',
           },
           hovermode: 'closest',
-          paper_bgcolor: 'white',
-          plot_bgcolor: 'white',
+          paper_bgcolor: bg,
+          plot_bgcolor: bg,
           xaxis: {
             automargin: true,
-            gridcolor: '#D2D2D2',
-            linecolor: '#D2D2D2',
+            gridcolor: grid,
+            linecolor: grid,
             title: {
               standoff: 15,
             },
-            zerolinecolor: '#D2D2D2',
+            zerolinecolor: grid,
             zerolinewidth: 2,
           },
           yaxis: {
             automargin: true,
-            gridcolor: '#D2D2D2',
-            linecolor: '#D2D2D2',
+            gridcolor: grid,
+            linecolor: grid,
             title: {
               standoff: 15,
             },
-            zerolinecolor: '#D2D2D2',
+            zerolinecolor: grid,
             zerolinewidth: 2,
           },
         },
@@ -146,12 +159,12 @@ const PlotlyChart = ({ data }) => {
       xaxis: {
         tickangle: -45,
         title: {
-          text: `${xLabel}`, //customization: All labels defined above
+          text: `${xLabel}`,
           font: {
             family:
               'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
             size: 15,
-            color: 'black',
+            color: text,
           },
         },
       },
@@ -159,29 +172,29 @@ const PlotlyChart = ({ data }) => {
         anchor: 'x',
         domain: [0.0, 1.0],
         title: {
-          text: `${yLabel}`, //customization: All labels defined above
+          text: `${yLabel}`,
           font: {
             family:
               'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
             size: 15,
-            color: 'black',
+            color: text,
           },
         },
-        color: '#4f5255',
+        color: textSecondary,
       },
       coloraxis: {
         colorbar: {
           title: {
             text: `${findZLabel()}`,
             font: {
-              color: '#4f5255',
+              color: textSecondary,
               family:
                 'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
               size: 15,
             },
           },
           tickfont: {
-            color: '#4f5255',
+            color: textSecondary,
             family:
               'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
             size: 15,
@@ -201,7 +214,7 @@ const PlotlyChart = ({ data }) => {
           font: {
             family:
               'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
-            color: '#4f5255',
+            color: textSecondary,
           },
         },
         font: {
@@ -214,13 +227,13 @@ const PlotlyChart = ({ data }) => {
       font: {
         family: 'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
         size: 14,
-        color: '#4f5255',
+        color: textSecondary,
       },
       title: {
         font: {
           family:
             'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
-          color: '#4f5255',
+          color: textSecondary,
           size: 15,
         },
       },
@@ -230,7 +243,7 @@ const PlotlyChart = ({ data }) => {
           family:
             'RedHatText, Overpass, overpass, helvetica, arial, sans-serif',
         },
-        bgcolor: '#151515',
+        bgcolor: tooltipBg,
       },
       style: { cursor: 'auto' },
     },

--- a/src/Components/Toolbar/Groups/SettingsPanel.tsx
+++ b/src/Components/Toolbar/Groups/SettingsPanel.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import { AttributeType, SetValues } from '../types';
 
 const OutlinedQuestionCircleIcon = styled(PFOutlinedQuestionCircleIcon)`
-  color: #151515;
+  color: var(--pf-t--global--text--color--100);
 `;
 
 const PopoverButton = styled(Button)`
@@ -47,7 +47,9 @@ const SettingsPanel: FunctionComponent<Props> = ({
   ariaLabel,
   bodyContent,
 }) => (
-  <Card style={{ backgroundColor: '#EEEEEE' }}>
+  <Card
+    style={{ backgroundColor: 'var(--pf-t--global--background--color--200)' }}
+  >
     <CardHeader
       actions={{
         actions: (

--- a/src/Containers/OrganizationStatistics/OrganizationStatistics.js
+++ b/src/Containers/OrganizationStatistics/OrganizationStatistics.js
@@ -43,6 +43,11 @@ import reportPaths from '../Reports/paths';
 
 const Divider = styled('hr')`
   border: 1px solid #ebebeb;
+
+  .pf-v6-theme-dark &,
+  .pf-theme-dark & {
+    border-color: var(--pf-t--global--border--color--100);
+  }
 `;
 
 const colorFunc = scaleOrdinal(pfmulti);

--- a/src/Containers/Reports/List/List.tsx
+++ b/src/Containers/Reports/List/List.tsx
@@ -189,7 +189,10 @@ const List: FunctionComponent<Record<string, never>> = () => {
                                     icon={<CaretDownIcon />}
                                     id='report_list'
                                     data-cy={'selected_report_dropdown'}
-                                    style={{ color: '#151515' }}
+                                    style={{
+                                      color:
+                                        'var(--pf-t--global--text--color--100)',
+                                    }}
                                   >
                                     {report.name}
                                   </MenuToggle>

--- a/src/Containers/Reports/List/ListItem/index.tsx
+++ b/src/Containers/Reports/List/ListItem/index.tsx
@@ -17,7 +17,7 @@ import paths from '../../paths';
 const Small = styled.small`
   display: block;
   margin-bottom: 10px;
-  color: #6a6e73;
+  color: inherit;
   white-space: pre-line;
 `;
 

--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/TotalSavings/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/TotalSavings/index.tsx
@@ -25,7 +25,7 @@ const TotalSavings: FunctionComponent<Props> = ({
         style={{
           color: isMoney
             ? 'var(--pf-t--global--color--status--success--200)'
-            : '#0063CF',
+            : 'var(--pf-t--global--color--status--info--default)',
         }}
       >
         {isMoney ? `${currencyFormatter(value)}` : `${hoursFormatter(value)}`}

--- a/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
+++ b/src/Containers/SavingsPlanner/Details/StatisticsTab/index.tsx
@@ -89,17 +89,17 @@ const getChartData = (data: Data): ApiReturnType => {
 const constants = (isMoney: boolean) => ({
   cost: {
     key: isMoney ? 'total_costs' : 'total_hours_spent_risk_adjusted',
-    color: '#8B8D8F',
+    color: 'var(--pf-t--global--text--color--200)',
   },
   benefit: {
     key: isMoney ? 'total_benefits' : 'total_hours_saved',
     color: isMoney
       ? 'var(--pf-t--global--color--status--success--default)'
-      : '#0063CF',
+      : 'var(--pf-t--global--color--status--info--default)',
   },
   net: {
     key: isMoney ? 'cumulative_net_benefits' : 'cumulative_time_net_benefits',
-    color: '#EE7A00',
+    color: 'var(--pf-t--global--color--status--warning--default)',
   },
 });
 
@@ -172,7 +172,7 @@ const StatisticsTab: FunctionComponent<Props> = ({ tabsArray, plan }) => {
         label: isMoney ? 'Money Saved' : 'Hours Saved',
         tickFormat: 'formatNumberAsK',
         style: {
-          grid: { stroke: '#D2D2D2' },
+          grid: { stroke: 'var(--pf-t--global--border--color--100)' },
           axisLabel: { padding: 60 },
         },
       },

--- a/src/Containers/SavingsPlanner/List/ListItem/index.js
+++ b/src/Containers/SavingsPlanner/List/ListItem/index.js
@@ -38,7 +38,7 @@ const CardLabel = styled.span`
 const Small = styled.small`
   display: block;
   margin-bottom: 10px;
-  color: #6a6e73;
+  color: inherit;
 `;
 
 const SCheckbox = styled(Checkbox)`

--- a/src/framework/PageFramework.css
+++ b/src/framework/PageFramework.css
@@ -12,20 +12,20 @@
 
 :root:where(.pf-v6-theme-dark) .dark-0,
 :root:where(.pf-theme-dark) .dark-0 {
-  background-color: var(--pf-t--global--background--color--200);
+  background-color: var(--pf-t--global--dark--background--color--100);
 }
 
 :root:where(.pf-v6-theme-dark) .dark-1,
 :root:where(.pf-theme-dark) .dark-1 {
-  background-color: var(--pf-t--global--background--color--100);
+  background-color: var(--pf-t--global--dark--background--color--100);
 }
 
 :root:where(.pf-v6-theme-dark) .dark-2,
 :root:where(.pf-theme-dark) .dark-2 {
-  background-color: var(--pf-t--global--background--color--300);
+  background-color: var(--pf-t--global--dark--background--color--200);
 }
 
 :root:where(.pf-v6-theme-dark) .dark-3,
 :root:where(.pf-theme-dark) .dark-3 {
-  background-color: var(--pf-t--global--background--color--400);
+  background-color: var(--pf-t--global--dark--background--color--300);
 }

--- a/src/framework/PageFramework.css
+++ b/src/framework/PageFramework.css
@@ -10,18 +10,22 @@
   background-color: var(--pf-t--global--background--color--100);
 }
 
+:root:where(.pf-v6-theme-dark) .dark-0,
 :root:where(.pf-theme-dark) .dark-0 {
   background-color: var(--pf-t--global--background--color--200);
 }
 
+:root:where(.pf-v6-theme-dark) .dark-1,
 :root:where(.pf-theme-dark) .dark-1 {
   background-color: var(--pf-t--global--background--color--100);
 }
 
+:root:where(.pf-v6-theme-dark) .dark-2,
 :root:where(.pf-theme-dark) .dark-2 {
   background-color: var(--pf-t--global--background--color--300);
 }
 
+:root:where(.pf-v6-theme-dark) .dark-3,
 :root:where(.pf-theme-dark) .dark-3 {
   background-color: var(--pf-t--global--background--color--400);
 }

--- a/src/framework/PageTable/PageTable.tsx
+++ b/src/framework/PageTable/PageTable.tsx
@@ -486,16 +486,13 @@ function TableHead<T extends object>(props: {
 
   return (
     <Thead>
-      <Tr className='light dark-2'>
-        {expandedRow && (
-          <Th style={{ padding: 0, backgroundColor: 'inherit' }} />
-        )}
+      <Tr>
+        {expandedRow && <Th style={{ padding: 0 }} />}
         {(showSelect || onSelect) && (
           <Th
             isStickyColumn
             stickyMinWidth='0px'
             hasRightBorder={props.scrollLeft}
-            style={{ backgroundColor: 'inherit' }}
           >
             &nbsp;
           </Th>
@@ -516,7 +513,6 @@ function TableHead<T extends object>(props: {
                         : undefined,
                   maxWidth:
                     column.maxWidth !== undefined ? column.maxWidth : undefined,
-                  backgroundColor: 'inherit',
                 }}
               >
                 {column.header}
@@ -532,7 +528,6 @@ function TableHead<T extends object>(props: {
               right: 0,
               padding: 0,
               paddingRight: 0,
-              backgroundColor: 'inherit',
               zIndex: 302,
             }}
             className={props.scrollRight ? 'pf-m-border-left' : undefined}

--- a/src/framework/components/Scrollable.tsx
+++ b/src/framework/components/Scrollable.tsx
@@ -8,6 +8,12 @@ import React, {
   useState,
 } from 'react';
 
+function isDarkTheme(): boolean {
+  if (typeof document === 'undefined') return false;
+  const cl = document.documentElement.classList;
+  return cl.contains('pf-v6-theme-dark') || cl.contains('pf-theme-dark');
+}
+
 export function Scrollable(props: {
   children?: ReactNode;
   borderTop?: boolean;
@@ -33,20 +39,21 @@ export function Scrollable(props: {
   useResizeObserver(divEl, () => {
     update();
   });
-  const shadowOpacityTop = 0.2 * topShadow;
-  const shadowOpacityBottom = 0.2 * bottomShadow;
-  // const [theme] = useTheme()
-  // if (theme === ThemeE.Dark) {
-  //     shadowOpacityTop *= 6
-  //     shadowOpacityBottom *= 6
-  // }
+
+  const dark = isDarkTheme();
+  const shadowBase = dark ? '255,255,255' : '0,0,0';
+  const shadowMultiplier = dark ? 6 : 1;
+  const shadowOpacityTop = 0.2 * topShadow * shadowMultiplier;
+  const shadowOpacityBottom = 0.2 * bottomShadow * shadowMultiplier;
 
   /* istanbul ignore next */
-  const borderTop = props.borderTop ? 'thin solid rgba(0, 0, 0, 0.12)' : '';
+  const borderTop = props.borderTop
+    ? `thin solid ${dark ? 'var(--pf-t--global--border--color--100)' : 'rgba(0, 0, 0, 0.12)'}`
+    : '';
 
   /* istanbul ignore next */
   const borderBottom = props.borderBottom
-    ? 'thin solid rgba(0, 0, 0, 0.12)'
+    ? `thin solid ${dark ? 'var(--pf-t--global--border--color--100)' : 'rgba(0, 0, 0, 0.12)'}`
     : '';
 
   return (
@@ -82,7 +89,7 @@ export function Scrollable(props: {
               top: 0,
               height: '10px',
               width: '100%',
-              background: `linear-gradient(rgba(0,0,0,${shadowOpacityTop}), rgba(0,0,0,0))`,
+              background: `linear-gradient(rgba(${shadowBase},${shadowOpacityTop}), rgba(${shadowBase},0))`,
             }}
           />
         )
@@ -95,7 +102,7 @@ export function Scrollable(props: {
               bottom: 0,
               height: '10px',
               width: '100%',
-              background: `linear-gradient(rgba(0,0,0,0), rgba(0,0,0,${shadowOpacityBottom}))`,
+              background: `linear-gradient(rgba(${shadowBase},0), rgba(${shadowBase},${shadowOpacityBottom}))`,
             }}
           />
         )


### PR DESCRIPTION
## What

Replace all hardcoded colors across D3 charts, Plotly charts, styled components, and inline styles with PatternFly design tokens or theme-aware helpers so the UI renders correctly in both light and dark themes. This touches 20 files — 2 new utility files and 18 modified source files.

## Why

The app uses PatternFly 6 which supports dark mode via the `pf-v6-theme-dark` class on `<html>`. However, ~18 files contained hardcoded hex colors (`#ffffff`, `#151515`, `#d7d7d7`, `#393f44`, etc.), named colors (`white`, `black`), and `rgba()` values that don't adapt when dark mode is activated. This makes charts unreadable, tooltips invisible, and UI panels broken in dark mode.

Two additional issues were found during implementation:
- The existing dark mode CSS selectors in `PageFramework.css` used `pf-theme-dark` (PF5 class) — PF6 uses `pf-v6-theme-dark`
- D3 SVG text elements default to `fill: black` and need CSS-based theming since they render before the dark theme class is applied

## Changes

| Category | Files | Change |
|----------|-------|--------|
| New utilities | `chartTheme.ts`, `chartDarkMode.css` | JS helpers for D3/Plotly runtime colors + CSS for SVG text dark mode |
| D3 charts (7) | `LineChart`, `BarChart`, `PieChart`, `GroupedBarChart`, `Tooltip`, `HostsTooltip`, `OrgsTooltip` | Hardcoded grid/tooltip/scale colors → PF tokens |
| Plotly chart | `PlotlyChart.js` | 20+ hardcoded colors (white bg, black text, gray grids) → PF tokens |
| UI components (5) | `SettingsPanel`, `ListItem` x2, `List`, `OrganizationStatistics` | Hardcoded text/bg/border colors → PF var() tokens |
| Framework (2) | `PageFramework.css`, `Scrollable.tsx` | pf-v6-theme-dark selectors, shadow/border dark mode |
| SavingsPlanner (2) | `StatisticsTab`, `TotalSavings` | Hardcoded chart colors → PF status/info tokens |

## Test plan

- [ ] Run `npm run start:prod` and verify light mode renders identically to before
- [ ] Toggle dark mode from the settings menu
- [ ] Verify D3 chart axis labels, tick text, grid lines, and tooltips adapt to dark background
- [ ] Verify Plotly chart backgrounds, text, and grids adapt
- [ ] Verify SettingsPanel, ListItems, and OrganizationStatistics borders/text adapt
- [ ] Verify SavingsPlanner statistics chart colors and grid adapt
- [ ] Verify Scrollable component borders and shadows are visible in dark mode
- [ ] npm run build passes with no new warnings

Assisted-by: Claude Code / Opus 4.6 (Anthropic)