### PR TITLE
[AAP-72929] Overrides follow-redirects to resolve CVE-2026-40895

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11133,9 +11133,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "appname": "automation-analytics"
   },
   "overrides": {
-    "axios": "1.15.0"
+    "axios": "1.15.0",
+    "follow-redirects": ">=1.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `follow-redirects >= 1.16.0` override to `package.json` to resolve CVE-2026-40895
- CVE-2026-40895: custom auth headers (X-API-Key, X-Auth-Token) leaked to cross-domain redirect targets in follow-redirects < 1.16.0
- Risk level is Low (transitive dev dependency only, not imported in source), but Red Hat rates the CVE as Important (CVSS 7.5)

## Test plan
- [x] Verify `npm list follow-redirects` shows 1.16.0 for all instances
- [x] Verify `npm install` completes without errors
- [x] Verify `npm run build` succeeds
- [x] Verify dev proxy (`npm start`) works correctly

Assisted-by: Claude Code / Opus 4.6 (Anthropic)