### PR TITLE
AAP-73557: Fix cryptographically weak PRNG in report token generation

### DIFF
--- a/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/SendEmail.tsx
+++ b/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/SendEmail.tsx
@@ -15,7 +15,23 @@ interface Props {
   pdfPostBody: PDFEmailParams;
 }
 
-const generateToken = () => Math.random().toString(36).substring(2, 16);
+const generateToken = (): string => {
+  // Use cryptographically secure random number generator
+  // Generate 14 random bytes (which will give us more than enough entropy for 14 characters)
+  const array = new Uint8Array(14);
+  crypto.getRandomValues(array);
+
+  // Convert to base36 string similar to original format
+  // Use a deterministic conversion to maintain compatibility
+  let token = '';
+  for (let i = 0; i < array.length; i++) {
+    // Convert each byte to base36 and append
+    token += array[i].toString(36);
+  }
+
+  // Return first 14 characters to match original length
+  return token.substring(0, 14);
+};
 
 const parseUrl = (
   emailExtraRows: boolean,

--- a/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/SendEmail.tsx
+++ b/src/Components/Toolbar/DownloadButton/Steps/EmailDetails/SendEmail.tsx
@@ -17,20 +17,10 @@ interface Props {
 
 const generateToken = (): string => {
   // Use cryptographically secure random number generator
-  // Generate 14 random bytes (which will give us more than enough entropy for 14 characters)
   const array = new Uint8Array(14);
   crypto.getRandomValues(array);
-
-  // Convert to base36 string similar to original format
-  // Use a deterministic conversion to maintain compatibility
-  let token = '';
-  for (let i = 0; i < array.length; i++) {
-    // Convert each byte to base36 and append
-    token += array[i].toString(36);
-  }
-
-  // Return first 14 characters to match original length
-  return token.substring(0, 14);
+  // Convert bytes to base36 characters
+  return Array.from(array, (b) => (b % 36).toString(36)).join('');
 };
 
 const parseUrl = (


### PR DESCRIPTION
## Summary
Fixes a security vulnerability in the email report token generation by replacing the cryptographically weak `Math.random()` with the cryptographically secure `crypto.getRandomValues()`.

## Issue
**[AAP-73557](https://redhat.atlassian.net/browse/AAP-73557)**: F-04 Use of Cryptographically Weak PRNG in Report Token Generation

## Problem
The "Email Report" functionality generates shareable links that grant access to sensitive PDF reports. These links use tokens passed as query parameters for authorization. The previous implementation used `Math.random()`, which is:
- A non-cryptographic Pseudo-Random Number Generator (PRNG)
- Mathematically susceptible to state reconstruction
- Vulnerable to token enumeration attacks through statistical analysis

## Solution
Replaced `Math.random()` with `crypto.getRandomValues()`, which:
- Uses a cryptographically secure random number generator (CSPRNG)
- Provides unpredictable random values suitable for security-sensitive operations
- Prevents token prediction and enumeration attacks

## Changes
- **File**: `src/Components/Toolbar/DownloadButton/Steps/EmailDetails/SendEmail.tsx`
- Replaced `Math.random().toString(36).substring(2, 16)` with `crypto.getRandomValues()`
- Maintained the same token format (14-character base36 string) for backward compatibility
- Added TypeScript return type annotation
- Added documentation comments explaining the security improvement

## Testing
- ✅ Linting passes for modified file
- ✅ Prettier formatting verified
- ✅ TypeScript compilation checked
- ✅ No breaking changes to API or behavior

## Security Impact
This change addresses:
- **CWE-331**: Insufficient Entropy
- **CWE-338**: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)

## References
- [CWE-331: Insufficient Entropy](https://cwe.mitre.org/data/definitions/331.html)
- [CWE-338: Use of Cryptographically Weak PRNG](https://cwe.mitre.org/data/definitions/338.html)
- [MDN: Crypto.getRandomValues()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAP-73557]: https://redhat.atlassian.net/browse/AAP-73557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ