### PR TITLE
[AAP-80502] Override sanitize-html to resolve CVE-2026-44990

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9103,7 +9103,6 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debounce-promise": {
@@ -14297,6 +14296,15 @@
         "shell-quote": "^1.8.3"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -17870,15 +17878,16 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
-      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }
@@ -17895,6 +17904,18 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/sanitize-html/node_modules/domhandler": {
@@ -17927,9 +17948,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -17939,9 +17960,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -17953,8 +17974,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/sass": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "overrides": {
     "axios": "1.16.1",
-    "follow-redirects": ">=1.16.0"
+    "follow-redirects": ">=1.16.0",
+    "sanitize-html": ">=2.17.4"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `sanitize-html >= 2.17.4` override to `package.json` to resolve CVE-2026-44990
- CVE-2026-44990: Stored Cross-Site Scripting via HTML sanitizer bypass in `sanitize-html` < 2.17.4. Attacker-controlled content inside a disallowed `xmp` element can be turned into live HTML or JavaScript under the default `disallowedTagsMode: 'discard'` path.
- `sanitize-html` is a transitive dependency via `@redhat-cloud-services/frontend-components` (was pinned at 2.17.1, now overridden to 2.17.5)

## Test plan
- [x] Verify `npm ls sanitize-html` shows >= 2.17.4 for all instances
- [x] Verify `npm install` completes without errors
- [x] Verify `npm run build` succeeds

Assisted-by: Claude Code