### PR TITLE
[AAP-81106] fix(deps): override decode-uri-component to 0.5.0 for CVE-2026-45822

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9129,9 +9129,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
   "overrides": {
     "axios": "1.16.1",
     "follow-redirects": ">=1.16.0",
+    "query-string": {
+      "decode-uri-component": "0.5.0"
+    },
     "sanitize-html": ">=2.17.4"
   }
 }


### PR DESCRIPTION
## What

Adds a scoped npm override for `decode-uri-component` to force version `0.5.0`, resolving CVE-2026-45822.

## Why

`decode-uri-component` through 0.4.1 is vulnerable to denial of service via super-linear parsing time on crafted percent-encoded input (CVSS 7.5, AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H).

The package is a transitive production dependency pulled in by `query-string`, which is directly used in:
- `src/QueryParams/helpers.ts` — parses URL query parameters
- `src/Api/methods.ts` — constructs API query strings

### CVE Details

| Field | Value |
|---|---|
| CVE ID | CVE-2026-45822 |
| Affected Package | `decode-uri-component` |
| Affected Versions | through 0.4.1 |
| Fixed Version | 0.5.0 |
| CVSS Score | 7.5 (High) |
| Red Hat Severity | Important |
| Dependency Chain | `query-string` → `decode-uri-component` |

### Root Cause

The `decode()` function splits input on `%` producing N tokens and calls `decodeComponents()`, exhibiting super-linear parsing time. An attacker can cause significant CPU consumption and event-loop blocking via crafted input.

## Changes

- Added scoped npm override in `package.json`: `query-string` → `decode-uri-component@0.5.0`
- Updated `package-lock.json` to resolve `decode-uri-component@0.5.0`

## Test Plan

- [x] `npm audit` no longer reports CVE-2026-45822
- [x] `npm list decode-uri-component` shows version 0.5.0
- [x] `npm run lint` passes
- [x] `npm run build` passes

Jira: AAP-81106
Assisted-by: Claude Code / Opus 4.6 (Anthropic)

Made with [Cursor](https://cursor.com)