### PR TITLE
feat(calculator): add default manual time input to Automation Calculator

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -136,6 +136,28 @@ describe('Automation Calculator page', () => {
     });
   });
 
+  it('can change default manual effort', () => {
+    // Skip test if no data available
+    cy.get('body').then(($body) => {
+      if ($body.find('.pf-v6-c-empty-state__content').length > 0) {
+        cy.log('Empty state found - skipping default manual effort test');
+        return;
+      }
+
+      cy.get('#default-manual-effort').clear();
+      waitToLoad();
+      cy.get('#default-manual-effort').should('have.value', '0');
+
+      cy.get('#default-manual-effort').type('60');
+      waitToLoad();
+      cy.get('#default-manual-effort')
+        .invoke('val')
+        .then((val) => {
+          expect(Number(val)).to.be.greaterThan(0);
+        });
+    });
+  });
+
   it('can change visibility', () => {
     let originalTotalSavingsValue = cy
       .getByCy('total_savings')

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -70,6 +70,7 @@ export interface saveROIParams {
   currency: string;
   hourly_manual_labor_cost: number;
   hourly_automation_cost: number;
+  default_manual_effort_minutes?: number;
   templates_manual_equivalent: {
     template_id: number;
     effort_minutes: number;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -181,7 +181,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       currency: 'USD',
       hourly_manual_labor_cost: manualCost,
       hourly_automation_cost: automationCost,
-      default_manual_effort_minutes: manualEffort,
+      ...(typeof manualEffort === 'number' && !isNaN(manualEffort)
+        ? { default_manual_effort_minutes: manualEffort }
+        : {}),
       templates_manual_equivalent: updatedDataApi,
     };
   };
@@ -200,20 +202,19 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   };
 
   const updateCalculationValues = async (varName: string, value: number) => {
+    if (isNaN(value)) return;
     const hourly_automation_cost =
       varName === 'automation_cost' ? value : costAutomation;
     const hourly_manual_labor_cost =
       varName === 'manual_cost' ? value : costManual;
     const manual_effort =
-      varName === 'default_manual_effort_minutes'
-        ? value
-        : defaultManualEffort;
+      varName === 'default_manual_effort_minutes' ? value : defaultManualEffort;
     const humanVarNames: Record<string, string> = {
       automation_cost: 'Automation cost',
       manual_cost: 'Manual cost',
       default_manual_effort_minutes: 'Default manual time',
     };
-    const humanVarName = humanVarNames[varName] || varName;
+    const humanVarName = humanVarNames[varName];
     try {
       await saveROI(
         getROISaveData(
@@ -333,7 +334,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       setCostManual(api.result.cost.hourly_manual_labor_cost);
       setCostAutomation(api.result.cost.hourly_automation_cost);
       setDefaultManualEffort(
-        api.result.cost.default_manual_effort_minutes ?? ''
+        api.result.cost.default_manual_effort_minutes ?? '',
       );
     }
   }, [api]);

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -99,6 +99,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   const [costAutomation, setCostAutomation] = useState<
     number | string | undefined
   >('');
+  const [defaultManualEffort, setDefaultManualEffort] = useState<
+    number | string | undefined
+  >('');
   const [isMoney, setIsMoney] = useState(true);
   const { queryParams, setFromToolbar, setFromPagination } =
     useQueryParams(defaultParams);
@@ -167,6 +170,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     items: any[],
     manualCost = costManual,
     automationCost = costAutomation,
+    manualEffort = defaultManualEffort,
   ) => {
     const updatedDataApi = items.map((el) => ({
       template_id: el.id,
@@ -177,6 +181,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       currency: 'USD',
       hourly_manual_labor_cost: manualCost,
       hourly_automation_cost: automationCost,
+      default_manual_effort_minutes: manualEffort,
       templates_manual_equivalent: updatedDataApi,
     };
   };
@@ -199,31 +204,41 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       varName === 'automation_cost' ? value : costAutomation;
     const hourly_manual_labor_cost =
       varName === 'manual_cost' ? value : costManual;
-    const humanVarName =
-      varName === 'automation_cost' ? 'Automation cost' : 'Manual cost';
+    const manual_effort =
+      varName === 'default_manual_effort_minutes'
+        ? value
+        : defaultManualEffort;
+    const humanVarNames: Record<string, string> = {
+      automation_cost: 'Automation cost',
+      manual_cost: 'Manual cost',
+      default_manual_effort_minutes: 'Default manual time',
+    };
+    const humanVarName = humanVarNames[varName] || varName;
     try {
       await saveROI(
         getROISaveData(
           api.result.items,
           hourly_manual_labor_cost,
           hourly_automation_cost,
+          manual_effort,
         ) as any,
       );
     } catch {
       addNotification({
         title: `Unable to save changes to ${humanVarName}.`,
-        description: `Unable to save changes ${humanVarName}. Please try again.`,
+        description: `Unable to save changes to ${humanVarName}. Please try again.`,
         variant: 'danger',
         dismissable: true,
       });
-      // don't update inputs
       return;
     }
     await update();
     if (varName === 'manual_cost') {
       setCostManual(value);
-    } else {
+    } else if (varName === 'automation_cost') {
       setCostAutomation(value);
+    } else if (varName === 'default_manual_effort_minutes') {
+      setDefaultManualEffort(value);
     }
   };
 
@@ -317,6 +332,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     if (api.result?.cost && !costAutomation && !costManual) {
       setCostManual(api.result.cost.hourly_manual_labor_cost);
       setCostAutomation(api.result.cost.hourly_automation_cost);
+      setDefaultManualEffort(
+        api.result.cost.default_manual_effort_minutes ?? ''
+      );
     }
   }, [api]);
 
@@ -496,6 +514,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
               costManual={costManual as any}
               setFromCalculation={updateCalculationValues}
               costAutomation={costAutomation as any}
+              defaultManualEffort={defaultManualEffort as any}
               readOnly={isReadOnly(api)}
             />
           </StackItem>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -4,6 +4,7 @@ import { InputGroup } from '@patternfly/react-core/dist/dynamic/components/Input
 import { InputGroupText } from '@patternfly/react-core/dist/dynamic/components/InputGroup';
 import { TextInput } from '@patternfly/react-core/dist/dynamic/components/TextInput';
 import DollarSignIcon from '@patternfly/react-icons/dist/dynamic/icons/dollar-sign-icon';
+import OutlinedClockIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined-clock-icon';
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
@@ -14,10 +15,16 @@ const WInputGroup = styled(InputGroup)`
 const validFloat = (value: number): number =>
   +value && +value < 0 ? NaN : value;
 
+const validPositiveInt = (value: number): number =>
+  !Number.isFinite(value) || value < 0 || !Number.isInteger(value)
+    ? NaN
+    : value;
+
 interface Props {
   costManual: number;
   setFromCalculation: (varName: string, value: number) => void;
   costAutomation: number;
+  defaultManualEffort: number;
   readOnly: boolean;
 }
 
@@ -25,6 +32,7 @@ const CalculationCost: FunctionComponent<Props> = ({
   costManual = 0,
   setFromCalculation = () => ({}),
   costAutomation = 0,
+  defaultManualEffort = 0,
   readOnly = true,
 }) => (
   <Card isPlain isCompact>
@@ -75,6 +83,31 @@ const CalculationCost: FunctionComponent<Props> = ({
           isDisabled={readOnly}
         />
         <InputGroupText>/hr</InputGroupText>
+      </WInputGroup>
+      <p style={{ paddingTop: '10px' }}>
+        Default manual time per template
+      </p>
+      <WInputGroup>
+        <InputGroupText>
+          <OutlinedClockIcon />
+        </InputGroupText>
+        <TextInput
+          id='default-manual-effort'
+          key='default-manual-effort'
+          type='number'
+          aria-label='default-manual-effort'
+          value={
+            isNaN(defaultManualEffort) ? '' : defaultManualEffort.toString()
+          }
+          onChange={(_event, value) =>
+            setFromCalculation(
+              'default_manual_effort_minutes',
+              validPositiveInt(+value)
+            )
+          }
+          isDisabled={readOnly}
+        />
+        <InputGroupText>min</InputGroupText>
       </WInputGroup>
     </CardBody>
   </Card>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -15,8 +15,13 @@ const WInputGroup = styled(InputGroup)`
 const validFloat = (value: number): number =>
   +value && +value < 0 ? NaN : value;
 
-const validPositiveInt = (value: number): number =>
-  !Number.isFinite(value) || value < 0 || !Number.isInteger(value)
+const MAX_PG_INT = 2147483646;
+
+const validNonNegativeInt = (value: number): number =>
+  !Number.isFinite(value) ||
+  value < 0 ||
+  !Number.isInteger(value) ||
+  value > MAX_PG_INT
     ? NaN
     : value;
 
@@ -85,7 +90,7 @@ const CalculationCost: FunctionComponent<Props> = ({
         <InputGroupText>/hr</InputGroupText>
       </WInputGroup>
       <p style={{ paddingTop: '10px' }}>
-        Default manual time per template
+        Default manual time per template (minutes)
       </p>
       <WInputGroup>
         <InputGroupText>
@@ -102,7 +107,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           onChange={(_event, value) =>
             setFromCalculation(
               'default_manual_effort_minutes',
-              validPositiveInt(+value)
+              validNonNegativeInt(+value),
             )
           }
           isDisabled={readOnly}


### PR DESCRIPTION
[AAP-84046] Add "Default manual time per template (minutes)" input alongside existing Manual cost / Automation cost inputs. 

Saves via existing roi_cost_effort_data endpoint with new default_manual_effort_minutes field. Positive integer validation, RBAC-controlled editability.

[AAP-84046]: https://redhat.atlassian.net/browse/AAP-84046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ