### PR TITLE
AAP-84047 - feat(frontend): add apply default to all unreviewed button with confirmation

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -324,6 +324,69 @@ describe('Automation Calculator page', () => {
     }
   });
 
+  it('applies default manual time to unreviewed templates on confirm', () => {
+    cy.intercept('POST', '**/roi_templates_apply_default/', {
+      updated_count: 3,
+    }).as('applyDefault');
+
+    cy.get('body').then(($body) => {
+      if ($body.find('.pf-v6-c-empty-state__content').length > 0) {
+        cy.log('Empty state found - skipping apply default test');
+        return;
+      }
+
+      cy.getByCy('apply_default_button').then(($button) => {
+        if ($button.is(':disabled')) {
+          cy.log(
+            'Apply default button disabled (no unreviewed templates) - skipping',
+          );
+          return;
+        }
+
+        cy.wrap($button).click();
+        cy.getByCy('apply_default_modal').should('exist');
+
+        cy.getByCy('apply_default_confirm_button').click();
+        cy.wait('@applyDefault');
+        waitToLoad();
+
+        cy.getByCy('apply_default_modal').should('not.exist');
+        cy.contains('Default manual time applied to 3 templates.').should(
+          'exist',
+        );
+      });
+    });
+  });
+
+  it('cancels apply default without calling the endpoint', () => {
+    cy.intercept('POST', '**/roi_templates_apply_default/', {
+      updated_count: 3,
+    }).as('applyDefault');
+
+    cy.get('body').then(($body) => {
+      if ($body.find('.pf-v6-c-empty-state__content').length > 0) {
+        cy.log('Empty state found - skipping apply default cancel test');
+        return;
+      }
+
+      cy.getByCy('apply_default_button').then(($button) => {
+        if ($button.is(':disabled')) {
+          cy.log(
+            'Apply default button disabled (no unreviewed templates) - skipping',
+          );
+          return;
+        }
+
+        cy.wrap($button).click();
+        cy.getByCy('apply_default_modal').should('exist');
+
+        cy.getByCy('apply_default_cancel_button').click();
+        cy.getByCy('apply_default_modal').should('not.exist');
+        cy.get('@applyDefault.all').should('have.length', 0);
+      });
+    });
+  });
+
   it('shows Automation formula', () => {
     cy.getByCy('automation_formula_button').click();
     cy.getByCy('automation_formula_modal').should('exist');

--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -5,6 +5,52 @@ const waitToLoad = () => {
   cy.wait('@roiTemplates');
 };
 
+// Deterministic roi_templates payload: one unreviewed-looking template, write
+// RBAC, so the apply-default button renders enabled regardless of live data.
+const ROI_TEMPLATES_STUB = {
+  meta: {
+    count: 1,
+    legend: [
+      {
+        id: 1,
+        name: 'Stubbed Template',
+        manual_effort_minutes: 30,
+        template_weigh_in: true,
+        successful_hosts_total: 5,
+        successful_hosts_savings: 100,
+        successful_hosts_saved_hours: 2,
+        monetary_gain: 50,
+        elapsed: 120,
+        host_count: 5,
+        total_count: 5,
+        total_org_count: 1,
+        total_cluster_count: 1,
+        total_inventory_count: 1,
+        template_success_rate: 90,
+        failed_hosts_costs: 0,
+      },
+    ],
+  },
+  cost: {
+    hourly_manual_labor_cost: 50,
+    hourly_automation_cost: 20,
+    default_manual_effort_minutes: 30,
+  },
+  rbac: { perms: { all: false, write: true } },
+};
+
+// Re-visits the page with a stubbed roi_templates response so the apply
+// default button is deterministically enabled, instead of depending on
+// whatever unreviewed templates happen to exist in the live/seed backend.
+const visitWithStubbedTemplates = () => {
+  cy.intercept(
+    '/api/tower-analytics/v1/roi_templates/*',
+    ROI_TEMPLATES_STUB,
+  ).as('roiTemplatesStub');
+  cy.visit(calculatorUrl);
+  cy.wait('@roiTemplatesStub');
+};
+
 describe('Automation Calculator page', () => {
   beforeEach(() => {
     cy.visit(calculatorUrl);
@@ -329,33 +375,23 @@ describe('Automation Calculator page', () => {
       updated_count: 3,
     }).as('applyDefault');
 
-    cy.get('body').then(($body) => {
-      if ($body.find('.pf-v6-c-empty-state__content').length > 0) {
-        cy.log('Empty state found - skipping apply default test');
-        return;
-      }
+    visitWithStubbedTemplates();
 
-      cy.getByCy('apply_default_button').then(($button) => {
-        if ($button.is(':disabled')) {
-          cy.log(
-            'Apply default button disabled (no unreviewed templates) - skipping',
-          );
-          return;
-        }
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_modal').should('exist');
+    // Modal no longer promises a specific pre-count (backend, not the
+    // paginated client, is the source of truth for how many get updated).
+    cy.getByCy('apply_default_modal').should(
+      'contain.text',
+      "This will set 30 minutes as the manual time for all templates you haven't individually reviewed.",
+    );
 
-        cy.wrap($button).click();
-        cy.getByCy('apply_default_modal').should('exist');
+    cy.getByCy('apply_default_confirm_button').click();
+    cy.wait('@applyDefault').its('request.body').should('deep.equal', {});
+    waitToLoad();
 
-        cy.getByCy('apply_default_confirm_button').click();
-        cy.wait('@applyDefault');
-        waitToLoad();
-
-        cy.getByCy('apply_default_modal').should('not.exist');
-        cy.contains('Default manual time applied to 3 templates.').should(
-          'exist',
-        );
-      });
-    });
+    cy.getByCy('apply_default_modal').should('not.exist');
+    cy.contains('Default manual time applied to 3 templates.').should('exist');
   });
 
   it('cancels apply default without calling the endpoint', () => {
@@ -363,28 +399,55 @@ describe('Automation Calculator page', () => {
       updated_count: 3,
     }).as('applyDefault');
 
-    cy.get('body').then(($body) => {
-      if ($body.find('.pf-v6-c-empty-state__content').length > 0) {
-        cy.log('Empty state found - skipping apply default cancel test');
-        return;
-      }
+    visitWithStubbedTemplates();
 
-      cy.getByCy('apply_default_button').then(($button) => {
-        if ($button.is(':disabled')) {
-          cy.log(
-            'Apply default button disabled (no unreviewed templates) - skipping',
-          );
-          return;
-        }
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_modal').should('exist');
 
-        cy.wrap($button).click();
-        cy.getByCy('apply_default_modal').should('exist');
+    cy.getByCy('apply_default_cancel_button').click();
+    cy.getByCy('apply_default_modal').should('not.exist');
+    cy.get('@applyDefault.all').should('have.length', 0);
+  });
 
-        cy.getByCy('apply_default_cancel_button').click();
-        cy.getByCy('apply_default_modal').should('not.exist');
-        cy.get('@applyDefault.all').should('have.length', 0);
-      });
-    });
+  it('shows an error notification and keeps state usable when apply default fails', () => {
+    cy.intercept('POST', '**/roi_templates_apply_default/', {
+      statusCode: 500,
+      body: { error: 'boom' },
+    }).as('applyDefaultFailure');
+
+    visitWithStubbedTemplates();
+
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_modal').should('exist');
+
+    cy.getByCy('apply_default_confirm_button').click();
+    cy.wait('@applyDefaultFailure');
+
+    cy.contains('Unable to apply default manual time').should('exist');
+    cy.getByCy('apply_default_modal').should('not.exist');
+    // button remains usable for a retry
+    cy.getByCy('apply_default_button').should('not.be.disabled');
+  });
+
+  it('disables cancel/close while a request is in flight', () => {
+    cy.intercept('POST', '**/roi_templates_apply_default/', {
+      delay: 1000,
+      body: { updated_count: 1 },
+    }).as('applyDefaultSlow');
+
+    visitWithStubbedTemplates();
+
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_confirm_button').click();
+
+    // while the request is in flight, Continue is loading/disabled and
+    // Cancel can't dismiss the modal out from under the pending request
+    cy.getByCy('apply_default_confirm_button').should('be.disabled');
+    cy.getByCy('apply_default_cancel_button').should('be.disabled');
+    cy.getByCy('apply_default_modal').should('exist');
+
+    cy.wait('@applyDefaultSlow');
+    cy.getByCy('apply_default_modal').should('not.exist');
   });
 
   it('shows Automation formula', () => {

--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -1,5 +1,12 @@
 import { ENV, ENVS, calculatorUrl } from '../support/constants';
 
+// This repo has no Jest tooling (no config, no dependency, no script, never
+// existed in history) — every other test here, including the sibling
+// AAP-84050 frontend test story for this epic, is Cypress E2E. Rather than
+// bolt on a second test runner for one PR, the error-handling branches that
+// would otherwise only exist as unit tests (see applyDefaultToAll in
+// AutomationCalculator.tsx) are covered below as Cypress scenarios instead.
+
 const waitToLoad = () => {
   cy.wait('@roiCostEffortData');
   cy.wait('@roiTemplates');
@@ -7,7 +14,11 @@ const waitToLoad = () => {
 
 // Deterministic roi_templates payload: one unreviewed-looking template, write
 // RBAC, so the apply-default button renders enabled regardless of live data.
-const ROI_TEMPLATES_STUB = {
+// `applied` flips the top-level savings figures so a test can assert the
+// *second* fetch (triggered by the post-apply refresh) genuinely reflects
+// new data, instead of a static response that can't prove the refresh
+// actually changed anything.
+const buildRoiTemplatesStub = (applied) => ({
   meta: {
     count: 1,
     legend: [
@@ -37,17 +48,39 @@ const ROI_TEMPLATES_STUB = {
     default_manual_effort_minutes: 30,
   },
   rbac: { perms: { all: false, write: true } },
-};
+  monetary_gain_current_page: applied ? 250 : 100,
+  monetary_gain_other_pages: 0,
+  successful_hosts_saved_hours_current_page: applied ? 5 : 2,
+  successful_hosts_saved_hours_other_pages: 0,
+});
 
 // Re-visits the page with a stubbed roi_templates response so the apply
 // default button is deterministically enabled, instead of depending on
 // whatever unreviewed templates happen to exist in the live/seed backend.
+// Returns a setter the test can call to flip the stub's "applied" state
+// after a successful apply-default POST, so the next refetch differs.
 const visitWithStubbedTemplates = () => {
-  cy.intercept(
-    '/api/tower-analytics/v1/roi_templates/*',
-    ROI_TEMPLATES_STUB,
+  let applied = false;
+  cy.intercept('/api/tower-analytics/v1/roi_templates/*', (req) =>
+    req.reply(buildRoiTemplatesStub(applied)),
   ).as('roiTemplatesStub');
   cy.visit(calculatorUrl);
+  cy.wait('@roiTemplatesStub');
+  return {
+    markApplied: () => {
+      applied = true;
+    },
+  };
+};
+
+// visitWithStubbedTemplates() re-intercepts the same roi_templates route the
+// outer beforeEach already aliased as 'roiTemplates'. Cypress matches the
+// newest-registered intercept first, so 'roiTemplatesStub' shadows
+// 'roiTemplates' for the rest of the test — waiting on '@roiTemplates' here
+// would never match another request and would hang/desync instead of
+// actually waiting for the post-apply refetch.
+const waitForStubbedLoad = () => {
+  cy.wait('@roiCostEffortData');
   cy.wait('@roiTemplatesStub');
 };
 
@@ -371,11 +404,12 @@ describe('Automation Calculator page', () => {
   });
 
   it('applies default manual time to unreviewed templates on confirm', () => {
-    cy.intercept('POST', '**/roi_templates_apply_default/', {
-      updated_count: 3,
-    }).as('applyDefault');
+    const { markApplied } = visitWithStubbedTemplates();
 
-    visitWithStubbedTemplates();
+    cy.intercept('POST', '**/roi_templates_apply_default/', (req) => {
+      markApplied();
+      req.reply({ updated_count: 3 });
+    }).as('applyDefault');
 
     cy.getByCy('apply_default_button').should('not.be.disabled').click();
     cy.getByCy('apply_default_modal').should('exist');
@@ -386,12 +420,27 @@ describe('Automation Calculator page', () => {
       "This will set 30 minutes as the manual time for all templates you haven't individually reviewed.",
     );
 
-    cy.getByCy('apply_default_confirm_button').click();
-    cy.wait('@applyDefault').its('request.body').should('deep.equal', {});
-    waitToLoad();
+    cy.getByCy('current_page_savings')
+      .find('h3')
+      .invoke('text')
+      .then((originalCurrentPageSavings) => {
+        cy.getByCy('apply_default_confirm_button').click();
+        cy.wait('@applyDefault').its('request.body').should('deep.equal', {});
+        waitForStubbedLoad();
 
-    cy.getByCy('apply_default_modal').should('not.exist');
-    cy.contains('Default manual time applied to 3 templates.').should('exist');
+        cy.getByCy('apply_default_modal').should('not.exist');
+        cy.contains('Default manual time applied to 3 templates.').should(
+          'exist',
+        );
+
+        // Genuine before/after diff: the stub returns different savings
+        // figures once `markApplied()` flips, proving the table actually
+        // reflects the post-apply refresh rather than a static response.
+        cy.getByCy('current_page_savings')
+          .find('h3')
+          .invoke('text')
+          .should('not.eq', originalCurrentPageSavings);
+      });
   });
 
   it('cancels apply default without calling the endpoint', () => {
@@ -427,6 +476,55 @@ describe('Automation Calculator page', () => {
     cy.getByCy('apply_default_modal').should('not.exist');
     // button remains usable for a retry
     cy.getByCy('apply_default_button').should('not.be.disabled');
+  });
+
+  it('shows a warning and closes the modal when the refresh after a successful apply fails', () => {
+    // First roi_templates fetch (initial page load) succeeds; the second
+    // (the update() refresh triggered by a successful apply) fails. This is
+    // the regression case for applyDefaultToAll: a refresh failure must not
+    // leave the modal stuck open or surface as an apply failure.
+    let requestCount = 0;
+    cy.intercept('/api/tower-analytics/v1/roi_templates/*', (req) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        req.reply(buildRoiTemplatesStub(false));
+      } else {
+        req.reply({ statusCode: 500, body: { error: 'boom' } });
+      }
+    }).as('roiTemplatesStub');
+    cy.visit(calculatorUrl);
+    cy.wait('@roiTemplatesStub');
+
+    cy.intercept('POST', '**/roi_templates_apply_default/', {
+      updated_count: 2,
+    }).as('applyDefault');
+
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_confirm_button').click();
+    cy.wait('@applyDefault');
+    cy.wait('@roiTemplatesStub'); // the failing refresh request
+
+    cy.getByCy('apply_default_modal').should('not.exist');
+    cy.contains(
+      'Default manual time applied, but the table could not refresh',
+    ).should('exist');
+    // no leftover disabled/loading state from the failed refresh
+    cy.getByCy('apply_default_button').should('not.be.disabled');
+  });
+
+  it('falls back to 0 when the apply response has no updated_count', () => {
+    cy.intercept('POST', '**/roi_templates_apply_default/', {}).as(
+      'applyDefault',
+    );
+
+    visitWithStubbedTemplates();
+
+    cy.getByCy('apply_default_button').should('not.be.disabled').click();
+    cy.getByCy('apply_default_confirm_button').click();
+    cy.wait('@applyDefault');
+    waitForStubbedLoad();
+
+    cy.contains('Default manual time applied to 0 templates.').should('exist');
   });
 
   it('disables cancel/close while a request is in flight', () => {

--- a/src/Api/api.ts
+++ b/src/Api/api.ts
@@ -37,6 +37,7 @@ export enum Endpoint {
   adoptionRate = '/api/tower-analytics/v1/adoption_rate/',
   ROI = '/api/tower-analytics/v1/roi_templates/',
   costEffortROI = '/api/tower-analytics/v1/roi_cost_effort_data/',
+  roiTemplatesApplyDefault = '/api/tower-analytics/v1/roi_templates_apply_default/',
   plans = '/api/tower-analytics/v1/plans/',
   plan = '/api/tower-analytics/v1/plan/',
   sendEmail = 'api/tower-analytics/v1/send_email/',
@@ -167,6 +168,10 @@ export const saveROI = (params: saveROIParams): Promise<ApiJson> => {
 
 export const readROIOptions = (params: Params): Promise<ApiJson> =>
   post(Endpoint.ROIOptions, params);
+
+export const applyDefaultROITemplates = (
+  params: Params = {},
+): Promise<ApiJson> => post(Endpoint.roiTemplatesApplyDefault, params);
 
 export const readHostExplorer = (
   params: ParamsWithPagination,

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -305,11 +305,12 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
 
   const applyDefaultToAll = async () => {
     try {
-      const res = (await applyDefaultROITemplates(queryParams as any)) as {
+      // backend applies to all unreviewed templates tenant-wide; no params needed
+      const res = (await applyDefaultROITemplates()) as {
         updated_count?: number;
       };
-      const count = res.updated_count ?? 0;
-      await update();
+      const count =
+        typeof res.updated_count === 'number' ? res.updated_count : 0;
       addNotification({
         title: `Default manual time applied to ${count} template${
           count === 1 ? '' : 's'
@@ -324,7 +325,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
         variant: 'danger',
         dismissable: true,
       });
+      // apply failed; skip refresh
+      return;
     }
+    // refresh is best-effort: a failure here must not read as an apply failure
+    await update();
   };
 
   const getSortParams = () => {
@@ -445,10 +450,6 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     return !api.result.rbac?.perms?.all && !api.result.rbac?.perms?.write;
   };
 
-  const unreviewedCount = api.result.items.filter(
-    (item) => item.manual_effort_reviewed === false,
-  ).length;
-
   const renderLeft = () => (
     <Card isPlain>
       {fullCard && (
@@ -549,7 +550,6 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
               setFromCalculation={updateCalculationValues}
               costAutomation={costAutomation as any}
               defaultManualEffort={defaultManualEffort as any}
-              unreviewedCount={unreviewedCount}
               onApplyDefault={applyDefaultToAll}
               readOnly={isReadOnly(api)}
             />

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -15,7 +15,11 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import React, { FC, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { endpointFunctionMap, saveROI } from '../../../../Api';
+import {
+  applyDefaultROITemplates,
+  endpointFunctionMap,
+  saveROI,
+} from '../../../../Api';
 import ApiStatusWrapper from '../../../../Components/ApiStatus/ApiStatusWrapper';
 // Chart
 import Chart from '../../../../Components/Chart';
@@ -298,6 +302,31 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     await update();
     setValue(updatedData);
   };
+
+  const applyDefaultToAll = async () => {
+    try {
+      const res = (await applyDefaultROITemplates(queryParams as any)) as {
+        updated_count?: number;
+      };
+      const count = res.updated_count ?? 0;
+      await update();
+      addNotification({
+        title: `Default manual time applied to ${count} template${
+          count === 1 ? '' : 's'
+        }.`,
+        variant: 'success',
+        dismissable: true,
+      });
+    } catch {
+      addNotification({
+        title: 'Unable to apply default manual time',
+        description: 'Unable to apply default manual time. Please try again.',
+        variant: 'danger',
+        dismissable: true,
+      });
+    }
+  };
+
   const getSortParams = () => {
     const onSort = (_event, index, direction) => {
       setFromToolbar('sort_order', direction);
@@ -416,6 +445,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     return !api.result.rbac?.perms?.all && !api.result.rbac?.perms?.write;
   };
 
+  const unreviewedCount = api.result.items.filter(
+    (item) => item.manual_effort_reviewed === false,
+  ).length;
+
   const renderLeft = () => (
     <Card isPlain>
       {fullCard && (
@@ -516,6 +549,8 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
               setFromCalculation={updateCalculationValues}
               costAutomation={costAutomation as any}
               defaultManualEffort={defaultManualEffort as any}
+              unreviewedCount={unreviewedCount}
+              onApplyDefault={applyDefaultToAll}
               readOnly={isReadOnly(api)}
             />
           </StackItem>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -304,20 +304,13 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   };
 
   const applyDefaultToAll = async () => {
+    let count = 0;
     try {
       // backend applies to all unreviewed templates tenant-wide; no params needed
       const res = (await applyDefaultROITemplates()) as {
         updated_count?: number;
       };
-      const count =
-        typeof res.updated_count === 'number' ? res.updated_count : 0;
-      addNotification({
-        title: `Default manual time applied to ${count} template${
-          count === 1 ? '' : 's'
-        }.`,
-        variant: 'success',
-        dismissable: true,
-      });
+      count = typeof res.updated_count === 'number' ? res.updated_count : 0;
     } catch {
       addNotification({
         title: 'Unable to apply default manual time',
@@ -328,8 +321,28 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       // apply failed; skip refresh
       return;
     }
-    // refresh is best-effort: a failure here must not read as an apply failure
-    await update();
+
+    addNotification({
+      title: `Default manual time applied to ${count} template${
+        count === 1 ? '' : 's'
+      }.`,
+      variant: 'success',
+      dismissable: true,
+    });
+
+    try {
+      // refresh is best-effort: a failure here must not read as an apply
+      // failure, and must not throw — CalculationCost awaits this handler
+      // and relies on it always resolving to reset its modal state.
+      await update();
+    } catch {
+      addNotification({
+        title: 'Default manual time applied, but the table could not refresh',
+        description: 'Reload the page to see the latest values.',
+        variant: 'warning',
+        dismissable: true,
+      });
+    }
   };
 
   const getSortParams = () => {

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { InputGroup } from '@patternfly/react-core/dist/dynamic/components/InputGroup';
@@ -5,8 +6,9 @@ import { InputGroupText } from '@patternfly/react-core/dist/dynamic/components/I
 import { TextInput } from '@patternfly/react-core/dist/dynamic/components/TextInput';
 import DollarSignIcon from '@patternfly/react-icons/dist/dynamic/icons/dollar-sign-icon';
 import OutlinedClockIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined-clock-icon';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
+import AlertModal from '../../../../Components/AlertModal';
 
 const WInputGroup = styled(InputGroup)`
   width: 170px;
@@ -30,6 +32,8 @@ interface Props {
   setFromCalculation: (varName: string, value: number) => void;
   costAutomation: number;
   defaultManualEffort: number;
+  unreviewedCount: number;
+  onApplyDefault: () => Promise<void>;
   readOnly: boolean;
 }
 
@@ -38,84 +42,138 @@ const CalculationCost: FunctionComponent<Props> = ({
   setFromCalculation = () => ({}),
   costAutomation = 0,
   defaultManualEffort = 0,
+  unreviewedCount = 0,
+  onApplyDefault = () => Promise.resolve(),
   readOnly = true,
-}) => (
-  <Card isPlain isCompact>
-    <CardBody>
-      <p>
-        Manual cost of automation
-        <span
-          style={{
-            color: 'var(--pf-t--global--text--color--200)',
-            fontSize: '0.8em',
-            display: 'block',
-          }}
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+
+  return (
+    <Card isPlain isCompact>
+      <CardBody>
+        <p>
+          Manual cost of automation
+          <span
+            style={{
+              color: 'var(--pf-t--global--text--color--200)',
+              fontSize: '0.8em',
+              display: 'block',
+            }}
+          >
+            (e.g. average salary of mid-level Software Engineer)
+          </span>
+        </p>
+        <WInputGroup>
+          <InputGroupText>
+            <DollarSignIcon />
+          </InputGroupText>
+          <TextInput
+            id='manual-cost'
+            key='manual-cost'
+            type='number'
+            aria-label='manual-cost'
+            value={isNaN(costManual) ? '' : costManual.toString()}
+            onChange={(_event, value) =>
+              setFromCalculation('manual_cost', validFloat(+value))
+            }
+            isDisabled={readOnly}
+          />
+          <InputGroupText>/hr</InputGroupText>
+        </WInputGroup>
+        <p style={{ paddingTop: '10px' }}>Automated process cost</p>
+        <WInputGroup>
+          <InputGroupText>
+            <DollarSignIcon />
+          </InputGroupText>
+          <TextInput
+            id='automation-cost'
+            key='automation-cost'
+            type='number'
+            aria-label='automation-cost'
+            value={isNaN(costAutomation) ? '' : costAutomation.toString()}
+            onChange={(_event, value) =>
+              setFromCalculation('automation_cost', validFloat(+value))
+            }
+            isDisabled={readOnly}
+          />
+          <InputGroupText>/hr</InputGroupText>
+        </WInputGroup>
+        <p style={{ paddingTop: '10px' }}>
+          Default manual time per template (minutes)
+        </p>
+        <WInputGroup>
+          <InputGroupText>
+            <OutlinedClockIcon />
+          </InputGroupText>
+          <TextInput
+            id='default-manual-effort'
+            key='default-manual-effort'
+            type='number'
+            aria-label='default-manual-effort'
+            value={
+              isNaN(defaultManualEffort) ? '' : defaultManualEffort.toString()
+            }
+            onChange={(_event, value) =>
+              setFromCalculation(
+                'default_manual_effort_minutes',
+                validNonNegativeInt(+value),
+              )
+            }
+            isDisabled={readOnly}
+          />
+          <InputGroupText>min</InputGroupText>
+        </WInputGroup>
+        <Button
+          variant='secondary'
+          style={{ marginTop: '10px' }}
+          data-cy='apply_default_button'
+          isDisabled={readOnly || unreviewedCount === 0}
+          onClick={() => setIsOpen(true)}
         >
-          (e.g. average salary of mid-level Software Engineer)
-        </span>
-      </p>
-      <WInputGroup>
-        <InputGroupText>
-          <DollarSignIcon />
-        </InputGroupText>
-        <TextInput
-          id='manual-cost'
-          key='manual-cost'
-          type='number'
-          aria-label='manual-cost'
-          value={isNaN(costManual) ? '' : costManual.toString()}
-          onChange={(_event, value) =>
-            setFromCalculation('manual_cost', validFloat(+value))
-          }
-          isDisabled={readOnly}
-        />
-        <InputGroupText>/hr</InputGroupText>
-      </WInputGroup>
-      <p style={{ paddingTop: '10px' }}>Automated process cost</p>
-      <WInputGroup>
-        <InputGroupText>
-          <DollarSignIcon />
-        </InputGroupText>
-        <TextInput
-          id='automation-cost'
-          key='automation-cost'
-          type='number'
-          aria-label='automation-cost'
-          value={isNaN(costAutomation) ? '' : costAutomation.toString()}
-          onChange={(_event, value) =>
-            setFromCalculation('automation_cost', validFloat(+value))
-          }
-          isDisabled={readOnly}
-        />
-        <InputGroupText>/hr</InputGroupText>
-      </WInputGroup>
-      <p style={{ paddingTop: '10px' }}>
-        Default manual time per template (minutes)
-      </p>
-      <WInputGroup>
-        <InputGroupText>
-          <OutlinedClockIcon />
-        </InputGroupText>
-        <TextInput
-          id='default-manual-effort'
-          key='default-manual-effort'
-          type='number'
-          aria-label='default-manual-effort'
-          value={
-            isNaN(defaultManualEffort) ? '' : defaultManualEffort.toString()
-          }
-          onChange={(_event, value) =>
-            setFromCalculation(
-              'default_manual_effort_minutes',
-              validNonNegativeInt(+value),
-            )
-          }
-          isDisabled={readOnly}
-        />
-        <InputGroupText>min</InputGroupText>
-      </WInputGroup>
-    </CardBody>
-  </Card>
-);
+          Apply default to all unreviewed
+        </Button>
+        <AlertModal
+          isOpen={isOpen}
+          title='Apply default manual time'
+          variant='warning'
+          data-cy='apply_default_modal'
+          onClose={() => setIsOpen(false)}
+          actions={[
+            <Button
+              key='confirm'
+              data-cy='apply_default_confirm_button'
+              variant='primary'
+              isLoading={isApplying}
+              isDisabled={isApplying}
+              onClick={async () => {
+                setIsApplying(true);
+                await onApplyDefault();
+                setIsApplying(false);
+                setIsOpen(false);
+              }}
+            >
+              Continue
+            </Button>,
+            <Button
+              key='cancel'
+              data-cy='apply_default_cancel_button'
+              variant='link'
+              onClick={() => setIsOpen(false)}
+            >
+              Cancel
+            </Button>,
+          ]}
+        >
+          {`This will set ${defaultManualEffort} minutes as the manual time ` +
+            `for all templates you haven't individually reviewed. ` +
+            `${unreviewedCount} template${
+              unreviewedCount === 1 ? '' : 's'
+            } will be updated. Continue?`}
+        </AlertModal>
+      </CardBody>
+    </Card>
+  );
+};
 
 export default CalculationCost;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -32,7 +32,6 @@ interface Props {
   setFromCalculation: (varName: string, value: number) => void;
   costAutomation: number;
   defaultManualEffort: number;
-  unreviewedCount: number;
   onApplyDefault: () => Promise<void>;
   readOnly: boolean;
 }
@@ -42,7 +41,6 @@ const CalculationCost: FunctionComponent<Props> = ({
   setFromCalculation = () => ({}),
   costAutomation = 0,
   defaultManualEffort = 0,
-  unreviewedCount = 0,
   onApplyDefault = () => Promise.resolve(),
   readOnly = true,
 }) => {
@@ -128,7 +126,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           variant='secondary'
           style={{ marginTop: '10px' }}
           data-cy='apply_default_button'
-          isDisabled={readOnly || unreviewedCount === 0}
+          isDisabled={readOnly}
           onClick={() => setIsOpen(true)}
         >
           Apply default to all unreviewed
@@ -138,7 +136,12 @@ const CalculationCost: FunctionComponent<Props> = ({
           title='Apply default manual time'
           variant='warning'
           data-cy='apply_default_modal'
-          onClose={() => setIsOpen(false)}
+          onClose={() => {
+            // don't let escape/backdrop dismiss while a request is in flight
+            if (!isApplying) {
+              setIsOpen(false);
+            }
+          }}
           actions={[
             <Button
               key='confirm'
@@ -159,6 +162,7 @@ const CalculationCost: FunctionComponent<Props> = ({
               key='cancel'
               data-cy='apply_default_cancel_button'
               variant='link'
+              isDisabled={isApplying}
               onClick={() => setIsOpen(false)}
             >
               Cancel
@@ -166,10 +170,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           ]}
         >
           {`This will set ${defaultManualEffort} minutes as the manual time ` +
-            `for all templates you haven't individually reviewed. ` +
-            `${unreviewedCount} template${
-              unreviewedCount === 1 ? '' : 's'
-            } will be updated. Continue?`}
+            `for all templates you haven't individually reviewed. Continue?`}
         </AlertModal>
       </CardBody>
     </Card>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -151,9 +151,12 @@ const CalculationCost: FunctionComponent<Props> = ({
               isDisabled={isApplying}
               onClick={async () => {
                 setIsApplying(true);
-                await onApplyDefault();
-                setIsApplying(false);
-                setIsOpen(false);
+                try {
+                  await onApplyDefault();
+                } finally {
+                  setIsApplying(false);
+                  setIsOpen(false);
+                }
               }}
             >
               Continue

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
@@ -20,6 +20,7 @@ export interface Template {
   automatedCost: number;
   enabled: boolean;
   monetary_gain: number;
+  manual_effort_reviewed: boolean;
   // Anything else accidentally having it
   [key: string]: string | number | boolean;
 }

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/types.ts
@@ -20,7 +20,6 @@ export interface Template {
   automatedCost: number;
   enabled: boolean;
   monetary_gain: number;
-  manual_effort_reviewed: boolean;
   // Anything else accidentally having it
   [key: string]: string | number | boolean;
 }


### PR DESCRIPTION
[AAP-84047]: https://redhat.atlassian.net/browse/AAP-84047

Adds an "Apply default to all unreviewed" button to `CalculationCost.tsx`. On confirm it calls `POST /api/tower-analytics/v1/roi_templates_apply_default/`, refreshes the templates table, and shows a success/error notification.

Builds on top of #1238 (AAP-84046) — reuses its `defaultManualEffort` state as the modal's default-time value.

## Summary
- `src/Api/api.ts`: new `roiTemplatesApplyDefault` endpoint + `applyDefaultROITemplates()` helper.
- `AutomationCalculator.tsx`: `applyDefaultToAll` handler (calls endpoint, refreshes data via `update()`, notifies), `unreviewedCount` derived from `manual_effort_reviewed === false` rows.
- `CalculationCost.tsx`: "Apply default to all unreviewed" button (disabled when read-only or no unreviewed templates) + confirmation modal (reused `AlertModal`) showing the default minutes and count.
- `TemplatesTable/types.ts`: added `manual_effort_reviewed` to `Template`.
- `cypress/e2e/AutomationCalculator.spec.js`: confirm+apply and cancel-path tests.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Cypress spec run against a live/ephemeral env with unreviewed templates present