### PR TITLE
AAP-84048 - fix(calculator): replace hardcoded 60-minute fallback with configurab…

### DIFF
--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -103,11 +103,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   const { queryParams, setFromToolbar, setFromPagination } =
     useQueryParams(defaultParams);
 
-  const mapApi = ({ legend = [] }) => {
+  const mapApi = ({ legend = [] }, defaultManualMinutes = 60) => {
     return legend.map((el: { [key: string]: number }) => ({
       ...el,
       delta: 0,
-      avgRunTime: el.manual_effort_minutes * 60 || 3600,
+      avgRunTime: el.manual_effort_minutes * 60 || defaultManualMinutes * 60,
       manualCost: 0,
       automatedCost: 0,
       enabled: el.template_weigh_in,
@@ -142,7 +142,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       return {
         ...response,
         items: updateDeltaCost(
-          mapApi(response.meta),
+          mapApi(
+            response.meta,
+            response.cost?.default_manual_effort_minutes ?? 60,
+          ),
           response.cost.hourly_manual_labor_cost,
           response.cost.hourly_automation_cost,
         ),
@@ -190,7 +193,12 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       res.successful_hosts_saved_hours_current_page;
     api.result.successful_hosts_saved_hours_other_pages =
       res.successful_hosts_saved_hours_other_pages;
-    setValue(mapApi(res.meta as any));
+    setValue(
+      mapApi(
+        res.meta as any,
+        (res as any).cost?.default_manual_effort_minutes ?? 60,
+      ),
+    );
     return res;
   };
 
@@ -583,6 +591,9 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
                   getSortParams={getSortParams as any}
                   readOnly={isReadOnly(api)}
                   isMoney={isMoney}
+                  defaultManualTime={
+                    api.result?.cost?.default_manual_effort_minutes ?? 60
+                  }
                 />
               )}
             </GridItem>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -26,6 +26,7 @@ interface Props {
   navigateToJobExplorer: (id: number) => void;
   readOnly: boolean;
   isMoney: boolean;
+  defaultManualTime: number;
 }
 
 const setLabeledValue = (key: string, value: number) => {
@@ -73,6 +74,7 @@ const Row: FunctionComponent<Props> = ({
   navigateToJobExplorer,
   readOnly = true,
   isMoney,
+  defaultManualTime,
 }) => {
   const [isExpanded, setIsExpanded] = useState(
     window.localStorage.getItem(template.id.toString()) === 'true' || false,
@@ -128,7 +130,7 @@ const Row: FunctionComponent<Props> = ({
                 onBlur={(event: React.ChangeEvent<HTMLInputElement>) => {
                   const minutes = +event.target.value;
                   if (minutes <= 0 || isNaN(minutes)) {
-                    event.target.value = '60';
+                    event.target.value = String(defaultManualTime);
                     setDataRunTime(+event.target.value * 60, template.id);
                   } else {
                     setDataRunTime(minutes * 60, template.id);

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/index.tsx
@@ -27,6 +27,7 @@ interface Props {
   getSortParams?: () => TableSortParams;
   readOnly: boolean;
   isMoney: boolean;
+  defaultManualTime: number;
 }
 
 const TopTemplates: FunctionComponent<Props> = ({
@@ -38,6 +39,7 @@ const TopTemplates: FunctionComponent<Props> = ({
   getSortParams = () => ({}),
   readOnly = true,
   isMoney,
+  defaultManualTime,
 }) => {
   const [isKebabOpen, setIsKebabOpen] = useState(false);
   const defaultParams = reportDefaultParams('automation_calculator');
@@ -140,6 +142,7 @@ const TopTemplates: FunctionComponent<Props> = ({
             setEnabled={setEnabled(template.id)}
             readOnly={readOnly}
             isMoney={isMoney}
+            defaultManualTime={defaultManualTime}
           />
         ))}
       </Tbody>


### PR DESCRIPTION

- mapApi now accepts defaultManualMinutes param; uses API value from response.cost.default_manual_effort_minutes, falls back to 60 for backward compat with older backends
- Row input reset on invalid value uses defaultManualTime prop instead of hardcoded '60'
- Pass defaultManualTime through AutomationCalculator -> TemplatesTable -> Row

Closes AAP-84048