### PR TITLE
AAP-89195 - feat(frontend): apply-default button applies to all templates

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -403,7 +403,7 @@ describe('Automation Calculator page', () => {
     }
   });
 
-  it('applies default manual time to unreviewed templates on confirm', () => {
+  it('applies default manual time to all templates on confirm', () => {
     const { markApplied } = visitWithStubbedTemplates();
 
     cy.intercept('POST', '**/roi_templates_apply_default/', (req) => {
@@ -417,7 +417,9 @@ describe('Automation Calculator page', () => {
     // paginated client, is the source of truth for how many get updated).
     cy.getByCy('apply_default_modal').should(
       'contain.text',
-      "This will set 30 minutes as the manual time for all templates you haven't individually reviewed.",
+      'This will overwrite the manual time for every template with the ' +
+        "current default of 30 minutes, including templates you've already " +
+        'reviewed. Do you want to apply this default value to all templates?',
     );
 
     cy.getByCy('current_page_savings')

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -314,7 +314,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   const applyDefaultToAll = async () => {
     let count = 0;
     try {
-      // backend applies to all unreviewed templates tenant-wide; no params needed
+      // backend applies to all templates tenant-wide; no params needed
       const res = (await applyDefaultROITemplates()) as {
         updated_count?: number;
       };

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -129,7 +129,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           isDisabled={readOnly}
           onClick={() => setIsOpen(true)}
         >
-          Apply default to all unreviewed
+          Apply default to all templates
         </Button>
         <AlertModal
           isOpen={isOpen}
@@ -172,8 +172,10 @@ const CalculationCost: FunctionComponent<Props> = ({
             </Button>,
           ]}
         >
-          {`This will set ${defaultManualEffort || 0} minutes as the manual time ` +
-            `for all templates you haven't individually reviewed. Continue?`}
+          {`This will overwrite the manual time for every template with the ` +
+            `current default of ${defaultManualEffort || 0} minutes, including ` +
+            `templates you've already reviewed. Do you want to apply this ` +
+            `default value to all templates?`}
         </AlertModal>
       </CardBody>
     </Card>


### PR DESCRIPTION
## Summary
- "Apply default to all unreviewed" button/flow is now all-or-nothing: it always overwrites every template's manual effort time with the tenant default, regardless of prior review status.
- Button label changed to "Apply default to all templates".
- Confirmation modal now warns that reviewed templates will be overwritten too, ending with "Do you want to apply this default value to all templates?"
- No API call shape change — endpoint is still called with no body.

 **button + modal screenshot:**
<img width="418" height="372" alt="button" src="https://github.com/user-attachments/assets/29cbbdc6-4662-48eb-80b8-8cbb81124e80" />
<img width="900" height="700" alt="modal" src="https://github.com/user-attachments/assets/567ffd0f-2242-44ca-8ad3-8c4b7cea8a00" />

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes on changed files
- [ ] Cypress: `applies default manual time to all templates on confirm` and related apply-default specs pass in CI
- [ ] Manual: click "Apply default to all templates", confirm modal copy, confirm/cancel both work as expected

Depends on backend change AAP-89193 (automation-analytics-backend) for `manual_effort_reviewed` reset behavior.