### PR TITLE
AAP-90564 - fix(frontend): sync default manual time reactively across UI

### DIFF
--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -432,7 +432,7 @@ describe('Automation Calculator page', () => {
         waitForStubbedLoad();
 
         cy.getByCy('apply_default_modal').should('not.exist');
-        cy.contains('Default manual time applied to 3 templates.').should(
+        cy.contains('Default manual time applied to all templates.').should(
           'exist',
         );
 
@@ -551,7 +551,7 @@ describe('Automation Calculator page', () => {
     cy.getByCy('apply_default_button').should('not.be.disabled');
   });
 
-  it('falls back to 0 when the apply response has no updated_count', () => {
+  it('shows success message when the apply response has no body', () => {
     cy.intercept('POST', '**/roi_templates_apply_default/', {}).as(
       'applyDefault',
     );
@@ -563,7 +563,9 @@ describe('Automation Calculator page', () => {
     cy.wait('@applyDefault');
     waitForStubbedLoad();
 
-    cy.contains('Default manual time applied to 0 templates.').should('exist');
+    cy.contains('Default manual time applied to all templates.').should(
+      'exist',
+    );
   });
 
   it('disables cancel/close while a request is in flight', () => {

--- a/cypress/e2e/AutomationCalculator.spec.js
+++ b/cypress/e2e/AutomationCalculator.spec.js
@@ -223,12 +223,13 @@ describe('Automation Calculator page', () => {
         return;
       }
 
+      // The default is staged locally and only persisted when "Apply default
+      // to all templates" is confirmed, so typing here must not hit the
+      // network — no waitToLoad().
       cy.get('#default-manual-effort').clear();
-      waitToLoad();
       cy.get('#default-manual-effort').should('have.value', '0');
 
       cy.get('#default-manual-effort').type('60');
-      waitToLoad();
       cy.get('#default-manual-effort')
         .invoke('val')
         .then((val) => {
@@ -442,6 +443,42 @@ describe('Automation Calculator page', () => {
           .find('h3')
           .invoke('text')
           .should('not.eq', originalCurrentPageSavings);
+      });
+  });
+
+  it('does not update savings when editing the default before applying', () => {
+    // The default manual time is staged locally, like a per-template manual
+    // time edit — neither savings figure should move until "Apply default to
+    // all templates" is confirmed.
+    visitWithStubbedTemplates();
+
+    cy.intercept('POST', '/api/tower-analytics/v1/roi_cost_effort_data/').as(
+      'roiCostEffortSave',
+    );
+    cy.intercept('POST', '**/roi_templates_apply_default/').as('applyDefault');
+
+    cy.getByCy('total_savings')
+      .find('h3')
+      .invoke('text')
+      .then((originalTotalSavings) => {
+        cy.getByCy('current_page_savings')
+          .find('h3')
+          .invoke('text')
+          .then((originalCurrentPageSavings) => {
+            cy.get('#default-manual-effort').clear();
+            cy.get('#default-manual-effort').type('45');
+
+            cy.getByCy('total_savings')
+              .find('h3')
+              .invoke('text')
+              .should('eq', originalTotalSavings);
+            cy.getByCy('current_page_savings')
+              .find('h3')
+              .invoke('text')
+              .should('eq', originalCurrentPageSavings);
+            cy.get('@roiCostEffortSave.all').should('have.length', 0);
+            cy.get('@applyDefault.all').should('have.length', 0);
+          });
       });
   });
 

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -204,6 +204,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       res.successful_hosts_saved_hours_current_page;
     api.result.successful_hosts_saved_hours_other_pages =
       res.successful_hosts_saved_hours_other_pages;
+    api.result.cost = res.cost;
     setValue(
       mapApi(
         res.meta as any,
@@ -215,16 +216,21 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
 
   const updateCalculationValues = async (varName: string, value: number) => {
     if (isNaN(value)) return;
+    if (varName === 'default_manual_effort_minutes') {
+      // Staged only: the default is committed via the explicit "Apply
+      // default to all templates" action (applyDefaultToAll), not on every
+      // keystroke. Mirrors per-template manual time, which also only
+      // commits on its own action (blur).
+      setDefaultManualEffort(value);
+      return;
+    }
     const hourly_automation_cost =
       varName === 'automation_cost' ? value : costAutomation;
     const hourly_manual_labor_cost =
       varName === 'manual_cost' ? value : costManual;
-    const manual_effort =
-      varName === 'default_manual_effort_minutes' ? value : defaultManualEffort;
     const humanVarNames: Record<string, string> = {
       automation_cost: 'Automation cost',
       manual_cost: 'Manual cost',
-      default_manual_effort_minutes: 'Default manual time',
     };
     const humanVarName = humanVarNames[varName] ?? varName;
     try {
@@ -233,7 +239,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
           api.result.items,
           hourly_manual_labor_cost,
           hourly_automation_cost,
-          manual_effort,
+          defaultManualEffort,
         ) as any,
       );
     } catch {
@@ -250,8 +256,6 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       setCostManual(value);
     } else if (varName === 'automation_cost') {
       setCostAutomation(value);
-    } else if (varName === 'default_manual_effort_minutes') {
-      setDefaultManualEffort(value);
     }
   };
 
@@ -314,6 +318,11 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   const applyDefaultToAll = async () => {
     let count = 0;
     try {
+      // The default is staged locally (see updateCalculationValues) and only
+      // committed here, so persist it before the apply endpoint reads it —
+      // that endpoint POSTs no body and relies on the server-persisted
+      // default_manual_effort_minutes.
+      await saveROI(getROISaveData(api.result.items) as any);
       // backend applies to all templates tenant-wide; no params needed
       const res = (await applyDefaultROITemplates()) as {
         updated_count?: number;

--- a/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/AutomationCalculator.tsx
@@ -316,7 +316,6 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
   };
 
   const applyDefaultToAll = async () => {
-    let count = 0;
     try {
       // The default is staged locally (see updateCalculationValues) and only
       // committed here, so persist it before the apply endpoint reads it —
@@ -324,10 +323,7 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
       // default_manual_effort_minutes.
       await saveROI(getROISaveData(api.result.items) as any);
       // backend applies to all templates tenant-wide; no params needed
-      const res = (await applyDefaultROITemplates()) as {
-        updated_count?: number;
-      };
-      count = typeof res.updated_count === 'number' ? res.updated_count : 0;
+      await applyDefaultROITemplates();
     } catch {
       addNotification({
         title: 'Unable to apply default manual time',
@@ -340,9 +336,10 @@ const AutomationCalculator: FC<AutmationCalculatorProps> = ({
     }
 
     addNotification({
-      title: `Default manual time applied to ${count} template${
-        count === 1 ? '' : 's'
-      }.`,
+      // updated_count from the backend only reflects templates with a prior
+      // manual-effort row, not the true total the default was applied to —
+      // so the message stays count-free.
+      title: 'Default manual time applied to all templates.',
       variant: 'success',
       dismissable: true,
     });

--- a/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/CalculationCost.tsx
@@ -14,6 +14,12 @@ const WInputGroup = styled(InputGroup)`
   width: 170px;
 `;
 
+const Divider = styled.hr`
+  margin: 16px 0 12px 0;
+  border: none;
+  border-top: 1px solid var(--pf-t--global--border--color--200);
+`;
+
 const validFloat = (value: number): number =>
   +value && +value < 0 ? NaN : value;
 
@@ -97,6 +103,7 @@ const CalculationCost: FunctionComponent<Props> = ({
           />
           <InputGroupText>/hr</InputGroupText>
         </WInputGroup>
+        <Divider />
         <p style={{ paddingTop: '10px' }}>
           Default manual time per template (minutes)
         </p>

--- a/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
+++ b/src/Containers/Reports/Layouts/AutomationCalculator/TemplatesTable/Row.tsx
@@ -117,6 +117,7 @@ const Row: FunctionComponent<Props> = ({
           <InputGroup>
             <InputGroupItem isFill>
               <TextInput
+                key={template.avgRunTime}
                 autoFocus={
                   window.localStorage.getItem('focused') ===
                   'manual-time-' + template.id.toString()


### PR DESCRIPTION
## Summary
- Fix template row "Manual time" input not refreshing after "Apply default to all templates" without a page reload (uncontrolled `TextInput` ignored the updated value).
- Fix "Default manual time per template" field auto-saving/refetching on every keystroke, which moved Total savings live while Current page savings stayed stuck. The default now stages locally, like a per-template manual time edit, and only persists when "Apply default to all templates" is confirmed — so both savings figures update together.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] `cypress run --spec cypress/e2e/AutomationCalculator.spec.js`
- [x] Manual: set default manual time, click Apply — confirm every row's Manual time input updates with no page refresh, and both Total savings and Current page savings update.
- [x] Manual: type in the default field without clicking Apply — confirm neither savings figure changes.
- [x] Manual: edit a single row's manual time and blur — confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)