### PR TITLE
fix(deps): override axios to 1.20.0 for CVE-2026-67313 (AAP-88408)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6813,13 +6813,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -11367,16 +11366,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -12448,10 +12446,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "appname": "automation-analytics"
   },
   "overrides": {
-    "axios": "1.16.1",
+    "axios": "1.20.0",
     "follow-redirects": ">=1.16.0",
     "query-string": {
       "decode-uri-component": "0.5.0"


### PR DESCRIPTION
## Summary

- Bumps the `axios` override from **1.16.1 → 1.20.0** to remediate CVE-2026-67313
- Clears all 10 axios security advisories affecting versions `>=1.0.0 <1.18.0`

## CVE Details

| Field | Value |
|-------|-------|
| Jira | [AAP-88408](https://redhat.atlassian.net/browse/AAP-88408) |
| CVE | CVE-2026-67313 |
| GHSA | [GHSA-42h9-826w-cgv3](https://github.com/advisories/GHSA-42h9-826w-cgv3) |
| Vulnerability | Excessive recursion in `formDataToJSON` — deeply nested bracket field names exhaust call stack → RangeError DoS |
| Affected range | `>=1.0.0 <1.18.0` |
| Previous version | 1.16.1 |
| Fixed version | **1.20.0** (latest stable) |

## Additional advisories cleared by this upgrade

Upgrading to 1.20.0 also addresses 9 other axes advisories in the `<1.18.0` range:
- GHSA-hcpx-6fm6-wx23 — form serializer maxDepth bypass via `{}` metatoken (>=1.15.1 <1.18.0)
- GHSA-xj6q-8x83-jv6g — Prototype pollution auth subfields inject Basic auth (>=1.15.2 <1.18.0)
- GHSA-mmx7-hfxf-jppx — Prototype pollution gadgets alter request construction (>=1.0.0 <1.18.0)
- GHSA-mwf2-3pr3-8698 — HTTP/2 streamed uploads bypass `maxBodyLength` (>=1.13.0 <1.18.0)
- GHSA-gcfj-64vw-6mp9 — Node HTTP adapter inherited proxy after interceptor cloning (>=1.15.2 <1.18.0)
- GHSA-7q8q-rj6j-mhjq — Nested option objects consume polluted prototype values (>=1.0.0 <1.18.0)
- GHSA-jqh4-m9w3-8hp9 — Fetch adapter ReadableStream uploads bypass `maxBodyLength` (>=1.7.0 <1.18.0)
- GHSA-f4gw-2p7v-4548 — NO_PROXY bypass for 0.0.0.0 local addresses (>=1.15.0 <1.18.0)

## Test plan

- [x] `npm audit` — zero axios vulnerabilities remaining after upgrade
- [x] `npx tsc --noEmit` — type check passes with no errors
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAP-88408]: https://redhat.atlassian.net/browse/AAP-88408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ